### PR TITLE
Player companion NPCs speak TLK_SMELL response concept

### DIFF
--- a/sp/src/game/server/ai_playerally.cpp
+++ b/sp/src/game/server/ai_playerally.cpp
@@ -738,6 +738,14 @@ bool CAI_PlayerAlly::SelectAlertSpeech( AISpeechSelection_t *pSelection )
 	}
 #endif
 
+#ifdef EZ2
+	// NPCs can comment on smells in EZ2
+	if ( HasCondition( COND_SMELL ) && GetExpresser()->CanSpeakConcept( TLK_SMELL ) && SelectSpeechResponse( TLK_SMELL, NULL, this, pSelection ) )
+	{
+		return true;
+	}
+#endif
+
 	return SelectIdleSpeech( pSelection );
 }
 

--- a/sp/src/game/server/hl2/npc_playercompanion.cpp
+++ b/sp/src/game/server/hl2/npc_playercompanion.cpp
@@ -1949,6 +1949,12 @@ int CNPC_PlayerCompanion::GetSoundInterests()
 			SOUND_DANGER			|
 			SOUND_BULLET_IMPACT		|
 			SOUND_MOVE_AWAY			|
+	// Companions can comment on smells
+	#ifdef EZ2
+			SOUND_CARCASS	|
+			SOUND_MEAT		|
+			SOUND_GARBAGE	|
+	#endif
 			SOUND_READINESS_LOW		|
 			SOUND_READINESS_MEDIUM	|
 			SOUND_READINESS_HIGH;


### PR DESCRIPTION
This PR is for companion NPCs reacting to ragdolls emitting SOUND_CARCASS smells with a response concept TLK_SMELL. It will also put companion NPCs into alert status in the presence of smells.

Before merging, I need to do some additional testing in regular EZ2 combat encounters to make sure that the alert state doesn't have any side effects.

This PR can be merged through a squash merge or rebase strategy if desired.