### PR TITLE
Pit Drones can summon reinforcements

### DIFF
--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -1151,7 +1151,7 @@ bool CGravityVortexController::TryCreateRecipeNPC( const char *szClass, const ch
 		const char * squadnameContext = GetContextValue( "squadname" );
 
 		// If the context "squadname" does not match an empty string, use that instead of the default Xen squad name
-		if (!Matcher_Match( squadnameContext, "" ))
+		if (!Matcher_Match( squadnameContext, "default" ))
 		{
 			DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadnameContext );
 			baseNPC->SetSquadName( AllocPooledString( squadnameContext ) );
@@ -1888,6 +1888,9 @@ CGravityVortexController *CGravityVortexController::Create( const Vector &origin
 
 	// Start the vortex working
 	pVortex->StartPull( origin, radius, strength, duration );
+
+	// Set the default value for the squadname context
+	pVortex->AddContext( "squadname:default" );
 
 	return pVortex;
 }

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -25,6 +25,8 @@
 #include "saverestore.h"
 #include "saverestore_utlmap.h"
 #include "items.h"
+#include "mapbase/matchers.h"
+
 
 #include "ai_hint.h"
 #include "ai_network.h"
@@ -405,6 +407,10 @@ public:
 //-----------------------------------------------------------------------------
 bool CGravityVortexController::CanConsumeEntity( CBaseEntity *pEnt )
 {
+	// Don't consume my owner entity
+	if (pEnt == GetOwnerEntity())
+		return false;
+
 	// Don't try to consume the player! What would even happen!?
 	if (pEnt->IsPlayer())
 		return false;
@@ -725,6 +731,10 @@ void CGravityVortexController::PullPlayersInRange( void )
 bool CGravityVortexController::KillNPCInRange( CBaseEntity *pVictim, IPhysicsObject **pPhysObj )
 {
 	CBaseCombatCharacter *pBCC = pVictim->MyCombatCharacterPointer();
+
+	// Don't kill owner
+	if (pBCC == GetOwnerEntity())
+		return false;
 
 	// See if we can ragdoll
 	if ( pBCC != NULL && pBCC->CanBecomeRagdoll() )
@@ -1137,10 +1147,22 @@ bool CGravityVortexController::TryCreateRecipeNPC( const char *szClass, const ch
 		baseNPC->AddSpawnFlags( SF_NPC_FALL_TO_GROUND );
 		baseNPC->m_tEzVariant = CAI_BaseNPC::EZ_VARIANT_XEN;
 
-		// Set the squad name of a new Xen NPC to 'xenpc_headcrab', 'xenpc_bullsquid', etc
-		char * squadname = UTIL_VarArgs( "xe%s", szClass );
-		DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadname );
-		baseNPC->SetSquadName( AllocPooledString( squadname ) );
+
+		const char * squadnameContext = GetContextValue( "squadname" );
+
+		// If the context "squadname" does not match an empty string, use that instead of the default Xen squad name
+		if (!Matcher_Match( squadnameContext, "" ))
+		{
+			DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadnameContext );
+			baseNPC->SetSquadName( AllocPooledString( squadnameContext ) );
+		}
+		else
+		{
+			// Set the squad name of a new Xen NPC to 'xenpc_headcrab', 'xenpc_bullsquid', etc
+			char * squadname = UTIL_VarArgs( "xe%s", szClass );
+			DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadname );
+			baseNPC->SetSquadName( AllocPooledString( squadname ) );
+		}
 	}
 	else if (CItem *pItem = dynamic_cast<CItem*>(pEntity))
 	{

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -25,8 +25,6 @@
 #include "saverestore.h"
 #include "saverestore_utlmap.h"
 #include "items.h"
-#include "mapbase/matchers.h"
-
 
 #include "ai_hint.h"
 #include "ai_network.h"

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -1150,8 +1150,8 @@ bool CGravityVortexController::TryCreateRecipeNPC( const char *szClass, const ch
 
 		const char * squadnameContext = GetContextValue( "squadname" );
 
-		// If the context "squadname" does not match an empty string, use that instead of the default Xen squad name
-		if (!Matcher_Match( squadnameContext, "default" ))
+		// If the context "squadname" does not match an empty string, use that instead of the default Xen squad name		
+		if (squadnameContext && squadnameContext[0])
 		{
 			DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadnameContext );
 			baseNPC->SetSquadName( AllocPooledString( squadnameContext ) );
@@ -1888,9 +1888,6 @@ CGravityVortexController *CGravityVortexController::Create( const Vector &origin
 
 	// Start the vortex working
 	pVortex->StartPull( origin, radius, strength, duration );
-
-	// Set the default value for the squadname context
-	pVortex->AddContext( "squadname:default" );
 
 	return pVortex;
 }

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -84,6 +84,7 @@ public:
 
 	void	SetNodeRadius( float flRadius ) { m_flNodeRadius = flRadius; }
 	void	SetConsumeRadius( float flRadius ) { m_flConsumeRadius = flRadius; }
+	void    SetConsumedMass( float flMass ) { m_flMass = flMass; };
 #else
 	static CGravityVortexController *Create( const Vector &origin, float radius, float strength, float duration );
 #endif

--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -25,6 +25,7 @@
 
 ConVar ai_debug_predator( "ai_debug_predator", "0" );
 ConVar sv_predator_heal_render_effects( "sv_predator_heal_render_effects", "1", FCVAR_NONE, "Should predators like bullsquids turn green after healing?" );
+ConVar sk_predator_eatincombat_fraction( "sk_predator_eatincombat_fraction", "1.0", FCVAR_NONE, "Below what percentage of health should predator NPCs like bullsquids eat during combat?" );
 
 LINK_ENTITY_TO_CLASS( npc_basepredator, CNPC_BasePredator );
 
@@ -687,7 +688,23 @@ bool CNPC_BasePredator::CanMateWithTarget( CNPC_BasePredator * pTarget, bool rec
 //=========================================================
 bool CNPC_BasePredator::ShouldEatInCombat()
 {
-	return m_iMaxHealth > m_iHealth && HasCondition( COND_PREDATOR_SMELL_FOOD ) && !IsSameSpecies( GetEnemy() ) && ( !IsInSquad() || OccupyStrategySlot( SQUAD_SLOT_FEED ) );
+	// Do we need health?
+	if ( m_iHealth >= (m_iMaxHealth * sk_predator_eatincombat_fraction.GetFloat()))
+		return false;
+	
+	// Do we smell food?
+	if ( !HasCondition( COND_PREDATOR_SMELL_FOOD ) )
+		return false;
+
+	// Are we fighting with a rival over food?
+	if ( IsSameSpecies( GetEnemy() ) )
+		return false;
+
+	// Can we acquire a squad slot for this?
+	if (IsInSquad() && !OccupyStrategySlot( SQUAD_SLOT_FEED ))
+		return false;
+	
+	return true;
 }
 
 //=========================================================

--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -689,7 +689,7 @@ bool CNPC_BasePredator::CanMateWithTarget( CNPC_BasePredator * pTarget, bool rec
 bool CNPC_BasePredator::ShouldEatInCombat()
 {
 	// Do we need health?
-	if ( m_iHealth >= (m_iMaxHealth * sk_predator_eatincombat_fraction.GetFloat()))
+	if ( m_iHealth >= ( m_iMaxHealth * GetEatInCombatPercentHealth() ) )
 		return false;
 	
 	// Do we smell food?

--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -25,7 +25,6 @@
 
 ConVar ai_debug_predator( "ai_debug_predator", "0" );
 ConVar sv_predator_heal_render_effects( "sv_predator_heal_render_effects", "1", FCVAR_NONE, "Should predators like bullsquids turn green after healing?" );
-ConVar sk_predator_eatincombat_fraction( "sk_predator_eatincombat_fraction", "1.0", FCVAR_NONE, "Below what percentage of health should predator NPCs like bullsquids eat during combat?" );
 
 LINK_ENTITY_TO_CLASS( npc_basepredator, CNPC_BasePredator );
 

--- a/sp/src/game/server/ez2/npc_basepredator.h
+++ b/sp/src/game/server/ez2/npc_basepredator.h
@@ -152,6 +152,7 @@ public:
 	virtual float GetBiteDamage( void ) { return 0.0f; };
 	virtual float GetWhipDamage( void ) { return 0.0f; };
 	virtual float GetSprintDistance( void ) { return 256.0f; };
+	virtual float GetEatInCombatPercentHealth( void ) { return 1.0f; };
 
 	void Event_Killed(const CTakeDamageInfo &info);
 

--- a/sp/src/game/server/ez2/npc_bullsquid.cpp
+++ b/sp/src/game/server/ez2/npc_bullsquid.cpp
@@ -27,6 +27,7 @@ ConVar sk_bullsquid_spawn_time( "sk_bullsquid_spawn_time", "5.0" );
 ConVar sk_bullsquid_monster_infighting( "sk_bullsquid_monster_infighting", "1" );
 ConVar sk_bullsquid_antlion_style_spit( "sk_bullsquid_antlion_style_spit", "1" );
 ConVar sk_bullsquid_lay_eggs( "sk_bullsquid_lay_eggs", "1" );
+ConVar sk_bullsquid_eatincombat_percent( "sk_bullsquid_eatincombat_percent", "1.0", FCVAR_NONE, "Below what percentage of health should bullsquids eat during combat?" );
 ConVar sk_max_squad_squids( "sk_max_squad_squids", "4" ); // How many squids in a pack before offspring start branching off into their own pack?
 
 //=========================================================
@@ -593,6 +594,14 @@ float CNPC_Bullsquid::GetBiteDamage( void )
 {
 	// Multiply the damage value by the scale of the model so that baby squids do less damage
 	return sk_bullsquid_dmg_bite.GetFloat() * GetModelScale() * ( m_bIsBaby ? 0.5f : 1.0f );
+}
+
+//=========================================================
+// At what percentage health should this NPC seek food?
+//=========================================================
+float CNPC_Bullsquid::GetEatInCombatPercentHealth( void )
+{
+	return sk_bullsquid_eatincombat_percent.GetFloat();
 }
 
 // Helper function from Antlion

--- a/sp/src/game/server/ez2/npc_bullsquid.h
+++ b/sp/src/game/server/ez2/npc_bullsquid.h
@@ -42,6 +42,7 @@ public:
 
 	float GetWhipDamage( void );
 	float GetBiteDamage( void );
+	float GetEatInCombatPercentHealth( void );
 
 	// Antlion worker styled spit attack
 	virtual bool GetSpitVector( const Vector &vecStartPos, const Vector &vecTarget, Vector *vecOut );

--- a/sp/src/game/server/ez2/npc_flyingpredator.cpp
+++ b/sp/src/game/server/ez2/npc_flyingpredator.cpp
@@ -24,6 +24,7 @@ ConVar sk_flyingpredator_spit_max_wait( "sk_flyingpredator_spit_max_wait", "1");
 ConVar sk_flyingpredator_radius_explode( "sk_flyingpredator_radius_explode", "128" );
 ConVar sk_flyingpredator_gestation( "sk_flyingpredator_gestation", "15.0" );
 ConVar sk_flyingpredator_spawn_time( "sk_flyingpredator_spawn_time", "5.0" );
+ConVar sk_flyingpredator_eatincombat_percent( "sk_flyingpredator_eatincombat_percent", "1.0", FCVAR_NONE, "Below what percentage of health should stukabats eat during combat?" );
 
 LINK_ENTITY_TO_CLASS( npc_flyingpredator, CNPC_FlyingPredator );
 LINK_ENTITY_TO_CLASS( npc_stukabat, CNPC_FlyingPredator );
@@ -218,6 +219,14 @@ float CNPC_FlyingPredator::GetMaxSpitWaitTime( void )
 float CNPC_FlyingPredator::GetMinSpitWaitTime( void )
 {
 	return sk_flyingpredator_spit_max_wait.GetFloat();
+}
+
+//=========================================================
+// At what percentage health should this NPC seek food?
+//=========================================================
+float CNPC_FlyingPredator::GetEatInCombatPercentHealth( void )
+{
+	return sk_flyingpredator_eatincombat_percent.GetFloat();
 }
 
 //=========================================================

--- a/sp/src/game/server/ez2/npc_flyingpredator.h
+++ b/sp/src/game/server/ez2/npc_flyingpredator.h
@@ -39,6 +39,7 @@ public:
 
 	float GetMaxSpitWaitTime( void );
 	float GetMinSpitWaitTime( void );
+	float GetEatInCombatPercentHealth( void );
 
 	bool IsPrey( CBaseEntity* pTarget ) { return pTarget->Classify() == CLASS_EARTH_FAUNA || pTarget->Classify() == CLASS_ALIEN_FAUNA; }
 	virtual bool IsSameSpecies( CBaseEntity* pTarget ) { return pTarget ? ClassMatches( pTarget->GetClassname() ) : false; } // Is this NPC the same species as me?

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -14,7 +14,6 @@
 #include "npc_pitdrone.h"
 #include "movevars_shared.h"
 #include "grenade_hopwire.h"
-#include "mapbase/matchers.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -22,7 +22,7 @@
 ConVar sk_pitdrone_health( "sk_pitdrone_health", "100" );
 ConVar sk_pitdrone_dmg_spit( "sk_pitdrone_dmg_spit", "15" );
 ConVar sk_pitdrone_dmg_slash( "sk_pitdrone_dmg_slash", "15" );
-ConVar sk_pitdrone_eatincombat_fraction( "sk_pitdrone_eatincombat_fraction", "1.0", FCVAR_NONE, "Below what percentage of health should Pit Drones eat during combat?" );
+ConVar sk_pitdrone_eatincombat_percent( "sk_pitdrone_eatincombat_percent", "1.0", FCVAR_NONE, "Below what percentage of health should Pit Drones eat during combat?" );
 ConVar sk_pitdrone_summon_time( "sk_pitdrone_summon_time", "5.0" );
 ConVar sk_pitdrone_spit_speed( "sk_pitdrone_spit_speed", "512" );
 ConVar sk_pitdrone_summon_cost( "sk_pitdrone_summon_cost", "12" );
@@ -193,7 +193,19 @@ float CNPC_PitDrone::MaxYawSpeed( void )
 //=========================================================
 bool CNPC_PitDrone::ShouldEatInCombat()
 {
-	return ( ( m_iAmmo <= 0 && m_iClip <= 0 ) || m_iMaxHealth > (m_iHealth / sk_pitdrone_eatincombat_fraction.GetFloat()) ) && HasCondition( COND_PREDATOR_SMELL_FOOD ) && ( !IsInSquad() || OccupyStrategySlot( SQUAD_SLOT_FEED ) );
+	// Do we need health or ammo?
+	if ( m_iHealth >= (m_iMaxHealth * GetEatInCombatPercentHealth() ) && ( m_iAmmo > 0 || m_iClip > 0 ) )
+		return false;
+
+	// Do we smell food?
+	if (!HasCondition( COND_PREDATOR_SMELL_FOOD ))
+		return false;
+
+	// Can we acquire a squad slot for this?
+	if (IsInSquad() && !OccupyStrategySlot( SQUAD_SLOT_FEED ))
+		return false;
+
+	return true;
 }
 
 //=========================================================
@@ -474,6 +486,14 @@ float CNPC_PitDrone::GetBiteDamage( void )
 float CNPC_PitDrone::GetWhipDamage( void )
 {
 	return sk_pitdrone_dmg_slash.GetFloat();
+}
+
+//=========================================================
+// At what percentage health should this NPC seek food?
+//=========================================================
+float CNPC_PitDrone::GetEatInCombatPercentHealth( void )
+{
+	return sk_pitdrone_eatincombat_percent.GetFloat();
 }
 
 //=========================================================

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -13,6 +13,8 @@
 #include "npcevent.h"
 #include "npc_pitdrone.h"
 #include "movevars_shared.h"
+#include "grenade_hopwire.h"
+#include "mapbase/matchers.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -139,6 +141,7 @@ void CNPC_PitDrone::Precache()
 	PrecacheScriptSound( "NPC_PitDrone.Bite" );
 	PrecacheScriptSound( "NPC_PitDrone.Eat" );
 	PrecacheScriptSound( "NPC_PitDrone.Explode" );
+	PrecacheScriptSound( "NPC_PitDrone.SummonBackup" );
 
 	UTIL_PrecacheOther( "crossbow_bolt" );
 	PrecacheModel( "models/pitdrone_projectile.mdl" );
@@ -205,6 +208,58 @@ int CNPC_PitDrone::RangeAttack1Conditions( float flDot, float flDist )
 	}
 
 	return(BaseClass::RangeAttack1Conditions( flDot, flDist ));
+}
+
+//=========================================================
+// Start task - selects the correct activity and performs
+// any necessary calculations to start the next task on the
+// schedule. 
+//
+// Overridden for bullsquids to play specific activities
+//=========================================================
+void CNPC_PitDrone::StartTask( const Task_t *pTask )
+{
+	CGravityVortexController *pVortex;
+
+	switch (pTask->iTask)
+	{
+	case TASK_PREDATOR_SPAWN:
+		// TODO - This should probably have an animation
+
+		// Play a sound
+		EmitSound( "NPC_PitDrone.SummonBackup" );
+
+		// Create a portal
+		pVortex = CGravityVortexController::Create( GetAbsOrigin(), 0.0f, 0.0f, 0.0f, this );
+		pVortex->AddContext( "owner_classname:npc_pitdrone" );
+
+		// If this mate is my squadmate, break off into a new squad for now
+		if (this->GetSquad() == NULL)
+		{
+			// Autogenerate a name for the new squad with GetDebugName()-entindex(). It's important that it has a name
+			g_AI_SquadManager.CreateSquad( AllocPooledString(UTIL_VarArgs("%s-%i", GetDebugName(), entindex() )))->AddToSquad( this );
+		}
+
+		// If we are in a squad and that squad has a name, apply that squad's name to the Xen singularity
+		if (GetSquad() && !Matcher_Match( GetSquad()->GetName(), ""))
+		{
+			pVortex->AddContext( UTIL_VarArgs( "squadname:%s", GetSquad()->GetName() ) );
+		}
+		// pVortex->SetMass( GetMass() * m_iTimesFed );
+		pVortex->SetMass( 2048 );
+		pVortex->SetConsumeRadius( 0 );
+		m_iTimesFed = 0;
+		// Subtract 6 spikes from ammo
+		m_iAmmo = MAX( m_iAmmo - 6, 0 );
+		m_bReadyToSpawn = false;
+		TaskComplete();
+		break;
+	default:
+	{
+		BaseClass::StartTask( pTask );
+		break;
+	}
+	}
 }
 
 //=========================================================
@@ -375,6 +430,22 @@ int CNPC_PitDrone::TranslateSchedule( int scheduleType )
 	return BaseClass::TranslateSchedule( scheduleType );
 }
 
+
+extern int g_interactionXenGrenadeCreate;
+
+bool CNPC_PitDrone::HandleInteraction( int interactionType, void * data, CBaseCombatCharacter * sourceEnt )
+{
+	if ( interactionType == g_interactionXenGrenadeCreate )
+	{
+		InputSetWanderAlways( inputdata_t() );
+		InputEnableSpawning( inputdata_t() );
+
+		return true;
+	}
+
+	return BaseClass::HandleInteraction( interactionType, data, sourceEnt );
+}
+
 //=========================================================
 // Damage for projectile attack
 //=========================================================
@@ -406,6 +477,26 @@ float CNPC_PitDrone::GetWhipDamage( void )
 void CNPC_PitDrone::OnFed()
 {
 	m_iAmmo += MAX_PITDRONE_CLIP;
+
+	if ( m_bSpawningEnabled )
+	{
+		int iExcessSpinesNeeded = MAX_PITDRONE_CLIP * 2;
+
+		// If already in a squad, multiply the required number of spines to call reinforcements by the number of squadmates
+		if ( IsInSquad() )
+		{
+			iExcessSpinesNeeded *= GetSquad()->NumMembers();
+		}
+
+		if (m_iAmmo >= iExcessSpinesNeeded)
+		{
+			m_bReadyToSpawn = true;
+
+			// Set the next spawn time based on the gestation period of the squid
+			m_flNextSpawnTime = gpGlobals->curtime + 5.0f;
+		}
+	}
+
 	BaseClass::OnFed();
 }
 

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -22,7 +22,11 @@
 ConVar sk_pitdrone_health( "sk_pitdrone_health", "100" );
 ConVar sk_pitdrone_dmg_spit( "sk_pitdrone_dmg_spit", "15" );
 ConVar sk_pitdrone_dmg_slash( "sk_pitdrone_dmg_slash", "15" );
+ConVar sk_pitdrone_eatincombat_fraction( "sk_pitdrone_eatincombat_fraction", "1.0", FCVAR_NONE, "Below what percentage of health should Pit Drones eat during combat?" );
+ConVar sk_pitdrone_summon_time( "sk_pitdrone_summon_time", "5.0" );
 ConVar sk_pitdrone_spit_speed( "sk_pitdrone_spit_speed", "512" );
+ConVar sk_pitdrone_summon_cost( "sk_pitdrone_summon_cost", "12" );
+
 
 LINK_ENTITY_TO_CLASS( npc_pitdrone, CNPC_PitDrone );
 
@@ -189,7 +193,7 @@ float CNPC_PitDrone::MaxYawSpeed( void )
 //=========================================================
 bool CNPC_PitDrone::ShouldEatInCombat()
 {
-	return ( m_iClip <= 0 || m_iMaxHealth > m_iHealth ) && HasCondition( COND_PREDATOR_SMELL_FOOD ) && ( !IsInSquad() || OccupyStrategySlot( SQUAD_SLOT_FEED ) );
+	return ( ( m_iAmmo <= 0 && m_iClip <= 0 ) || m_iMaxHealth > (m_iHealth / sk_pitdrone_eatincombat_fraction.GetFloat()) ) && HasCondition( COND_PREDATOR_SMELL_FOOD ) && ( !IsInSquad() || OccupyStrategySlot( SQUAD_SLOT_FEED ) );
 }
 
 //=========================================================
@@ -248,8 +252,7 @@ void CNPC_PitDrone::StartTask( const Task_t *pTask )
 		{
 			pVortex->AddContext( UTIL_VarArgs( "squadname:%s", GetSquad()->GetName() ) );
 		}
-		// pVortex->SetMass( GetMass() * m_iTimesFed );
-		pVortex->SetMass( 2048 );
+		pVortex->SetConsumedMass( GetMass() * m_iTimesFed );
 		pVortex->SetConsumeRadius( 0 );
 		m_iTimesFed = 0;
 		// Subtract 6 spikes from ammo
@@ -483,7 +486,7 @@ void CNPC_PitDrone::OnFed()
 
 	if ( m_bSpawningEnabled )
 	{
-		int iExcessSpinesNeeded = MAX_PITDRONE_CLIP * 2;
+		int iExcessSpinesNeeded = sk_pitdrone_summon_cost.GetFloat();
 
 		// If already in a squad, multiply the required number of spines to call reinforcements by the number of squadmates
 		if ( IsInSquad() )
@@ -495,8 +498,8 @@ void CNPC_PitDrone::OnFed()
 		{
 			m_bReadyToSpawn = true;
 
-			// Set the next spawn time based on the gestation period of the squid
-			m_flNextSpawnTime = gpGlobals->curtime + 5.0f;
+			// Set the next spawn time based on the time required for a pit drone to summon
+			m_flNextSpawnTime = gpGlobals->curtime + sk_pitdrone_summon_time.GetFloat();
 		}
 	}
 

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -260,7 +260,7 @@ void CNPC_PitDrone::StartTask( const Task_t *pTask )
 		}
 
 		// If we are in a squad and that squad has a name, apply that squad's name to the Xen singularity
-		if (GetSquad() && !Matcher_Match( GetSquad()->GetName(), ""))
+		if (GetSquad() && GetSquad()->GetName() && GetSquad()->GetName()[0])
 		{
 			pVortex->AddContext( UTIL_VarArgs( "squadname:%s", GetSquad()->GetName() ) );
 		}

--- a/sp/src/game/server/ez2/npc_pitdrone.h
+++ b/sp/src/game/server/ez2/npc_pitdrone.h
@@ -33,9 +33,11 @@ public:
 
 	int RangeAttack1Conditions( float flDot, float flDist );
 
+	void StartTask ( const Task_t *pTask );
 	void HandleAnimEvent( animevent_t *pEvent );
-
 	virtual int TranslateSchedule( int scheduleType );
+
+	virtual bool	HandleInteraction( int interactionType, void *data, CBaseCombatCharacter* sourceEnt );
 
 	// Projectile methods
 	virtual float GetProjectileDamge();
@@ -50,6 +52,8 @@ public:
 
 	// Pit drones in opposing force hated headcrabs - this was an oversight, but let's keep it
 	bool IsPrey( CBaseEntity* pTarget ) { return pTarget->Classify() == CLASS_HEADCRAB; }
+
+	void SummonDrones( void );
 
 	DEFINE_CUSTOM_AI;
 

--- a/sp/src/game/server/ez2/npc_pitdrone.h
+++ b/sp/src/game/server/ez2/npc_pitdrone.h
@@ -45,6 +45,7 @@ public:
 	virtual float GetProjectileDamge();
 	virtual float GetBiteDamage( void );
 	virtual float GetWhipDamage( void );
+	virtual float GetEatInCombatPercentHealth( void );
 
 	// On feeding
 	virtual void OnFed();

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -859,6 +859,13 @@ void CNPC_Gonome::HandleAnimEvent( animevent_t *pEvent )
 			
 				pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (right * 200) );
 				pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (up * 100) );
