### PR TITLE
Fixed APC rockets not crediting driver

### DIFF
--- a/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
+++ b/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
@@ -1803,7 +1803,11 @@ void CPropDrivableAPC::FireRocket( void )
 	QAngle angles;
 	VectorAngles( vecDir, angles );
 
+#ifdef EZ
+	CAPCMissile *pRocket = (CAPCMissile *)CAPCMissile::Create( vecRocketOrigin, angles, vecVelocity, GetDriver() );
+#else
 	CAPCMissile *pRocket = (CAPCMissile *)CAPCMissile::Create( vecRocketOrigin, angles, vecVelocity, this );
+#endif
 	pRocket->IgniteDelay();
 #ifdef EZ
 	// If the APC has a target, disable guiding and aim at that target instead

--- a/sp/src/game/server/hl2/weapon_rpg.cpp
+++ b/sp/src/game/server/hl2/weapon_rpg.cpp
@@ -1187,7 +1187,8 @@ void CAPCMissile::DoExplosion( void )
 #if defined(HL2_EPISODIC) && !defined(EZ) // Blixibon - APC rockets must credit their owner
 		ExplosionCreate( GetAbsOrigin(), GetAbsAngles(), this, APC_MISSILE_DAMAGE, 100, true, 20000 );
 #else
-		ExplosionCreate( GetAbsOrigin(), GetAbsAngles(), GetOwnerEntity(), APC_MISSILE_DAMAGE, 100, true, 20000 );
+		ExplosionCreate( GetAbsOrigin(), GetAbsAngles(), GetOwnerEntity(), APC_MISSILE_DAMAGE, 100,
+			SF_ENVEXPLOSION_NOSPARKS | SF_ENVEXPLOSION_NODLIGHTS | SF_ENVEXPLOSION_NOSMOKE, 20000, this );
 #endif
 	}
 }


### PR DESCRIPTION
APC rockets didn't credit the driver, so Bad Cop didn't say anything when he killed an enemy with an APC rocket despite having a specific response for it.

Apparently I had tried to fix this in the past, but it doesn't look like I got it working. I feel like this is something we should've noticed a whole lot sooner 😅