### PR TITLE
Wilson ignores bullseyes

### DIFF
--- a/sp/src/game/server/ez2/npc_wilson.cpp
+++ b/sp/src/game/server/ez2/npc_wilson.cpp
@@ -986,6 +986,21 @@ void CNPC_Wilson::OnFriendDamaged( CBaseCombatCharacter *pSquadmate, CBaseEntity
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
+bool CNPC_Wilson::IsValidEnemy( CBaseEntity *pEnemy )
+{
+	if (!BaseClass::IsValidEnemy( pEnemy ))
+		return false;
+
+	// HACKHACK: Just completely ignore bullseyes for now
+	if (pEnemy->Classify() == CLASS_BULLSEYE)
+		return false;
+
+	return true;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
 bool CNPC_Wilson::CanBeAnEnemyOf( CBaseEntity *pEnemy )
 { 
 	// Don't be anyone's enemy unless it's needed for something

--- a/sp/src/game/server/ez2/npc_wilson.h
+++ b/sp/src/game/server/ez2/npc_wilson.h
@@ -154,6 +154,8 @@ public:
 
 	int		BloodColor( void ) { return DONT_BLEED; }
 
+	bool	IsValidEnemy( CBaseEntity *pEnemy );
+
 	// By default, Will-E doesn't attack anyone and nobody attacks him. (although he does see enemies for BC, see IRelationType)
 	// You can make NPCs attack him with m_bCanBeEnemy, but Will-E is literally incapable of combat.
 	bool	CanBeAnEnemyOf( CBaseEntity *pEnemy );


### PR DESCRIPTION
This is a hack which fixes an obscure, long-standing issue where Wilson acquires all(?) bullseyes as enemies and never loses them. This mainly just caused Wilson's eye to look freaked-out 24/7.