+
+				// If we were trying to spawn and hit something by accident, defer spawning for a while
+				if (m_bReadyToSpawn)
+				{
+					PredMsg( UTIL_VarArgs( "npc_zassassin '%s' tried to create a headcrab but hit something instead. Waiting %f seconds before retrying.", GetDebugName(), sk_zombie_assassin_spawn_time.GetFloat() ) );
+					m_flNextSpawnTime = gpGlobals->curtime + sk_zombie_assassin_spawn_time.GetFloat();
+				}
 			} 			
 			// Reusing this activity / animation event for headcrab spawning
 			else if ( m_bReadyToSpawn )
@@ -874,6 +881,7 @@ void CNPC_Gonome::HandleAnimEvent( animevent_t *pEvent )
 				// Wait a while before retrying
 				else
 				{
+					PredMsg( UTIL_VarArgs("npc_zassassin '%s' failed to create a headcrab. Waiting %f seconds before retrying.", GetDebugName(), sk_zombie_assassin_spawn_time.GetFloat()));
 					m_flNextSpawnTime = gpGlobals->curtime + sk_zombie_assassin_spawn_time.GetFloat();
 				}
 			}

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -80,6 +80,7 @@ ConVar sk_zombie_assassin_dmg_whip ( "sk_zombie_assassin_dmg_whip", "35" );
 ConVar sk_zombie_assassin_dmg_spit ( "sk_zombie_assassin_dmg_spit", "15" );
 ConVar sk_zombie_assassin_spawn_time( "sk_zombie_assassin_spawn_time", "5.0" );
 ConVar sk_zombie_assassin_look_dist( "sk_zombie_assassin_look_dist", "1024.0" );
