### PR TITLE
Wilson scanners turn off when disabled

### DIFF
--- a/sp/src/game/server/ez2/npc_wilson.cpp
+++ b/sp/src/game/server/ez2/npc_wilson.cpp
@@ -2042,6 +2042,7 @@ void CArbeitScanner::Spawn( void )
 	{
 		SetThink( NULL );
 		SetNextThink( TICK_NEVER_THINK );
+		SetScanState( SCAN_OFF );
 	}
 }
 
@@ -2070,6 +2071,7 @@ void CArbeitScanner::InputEnable( inputdata_t &inputdata )
 	{
 		SetThink( &CArbeitScanner::IdleThink );
 		SetNextThink( gpGlobals->curtime );
+		SetScanState( SCAN_IDLE );
 	}
 }
 
@@ -2077,7 +2079,7 @@ void CArbeitScanner::InputDisable( inputdata_t &inputdata )
 {
 	// Clean up any scans
 	CleanupScan(true);
-	SetScanState( SCAN_IDLE );
+	SetScanState( SCAN_OFF );
 
 	SetThink( NULL );
 	SetNextThink( TICK_NEVER_THINK );

--- a/sp/src/game/server/ez2/npc_wilson.h
+++ b/sp/src/game/server/ez2/npc_wilson.h
@@ -310,6 +310,7 @@ public:
 		SCAN_SCANNING,	// Scan in progress
 		SCAN_DONE,		// Scanning done, displays a checkmark or something
 		SCAN_REJECT,	// Scanning rejected, displays an X or something
+		SCAN_OFF,		// Scanner is disabled
 	};
 
 	COutputEvent m_OnScanDone;


### PR DESCRIPTION
Scanners use a new "off" skin, which is just the default monitor screen texture.

Communicates to players that disabled scanners cannot be used and fixes an issue in `c4_1` where a Wilson scanner appears to be powered even though the power in the building is off.