### PR TITLE
E:Z2 kick achievement counts one kick per door and doesn't count unkickable doors

### DIFF
--- a/sp/src/game/server/ez2/achievements_EZ2.cpp
+++ b/sp/src/game/server/ez2/achievements_EZ2.cpp
@@ -672,8 +672,6 @@ DECLARE_ACHIEVEMENT( CAchievementEZ2XenGrenadeWeight, ACHIEVEMENT_EZ2_XENGRENADE
 // Kick Achievements
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// TODO - We might need a way to make the door kicking achievement "remember" previously kicked doors
-// For now allowing any door kick
 class CAchievementEZ2KickDoors : public CBaseAchievement
 {
 protected:
@@ -685,6 +683,16 @@ protected:
 		SetFlags( ACH_LISTEN_KICK_EVENTS | ACH_SAVE_GLOBAL );
 		SetGameDirFilter( "EntropyZero2" );
 		SetGoal( KICK_DOORS_COUNT );
+	}
+
+	virtual void Event_EntityKicked( CBaseEntity *pVictim, CBaseEntity *pAttacker, CBaseEntity *pInflictor, IGameEvent *event )
+	{
+		// We only want one kick per entity
+		int iIndex = pVictim->FindContextByName( "kicked" );
+		if (iIndex != -1 && atoi( pVictim->GetContextValue( iIndex ) ) > 0)
+			return;
+
+		IncrementCount();
 	}
 
 	// Show progress for this achievement

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -399,10 +399,12 @@ struct KickInfo_t
 	{
 		tr = _tr;
 		dmgInfo = _dmgInfo;
+		success = true;
 	}
 
 	trace_t *tr;
 	CTakeDamageInfo *dmgInfo;
+	bool success; // Can be set by interactions to determine if a kick was "successful" (whether it should be counted by kick trackers)
 };
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -5268,6 +5268,11 @@ bool CBasePropDoor::HandleInteraction( int interactionType, void *data, CBaseCom
 
 			// Open the door away from the source entity if you can
 			OpenIfUnlocked( sourceEnt, sourceEnt );
+
+			// Return successful if we're opening
+			KickInfo_t *info = static_cast<KickInfo_t*>(data);
+			if (info)
+				info->success = IsDoorOpening();
 		}
 
 		return true;


### PR DESCRIPTION
"Unkickable" doors are doors which are locked, already open, or don't have "Open on kick" enabled.

This PR also contains a fix for brush doors.