+ConVar sk_zombie_assassin_eatincombat_percent( "sk_zombie_assassin_eatincombat_percent", "1.0", FCVAR_NONE, "Below what percentage of health should gonomes eat during combat?" );
 
 //=========================================================
 // monster-specific schedule types
@@ -978,6 +979,14 @@ void CNPC_Gonome::InputGoHomeInstant( inputdata_t &inputdata )
 float CNPC_Gonome::GetWhipDamage( void )
 {
 	return sk_zombie_assassin_dmg_whip.GetFloat();
+}
+
+//=========================================================
+// At what percentage health should this NPC seek food?
+//=========================================================
+float CNPC_Gonome::GetEatInCombatPercentHealth( void )
+{
+	return sk_zombie_assassin_eatincombat_percent.GetFloat();
 }
 
 // Overriden to play a sound when this NPC is killed by Hammer I/O

--- a/sp/src/game/server/ez2/npc_zassassin.h
+++ b/sp/src/game/server/ez2/npc_zassassin.h
@@ -49,6 +49,7 @@ public:
 	float GetMaxSpitWaitTime( void ) { return 5.0f; };
 	float GetMinSpitWaitTime( void ) { return 0.5f; };
 	float GetWhipDamage( void );
+	float GetEatInCombatPercentHealth( void );
 	
 	void Ignite( float flFlameLifetime, bool bNPCOnly = true, float flSize = 0.0f, bool bCalledByLevelDesigner = false );
 


### PR DESCRIPTION
This PR is to enable Pit Drone spawning similar to bullsquids, gonomes, and stukabats. Unlike those other predator types, pit drones spawn by opening a Xen portal and using the xen grenade recipe system to spawn reinforcements.