### PR TITLE
Improved manhack tossing

### DIFF
--- a/sp/src/game/server/ez1/weapon_ManhackToss.cpp
+++ b/sp/src/game/server/ez1/weapon_ManhackToss.cpp
@@ -210,6 +210,7 @@ void CWeaponManhackToss::PrimaryAttack(void)
 	PlayerManhacks->Spawn();
 	PlayerManhacks->Activate();
 	PlayerManhacks->ShouldFollowPlayer(true);
+	PlayerManhacks->SetUse(&CNPC_Manhack::PlayerPickup);
 
 	pOwner->ViewPunchReset();
 	pOwner->RemoveAmmo( 1, m_iPrimaryAmmoType );

--- a/sp/src/game/server/ez1/weapon_ManhackToss.cpp
+++ b/sp/src/game/server/ez1/weapon_ManhackToss.cpp
@@ -39,73 +39,15 @@ public:
 
 	void	Precache(void);
 	void	ItemPostFrame(void);
-	void	ItemPreFrame(void);
-	void	ItemBusyFrame(void);
 	void	PrimaryAttack(void);
 	void	AddViewKick(void);
-	void	DryFire(void);
-	void	Operator_HandleAnimEvent(animevent_t *pEvent, CBaseCombatCharacter *pOperator);
-
-
-	void	UpdatePenaltyTime(void);
 
 	int		CapabilitiesGet(void) { return bits_CAP_WEAPON_RANGE_ATTACK1; }
-	Activity	GetPrimaryAttackActivity(void);
-
-	virtual bool Reload(void);
-
-	virtual const Vector& GetBulletSpread(void)
-	{
-		// Handle NPCs first
-		static Vector npcCone = VECTOR_CONE_5DEGREES;
-		if (GetOwner() && GetOwner()->IsNPC())
-			return npcCone;
-
-		static Vector cone;
-
-		if (manhacktoss_use_new_accuracy.GetBool())
-		{
-			float ramp = RemapValClamped(m_flAccuracyPenalty,
-				0.0f,
-				MANHACKTOSS_ACCURACY_MAXIMUM_PENALTY_TIME,
-				0.0f,
-				1.0f);
-
-			// We lerp from very accurate to inaccurate over time
-			VectorLerp(VECTOR_CONE_1DEGREES, VECTOR_CONE_6DEGREES, ramp, cone);
-		}
-		else
-		{
-			// Old value
-			cone = VECTOR_CONE_4DEGREES;
-		}
-
-		return cone;
-	}
-
-	virtual int	GetMinBurst()
-	{
-		return 1;
-	}
-
-	virtual int	GetMaxBurst()
-	{
-		return 3;
-	}
-
-	virtual float GetFireRate(void)
-	{
-		return 2.0f;
-	}
+	Activity	GetPrimaryAttackActivity(void) { return ACT_VM_THROW; }
 
 	DECLARE_ACTTABLE();
 
 private:
-	float	m_flSoonestPrimaryAttack;
-	float	m_flLastAttackTime;
-	float	m_flAccuracyPenalty;
-	int		m_nNumShotsFired;
-	int		m_iSemi;
 	bool m_bDeploying;
 };
 
@@ -117,12 +59,6 @@ LINK_ENTITY_TO_CLASS(weapon_manhacktoss, CWeaponManhackToss);
 PRECACHE_WEAPON_REGISTER(weapon_manhacktoss);
 
 BEGIN_DATADESC(CWeaponManhackToss)
-
-DEFINE_FIELD(m_flSoonestPrimaryAttack, FIELD_TIME),
-DEFINE_FIELD(m_flLastAttackTime, FIELD_TIME),
-DEFINE_FIELD(m_flAccuracyPenalty, FIELD_FLOAT), //NOTENOTE: This is NOT tracking game time
-DEFINE_FIELD(m_nNumShotsFired, FIELD_INTEGER),
-
 END_DATADESC()
 
 acttable_t	CWeaponManhackToss::m_acttable[] =
@@ -152,16 +88,7 @@ IMPLEMENT_ACTTABLE(CWeaponManhackToss);
 //-----------------------------------------------------------------------------
 CWeaponManhackToss::CWeaponManhackToss(void)
 {
-	m_flSoonestPrimaryAttack = gpGlobals->curtime;
-	m_flAccuracyPenalty = 0.0f;
-
-	m_fMinRange1 = 24;
-	m_fMaxRange1 = 1500;
-	m_fMinRange2 = 24;
-	m_fMaxRange2 = 200;
-
 	m_bFiresUnderwater = true;
-	m_iSemi = MAXBURST;
 	m_bDeploying = false;
 }
 
