### PR TITLE
Fixed velocity bug on APCs dropped by dropships

### DIFF
--- a/sp/src/game/server/hl2/npc_combinedropship.cpp
+++ b/sp/src/game/server/hl2/npc_combinedropship.cpp
@@ -1847,7 +1847,7 @@ void CNPC_CombineDropship::InputDropCargo( inputdata_t &inputdata )
 	{
 		vecAbsVelocity.z = 0.0f;
 	}
-	if ( m_hContainer->GetHealth() > 0 )
+	if ( m_hContainer->GetHealth() > 0 || m_hContainer->GetServerVehicle() != NULL )
 	{
 		vecAbsVelocity = vec3_origin;
 	}


### PR DESCRIPTION
If the player jumps on or moves against an APC previously dropped by a dropship, they will go flying in a certain direction. This turned out to be because the dropship was assigning velocity to its cargo in a way vehicles don't like.

This fix will also be added to Mapbase in the future.