@@ -177,48 +104,30 @@ void CWeaponManhackToss::Precache(void)
 
 //-----------------------------------------------------------------------------
 // Purpose:
-// Input  :
-// Output :
 //-----------------------------------------------------------------------------
-void CWeaponManhackToss::Operator_HandleAnimEvent(animevent_t *pEvent, CBaseCombatCharacter *pOperator)
+void CWeaponManhackToss::ItemPostFrame(void)
 {
-	switch (pEvent->event)
+	BaseClass::ItemPostFrame();
+
+	if ( m_bDeploying && IsViewModelSequenceFinished() )
 	{
-	case EVENT_WEAPON_PISTOL_FIRE:
-	{
-		Vector vecShootOrigin, vecShootDir;
-		vecShootOrigin = pOperator->Weapon_ShootPosition();
+		if ( !HasPrimaryAmmo() )
+		{
+			CBasePlayer *pPlayer = ToBasePlayer(GetOwner());
+			if ( pPlayer )
+			{
+				pPlayer->ClearActiveWeapon();
+				pPlayer->SwitchToNextBestWeapon( this );
+			}
+		}
+		else
+		{
+			SendWeaponAnim( ACT_VM_DRAW );
+			m_flNextPrimaryAttack = gpGlobals->curtime + SequenceDuration();
+		}
 
-		CAI_BaseNPC *npc = pOperator->MyNPCPointer();
-		ASSERT(npc != NULL);
-
-		vecShootDir = npc->GetActualShootTrajectory(vecShootOrigin);
-
-		CSoundEnt::InsertSound(SOUND_COMBAT | SOUND_CONTEXT_GUNFIRE, pOperator->GetAbsOrigin(), SOUNDENT_VOLUME_PISTOL, 0.2, pOperator, SOUNDENT_CHANNEL_WEAPON, pOperator->GetEnemy());
-
-		WeaponSound(SINGLE_NPC);
-		pOperator->FireBullets(1, vecShootOrigin, vecShootDir, VECTOR_CONE_PRECALCULATED, MAX_TRACE_LENGTH, m_iPrimaryAmmoType, 2);
-		pOperator->DoMuzzleFlash();
-
-		m_iClip1 = m_iClip1 - 1;
+		m_bDeploying = false;
 	}
-	break;
-	default:
-		BaseClass::Operator_HandleAnimEvent(pEvent, pOperator);
-		break;
-	}
-}
-
-//-----------------------------------------------------------------------------
-// Purpose:
-//-----------------------------------------------------------------------------
-void CWeaponManhackToss::DryFire(void)
-{
-	WeaponSound(EMPTY);
-	//SendWeaponAnim(ACT_VM_DRYFIRE);
-
-	m_flSoonestPrimaryAttack = gpGlobals->curtime + MANHACKTOSS_FASTEST_DRY_REFIRE_TIME;
-	m_flNextPrimaryAttack = gpGlobals->curtime + SequenceDuration();
 }
 
 //-----------------------------------------------------------------------------
@@ -226,20 +135,6 @@ void CWeaponManhackToss::DryFire(void)
 //-----------------------------------------------------------------------------
 void CWeaponManhackToss::PrimaryAttack(void)
 {
-	SendWeaponAnim(ACT_VM_THROW);
-
-	if ((gpGlobals->curtime - m_flLastAttackTime) > 0.5f)
-	{
-		m_nNumShotsFired = 0;
-	}
-	else
-	{
-		m_nNumShotsFired++;
-	}
-
-	// Time we wait before allowing to throw another
-	m_flNextPrimaryAttack = gpGlobals->curtime + 0.75;
-
 
 	CBasePlayer *pOwner = ToBasePlayer(GetOwner());
 	if (!pOwner)
@@ -250,9 +145,11 @@ void CWeaponManhackToss::PrimaryAttack(void)
 	VectorScale(vecThrow, 25.0f, vecThrow);
 
 	// This is where we actually make the manhack spawn
-	CNPC_Manhack *PlayerManhacks = (CNPC_Manhack * )CBaseEntity::CreateNoSpawn("npc_manhack", pOwner->Weapon_ShootPosition() + vecThrow, GetOwner()->EyeAngles(), GetOwnerEntity());
+	CNPC_Manhack *PlayerManhacks = (CNPC_Manhack * )CBaseEntity::CreateNoSpawn("npc_manhack", pOwner->Weapon_ShootPosition() + vecThrow, pOwner->EyeAngles(), pOwner);
 
 	if (PlayerManhacks == NULL) { return; }
+
+	SendWeaponAnim(ACT_VM_THROW);
 
 	PlayerManhacks->AddSpawnFlags(SF_MANHACK_PACKED_UP);
 	PlayerManhacks->KeyValue("squadname", "controllable_manhack_squad");
@@ -263,134 +160,12 @@ void CWeaponManhackToss::PrimaryAttack(void)
 	pOwner->ViewPunchReset();
 	pOwner->RemoveAmmo( 1, m_iPrimaryAmmoType );
 
-	if (m_iSemi <= 0)
-		return;
-	m_iSemi--;
-
 	m_iPrimaryAttacks++;
+	// Time we wait before allowing to throw another
+	m_flNextPrimaryAttack = gpGlobals->curtime + SequenceDuration();
+	m_bDeploying = true;
 
 	gamestats->Event_WeaponFired(pOwner, true, GetClassname());
-
-	/*if ( !HasPrimaryAmmo() )
-	{
-	pPlayer->SwitchToNextBestWeapon( this );
-	}*/
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void CWeaponManhackToss::UpdatePenaltyTime(void)
-{
-	CBasePlayer *pOwner = ToBasePlayer(GetOwner());
-
-	if (pOwner == NULL)
-		return;
-
-	// Check our penalty time decay
-	if (((pOwner->m_nButtons & IN_ATTACK) == false) && (m_flSoonestPrimaryAttack < gpGlobals->curtime))
-	{
-		m_flAccuracyPenalty -= gpGlobals->frametime;
-		m_flAccuracyPenalty = clamp(m_flAccuracyPenalty, 0.0f, MANHACKTOSS_ACCURACY_MAXIMUM_PENALTY_TIME);
-	}
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void CWeaponManhackToss::ItemPreFrame(void)
-{
-	UpdatePenaltyTime();
-
-	BaseClass::ItemPreFrame();
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void CWeaponManhackToss::ItemBusyFrame(void)
-{
-	UpdatePenaltyTime();
-
-	BaseClass::ItemBusyFrame();
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: Allows firing as fast as button is pressed
-//-----------------------------------------------------------------------------
-void CWeaponManhackToss::ItemPostFrame(void)
-{
-	BaseClass::ItemPostFrame();
-
-	if (m_bInReload)
-		return;
-
-	CBasePlayer *pOwner = ToBasePlayer(GetOwner());
-	if (!(pOwner->m_nButtons & IN_ATTACK))
-		m_iSemi = MAXBURST;
-
-	if (pOwner == NULL)
-		return;
-
-	//Allow a refire as fast as the player can click
-	if (((pOwner->m_nButtons & IN_ATTACK) == false) && (m_flSoonestPrimaryAttack < gpGlobals->curtime))
-	{
-		m_flNextPrimaryAttack = gpGlobals->curtime - 1.0f;
-	}
-	else if ((pOwner->m_nButtons & IN_ATTACK) && (m_flNextPrimaryAttack < gpGlobals->curtime) && (m_iClip1 <= 0))
-	{
-		DryFire();
-	}
-
-   if ( m_bDeploying && IsViewModelSequenceFinished() )
-   {
-       if ( !HasPrimaryAmmo() )
-       {
-           if ( pOwner )
-           {
-               pOwner->ClearActiveWeapon();
-               pOwner->SwitchToNextBestWeapon( this );
-           }
-       }
-       else
-       {
-           SendWeaponAnim( ACT_VM_DRAW );
-           m_flNextPrimaryAttack = gpGlobals->curtime + SequenceDuration();
-       }
-
-       m_bDeploying = false;
-   }
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-// Output : int
-//-----------------------------------------------------------------------------
-Activity CWeaponManhackToss::GetPrimaryAttackActivity(void)
-{
-	if (m_nNumShotsFired < 1)
-		return ACT_VM_THROW;
-
-	if (m_nNumShotsFired < 2)
-		return ACT_VM_RECOIL1;
-
-	if (m_nNumShotsFired < 3)
-		return ACT_VM_RECOIL2;
-
-	return ACT_VM_RECOIL3;
-}
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-bool CWeaponManhackToss::Reload(void)
-{
-	bool fRet = DefaultReload(GetMaxClip1(), GetMaxClip2(), ACT_VM_RELOAD);
-	if (fRet)
-	{
-		WeaponSound(RELOAD);
-		m_flAccuracyPenalty = 0.0f;
-	}
-	return fRet;
 }
 
 //-----------------------------------------------------------------------------
@@ -398,12 +173,12 @@ bool CWeaponManhackToss::Reload(void)
 //-----------------------------------------------------------------------------
 void CWeaponManhackToss::AddViewKick(void)
 {
-	CBasePlayer *pPlayer = ToBasePlayer(GetOwner());
+	CBaseCombatCharacter *pPlayer = GetOwner();
 
 	if (pPlayer == NULL)
 		return;
 
-	QAngle	viewPunch;
+	QAngle viewPunch;
 
 	viewPunch.x = random->RandomFloat(0.25f, 0.5f);
 	viewPunch.y = random->RandomFloat(-.6f, .6f);

--- a/sp/src/game/server/ez1/weapon_ManhackToss.cpp
+++ b/sp/src/game/server/ez1/weapon_ManhackToss.cpp
@@ -81,7 +81,6 @@ public:
 	void	Precache(void);
 	void	ItemPostFrame(void);
 	void	PrimaryAttack(void);
-	void	AddViewKick(void);
 
 	int		CapabilitiesGet(void) { return bits_CAP_WEAPON_RANGE_ATTACK1; }
 	Activity	GetPrimaryAttackActivity(void) { return ACT_VM_THROW; }
@@ -182,8 +181,8 @@ void CWeaponManhackToss::PrimaryAttack(void)
 		return;
 	
 	Vector vecThrow;
-	AngleVectors(pOwner->EyeAngles() + pOwner->GetPunchAngle(), &vecThrow);
-	VectorScale(vecThrow, 25.0f, vecThrow);
+	AngleVectors(pOwner->EyeAngles(), &vecThrow);
+	VectorScale(vecThrow, 15.0f, vecThrow);
 	Vector vecSpawnPos = pOwner->Weapon_ShootPosition() + vecThrow;
 
 	// This is where we actually make the manhack spawn
@@ -212,7 +211,6 @@ void CWeaponManhackToss::PrimaryAttack(void)
 	PlayerManhacks->ShouldFollowPlayer(true);
 	PlayerManhacks->SetUse(&CNPC_Manhack::PlayerPickup);
 
-	pOwner->ViewPunchReset();
 	pOwner->RemoveAmmo( 1, m_iPrimaryAmmoType );
 
 	m_iPrimaryAttacks++;
@@ -221,24 +219,4 @@ void CWeaponManhackToss::PrimaryAttack(void)
 	m_bDeploying = true;
 
 	gamestats->Event_WeaponFired(pOwner, true, GetClassname());
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void CWeaponManhackToss::AddViewKick(void)
-{
-	CBaseCombatCharacter *pPlayer = GetOwner();
-
-	if (pPlayer == NULL)
-		return;
-
-	QAngle viewPunch;
-
-	viewPunch.x = random->RandomFloat(0.25f, 0.5f);
-	viewPunch.y = random->RandomFloat(-.6f, .6f);
-	viewPunch.z = 0.0f;
-
-	//Add it to the view punch
-	pPlayer->ViewPunch(viewPunch);
 }

--- a/sp/src/game/server/hl2/npc_manhack.cpp
+++ b/sp/src/game/server/hl2/npc_manhack.cpp
@@ -189,6 +189,9 @@ BEGIN_DATADESC( CNPC_Manhack )
 	DEFINE_INPUTFUNC( FIELD_VOID,   "Unpack",		InputUnpack ),
 
 	DEFINE_ENTITYFUNC( CrashTouch ),
+#ifdef EZ
+	DEFINE_USEFUNC( PlayerPickup ),
+#endif
 
 	DEFINE_BASENPCINTERACTABLE_DATADESC(),
 
@@ -1116,10 +1119,16 @@ void CNPC_Manhack::MaintainGroundHeight( void )
 bool CNPC_Manhack::OverrideMove( float flInterval )
 {
 	SpinBlades( flInterval );
-		
+
 	// Don't execute any move code if packed up.
 	if( HasSpawnFlags(SF_MANHACK_PACKED_UP|SF_MANHACK_CARRIED) )
 		return true;
+
+#ifdef EZ
+	//this can happen on player pickup
+	if ( IsMarkedForDeletion() )
+		return true;
+#endif
 
 	if( IsLoitering() )
 	{
@@ -2471,6 +2480,17 @@ void CNPC_Manhack::Spawn(void)
 }
 
 #ifdef EZ
+int CNPC_Manhack::ObjectCaps(void)
+{
+	int caps = UsableNPCObjectCaps( BaseClass::ObjectCaps() );
+	if ( caps & FCAP_IMPULSE_USE )
+	{
+		//this is apparently required if this is to be used by the owner entity
+		caps |= FCAP_USE_IN_RADIUS;
+	}
+	return caps;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Return the pointer for a given sprite given an index
 //-----------------------------------------------------------------------------
@@ -3426,6 +3446,20 @@ bool CNPC_Manhack::CreateVPhysics( void )
 
 	return BaseClass::CreateVPhysics();
 }
+
+#ifdef EZ
+void CNPC_Manhack::PlayerPickup( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value )
+{
+	CBasePlayer *pPlayer = ToBasePlayer( pActivator );
+	if ( !pPlayer || GetOwnerEntity() != pPlayer || IsInAScript() || m_NPCState == NPC_STATE_SCRIPT || IRelationType( pActivator ) == D_HT )
+		return;
+
+	if ( pPlayer->GiveAmmo( 1, "Manhack" ) )
+	{
+		UTIL_Remove( this );
+	}
+}
+#endif
 
 //-----------------------------------------------------------------------------
 //

--- a/sp/src/game/server/hl2/npc_manhack.h
+++ b/sp/src/game/server/hl2/npc_manhack.h
@@ -116,6 +116,10 @@ public:
 	void			Spawn(void);
 	void			Activate();
 	void			StartTask( const Task_t *pTask );
+#ifdef EZ
+	//allow use/pickup
+	int			ObjectCaps( void );
+#endif
 
 	virtual void			BladesInit();
 	virtual void			SoundInit( void );
@@ -160,6 +164,10 @@ public:
 	// 	CDefaultPlayerPickupVPhysics
 	virtual void	OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t reason );
 	virtual void	OnPhysGunDrop( CBasePlayer *pPhysGunUser, PhysGunDrop_t Reason );
+
+#ifdef EZ
+	void	PlayerPickup( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
+#endif
 
 	CBasePlayer *HasPhysicsAttacker( float dt );
 

--- a/sp/src/game/shared/hl2/hl2_gamerules.cpp
+++ b/sp/src/game/shared/hl2/hl2_gamerules.cpp
@@ -1827,7 +1827,7 @@ CAmmoDef *GetAmmoDef()
 		def.AddAmmoType("AirboatGun",		DMG_AIRBOAT,				TRACER_LINE,			"sk_plr_dmg_airboat",		"sk_npc_dmg_airboat",		NULL,					BULLET_IMPULSE(10, 600), 0 );
 			
 		//Entropy Zero
-		def.AddAmmoType("Manhack", DMG_BURN, TRACER_NONE, 0, 0, 2, 0, 0);
+		def.AddAmmoType("Manhack", DMG_BURN, TRACER_NONE, 0, 0, 3, 0, 0);
 
 		// Custom
 		def.AddAmmoType("FlareRound", DMG_BURN, TRACER_NONE, "sk_plr_dmg_flare_round", "sk_npc_dmg_flare_round", "sk_max_flare_round", 0, 0);


### PR DESCRIPTION
The first two commits should be a strict improvement. The `scripts/weapon_manhacktoss.txt` must be adapted such that `"clip_size" "-1"` and `"default_clip" "1"`. I've also set `"item_flags" "4" // ITEM_FLAG_EXHAUSTIBLE`.
Also with this change it plays the deploy-animation after the attack is finished. I thought that looks good.

Rejecting spawning the manhack in solids is a good change too I think.

Picking manhacks (via +use) up does change the balance a little. Currently I have it so that the manhacks tossed by the player can be picked up. This should probably be explained to the player.
This can be used (exploited?) to "repair" the manhacks. This can be fixed by storing an HP-list on the player and referencing that when tossing/picking up manhacks.
Maybe a button to recall manhacks could be a useful addition to this.