### PR TITLE
Universalized E:Z variants + Xen grenade recipe precaching system

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -11730,13 +11730,8 @@ CBaseEntity *CAI_BaseNPC::DropItem ( const char *pszItemName, Vector vecPos, QAn
 #ifdef EZ
 	CBaseEntity *pItem = CBaseEntity::CreateNoSpawn( pszItemName, vecPos, vecAng, this );
 
-	if (m_tEzVariant != EZ_VARIANT_DEFAULT)
-	{
-		// Make the item match our variant
-		CItem *pCItem = dynamic_cast<CItem*>(pItem);
-		if (pCItem)
-			pCItem->m_tEzVariant = m_tEzVariant;
-	}
+	// Make the item match our variant
+	pItem->SetEZVariant( GetEZVariant() );
 
 	DispatchSpawn( pItem );
 #else

--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -2309,19 +2309,11 @@ private:
 	// Entropy : Zero 2 Variants
 	//-----------------------------------------------------
 public:
-	enum EZ_VARIANT
-	{
-		EZ_VARIANT_INVALID = -1,
-		EZ_VARIANT_DEFAULT = 0,
-		EZ_VARIANT_XEN,
-		EZ_VARIANT_RAD,
-		EZ_VARIANT_TEMPORAL,
-		EZ_VARIANT_ARBEIT, // For Arbeit stuff that isn't covered in goo
 
-		EZ_VARIANT_COUNT, // Keep this at the end
-	};
+	EZ_VARIANT	GetEZVariant() { return m_tEzVariant; }
+	void		SetEZVariant( EZ_VARIANT variant ) { m_tEzVariant = variant; }
 
-	EZ_VARIANT m_tEzVariant;
+	EZ_VARIANT m_tEzVariant; // TODO: Now that we have accessor functions, this should be private
 
 #ifdef EZ
 	virtual bool	ShouldDropGooPuddle() { return true; }

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -1868,15 +1868,10 @@ void CBaseCombatCharacter::Event_Killed( const CTakeDamageInfo &info )
 #ifdef EZ
 		CBaseEntity *pItem = CBaseEntity::CreateNoSpawn( "item_healthvial", GetAbsOrigin(), GetAbsAngles() );
 
-		if (IsNPC())
+		if (pItem)
 		{
-			if (MyNPCPointer()->m_tEzVariant != CAI_BaseNPC::EZ_VARIANT_DEFAULT)
-			{
-				// Make the item match our variant
-				CItem *pCItem = dynamic_cast<CItem*>(pItem);
-				if (pCItem)
-					pCItem->m_tEzVariant = MyNPCPointer()->m_tEzVariant;
-			}
+			// Make the item match our variant
+			pItem->SetEZVariant( GetEZVariant() );
 		}
 
 		DispatchSpawn( pItem );

--- a/sp/src/game/server/baseentity.h
+++ b/sp/src/game/server/baseentity.h
@@ -135,6 +135,21 @@ enum Class_T
 	NUM_AI_CLASSES
 };
 
+//-----------------------------------------------------
+// Entropy : Zero Variants
+//-----------------------------------------------------
+enum EZ_VARIANT
+{
+	EZ_VARIANT_INVALID = -1,
+	EZ_VARIANT_DEFAULT = 0,
+	EZ_VARIANT_XEN,				// Came from Xen or a place connected to Xen. Used by Xen relay grenades.
+	EZ_VARIANT_RAD,				// Covered in blue radioactive goo. NPCs leave behind hazardous puddles when they die.
+	EZ_VARIANT_TEMPORAL,		// Affected by temporal anomalies. Used by temporal crabs.
+	EZ_VARIANT_ARBEIT,			// Property of Arbeit Communications. Used for Arbeit stuff that isn't covered in goo.
+
+	EZ_VARIANT_COUNT, // Keep this at the end
+};
+
 #elif defined( HL1_DLL )
 
 enum Class_T
@@ -1130,6 +1145,9 @@ public:
 #ifdef EZ
 	virtual bool	IsDisplacementImpossible() { return true; }
 	virtual void	SetDisplacementImpossible( bool displacementImpossible ) {}
+
+	virtual EZ_VARIANT	GetEZVariant() { return EZ_VARIANT_DEFAULT; }
+	virtual void		SetEZVariant( EZ_VARIANT variant ) {}
 #endif
 
 	// If this is a vehicle, returns the vehicle interface

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -119,123 +119,355 @@ static const char *g_SpawnThinkContext = "SpawnThink";
 static const char *g_SchlorpThinkContext = "SchlorpThink";
 
 //-----------------------------------------------------------------------------
-// Purpose: 
+// Purpose: Ensures Xen recipes are loaded and precached when they are needed.
 //-----------------------------------------------------------------------------
-class CXenGrenadeRecipeManager : public CBaseEntity
+class CXenGrenadeRecipeManager : public CAutoGameSystem
 {
-	DECLARE_CLASS( CXenGrenadeRecipeManager, CBaseEntity );
-	DECLARE_DATADESC();
-
 public:
-
-	CXenGrenadeRecipeManager()
+	CXenGrenadeRecipeManager() : CAutoGameSystem( "CXenGrenadeRecipeManager" )
 	{
 	}
 
-	void Spawn( void );
-	void Activate( void );
+	virtual bool Init()
+	{
+		return true;
+	}
 
-	virtual IResponseSystem *GetResponseSystem() { return m_pInstancedResponseSystem; }
+	virtual void LevelInitPreEntity()
+	{
+		// Unless cheats are on, assume Xen doesn't exist by default
+		if (sv_cheats->GetBool())
+		{
+			m_bXenExists = true;
+			m_pszXenCreator = "sv_cheats";
+		}
+		else
+		{
+			m_bXenExists = false;
+			m_pszXenCreator = "Unknown"; // Default value
+		}
 
-	virtual int	Save( ISave &save );
-	virtual int	Restore( IRestore &restore );
+		m_bXenPrecached = false;
+
+		m_bPrecachedLate = false;
+	}
+
+	virtual void LevelInitPostEntity()
+	{
+		// If Xen exists, precache Xen
+		if (m_bXenExists)
+		{
+			PrecacheXenRecipes();
+			m_bXenPrecached = true;
+		}
+	}
+
+	virtual void LevelShutdownPreEntity()
+	{
+	}
+
+	virtual void LevelShutdownPostEntity()
+	{
+	}
+
+	virtual void OnRestore()
+	{
+		if (m_bXenExists)
+		{
+			PrecacheXenRecipes();
+		}
+	}
+
+	//------------------------------------------------------------------------------------
+
+	inline bool XenExists() const { return m_bXenExists; }
+
+	inline bool PrecachedLate() const { return m_bPrecachedLate; }
+	inline const char *GetXenCreator() const { return m_pszXenCreator; }
+
+	// Affirms the existence of Xen.
+	void VerifyRecipeManager( const char *pszActivator )
+	{
+		if (!m_bXenExists)
+		{
+			XenGrenadeDebugMsg( "Xen recipe manager activated\n" );
+			m_pszXenCreator = pszActivator;
+		}
+
+		m_bXenExists = true;
+
+		if (!m_bXenPrecached && gpGlobals->curtime > 2.0f)
+		{
+			// Uh-oh. Late precache is a serious hang.
+			// There's not much more we could do about it, unfortunately.
+			UTIL_CenterPrintAll( "Precaching Xen...\n" );
+
+			PrecacheXenRecipes();
+
+			//Warning( "************************************\n!!!!! Late precache of Xen recipe manager !!!!!\n************************************\n" );
+
+			m_bPrecachedLate = true;
+			m_bXenPrecached = true;
+		}
+	}
+
+	void PrecacheXenRecipes();
 
 	bool FindBestRecipe( char *szRecipe, size_t szRecipeSize, AI_CriteriaSet &set, CGravityVortexController *pActivator );
 
-	bool ParseRecipe( char *szRecipe, CGravityVortexController *pActivator );
-	bool ParseRecipeBlock( char *szRecipe, CGravityVortexController *pActivator );
+	bool ParseRecipe( char *szRecipe, CUtlMap<string_t, string_t> &spawnList );
+	bool ParseRecipeBlock( char *szRecipe, CUtlMap<string_t, string_t> &spawnList );
+
+	inline IResponseSystem *GetResponseSystem() { return m_pInstancedResponseSystem; }
+
+	friend class CXenRecipeSaveRestoreBlockHandler;
 
 protected:
 	IResponseSystem *m_pInstancedResponseSystem;
+
+	bool m_bXenExists;
+	bool m_bXenPrecached;
+
+	// The creator of Xen.
+	const char *m_pszXenCreator;
+
+	bool m_bPrecachedLate;
 };
 
-CHandle<CXenGrenadeRecipeManager> g_hXenGrenadeRecipeManager;
+CXenGrenadeRecipeManager	g_XenGrenadeRecipeManager;
 
-BEGIN_DATADESC( CXenGrenadeRecipeManager )
-END_DATADESC()
+//-----------------------------------------------------------------------------
+// Recipe Response System Save/Restore
+//-----------------------------------------------------------------------------
+static short XEN_RECIPE_SAVE_RESTORE_VERSION = 1;
 
-LINK_ENTITY_TO_CLASS( xen_grenade_recipe_manager, CXenGrenadeRecipeManager );
-
-void CXenGrenadeRecipeManager::Spawn( void )
+class CXenRecipeSaveRestoreBlockHandler : public CDefSaveRestoreBlockHandler
 {
-    SetSolid( SOLID_NONE );
-    SetMoveType( MOVETYPE_NONE );
+public:
+	const char *GetBlockName()
+	{
+		return "XenRecipes";
+	}
+
+	//---------------------------------
+
+	void Save( ISave *pSave )
+	{
+		bool bDoSave = g_XenGrenadeRecipeManager.XenExists() && g_XenGrenadeRecipeManager.m_pInstancedResponseSystem != NULL;
+
+		pSave->WriteBool( &bDoSave );
+		if ( bDoSave )
+		{
+			pSave->StartBlock( "InstancedResponseSystem" );
+			{
+				SaveRestoreFieldInfo_t fieldInfo = { &g_XenGrenadeRecipeManager.m_pInstancedResponseSystem, 0, NULL };
+				responseSystemSaveRestoreOps->Save( fieldInfo, pSave );
+			}
+			pSave->EndBlock();
+		}
+	}
+
+	//---------------------------------
+
+	void WriteSaveHeaders( ISave *pSave )
+	{
+		pSave->WriteShort( &XEN_RECIPE_SAVE_RESTORE_VERSION );
+	}
+
+	//---------------------------------
+
+	void ReadRestoreHeaders( IRestore *pRestore )
+	{
+		// No reason why any future version shouldn't try to retain backward compatability. The default here is to not do so.
+		short version;
+		pRestore->ReadShort( &version );
+		m_fDoLoad = ( version == XEN_RECIPE_SAVE_RESTORE_VERSION );
+	}
+
+	//---------------------------------
+
+	void Restore( IRestore *pRestore, bool createPlayers )
+	{
+		if ( m_fDoLoad )
+		{
+			bool bDoRestore = false;
+
+			pRestore->ReadBool( &bDoRestore );
+			if ( bDoRestore )
+			{
+				char szResponseSystemBlockName[SIZE_BLOCK_NAME_BUF];
+				pRestore->StartBlock( szResponseSystemBlockName );
+				if ( !Q_stricmp( szResponseSystemBlockName, "InstancedResponseSystem" ) )
+				{
+					if ( !g_XenGrenadeRecipeManager.m_pInstancedResponseSystem )
+					{
+						// TODO: Verify that using 'PrecacheXenGrenadeResponseSystem' instead of 'PrecacheCustomResponseSystem' on restore is a good thing
+						g_XenGrenadeRecipeManager.m_pInstancedResponseSystem = PrecacheXenGrenadeResponseSystem( XEN_GRENADE_RECIPE_SCRIPT );
+						if (g_XenGrenadeRecipeManager.m_pInstancedResponseSystem)
+						{
+							SaveRestoreFieldInfo_t fieldInfo =
+							{
+								&g_XenGrenadeRecipeManager.m_pInstancedResponseSystem,
+								0,
+								NULL
+							};
+							responseSystemSaveRestoreOps->Restore( fieldInfo, pRestore );
+						}
+					}
+				}
+				pRestore->EndBlock();
+			}
+
+			// Tell the manager Xen has been restored
+			g_XenGrenadeRecipeManager.m_bXenExists = true;
+		}
+	}
+
+private:
+	bool m_fDoLoad;
+};
+
+//-----------------------------------------------------------------------------
+
+CXenRecipeSaveRestoreBlockHandler g_XenRecipeSaveRestoreBlockHandler;
+
+//-------------------------------------
+
+ISaveRestoreBlockHandler *GetXenRecipeSaveRestoreBlockHandler()
+{
+	return &g_XenRecipeSaveRestoreBlockHandler;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Designed to be used externally
+//-----------------------------------------------------------------------------
+void VerifyXenRecipeManager( const char *pszActivator )
+{
+	g_XenGrenadeRecipeManager.VerifyRecipeManager( pszActivator );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Debug commands
+//-----------------------------------------------------------------------------
+CON_COMMAND( hopwire_xen_print_state, "Prints the current state of Xen." )
+{
+	char szMsg[512];
+	if (g_XenGrenadeRecipeManager.XenExists())
+	{
+		Q_strncpy( szMsg, "Xen exists.\n{\n", sizeof( szMsg ) );
+
+		Q_snprintf( szMsg, sizeof( szMsg ), "%s	Creator of Xen: %s\n", szMsg, g_XenGrenadeRecipeManager.GetXenCreator() );
+		Q_snprintf( szMsg, sizeof( szMsg ), "%s	Precached late: %s\n", szMsg, g_XenGrenadeRecipeManager.PrecachedLate() ? "Yes" : "No" );
+
+		Q_snprintf( szMsg, sizeof( szMsg ), "%s}\n", szMsg );
+	}
+	else
+	{
+		Q_strncpy( szMsg, "Xen does not exist.\n", sizeof( szMsg ) );
+	}
+
+	ConColorMsg( XenColor, "%s", szMsg );
+}
+
+CON_COMMAND( hopwire_xen_force_create, "Forces the creation of Xen if it doesn't exist already." )
+{
+	CBasePlayer *pPlayer = UTIL_GetCommandClient();
+
+	if (!g_XenGrenadeRecipeManager.XenExists())
+	{
+		VerifyXenRecipeManager( pPlayer ? pPlayer->GetPlayerName() : "You, apparently!" );
+		ConColorMsg( XenColor, "Xen created!\n" );
+	}
+	else
+	{
+		ConColorMsg( XenColor, "Xen already exists.\n" );
+	}
+}
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// Purpose: Precaches Xen
+//-----------------------------------------------------------------------------
+void CXenGrenadeRecipeManager::PrecacheXenRecipes( void )
+{
+	if ( m_bXenPrecached )
+		return;
 
 	if ( !m_pInstancedResponseSystem )
 	{
 		m_pInstancedResponseSystem = PrecacheXenGrenadeResponseSystem( XEN_GRENADE_RECIPE_SCRIPT );
 	}
-}
 
-void CXenGrenadeRecipeManager::Activate( void )
-{
-	BaseClass::Activate();
-
-	g_hXenGrenadeRecipeManager = this;
-	XenGrenadeDebugMsg( "Assigned g_hXenGrenadeRecipeManager in CXenGrenadeRecipeManager::Activate()\n" );
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: Need a custom save restore so we can restore the instanced response system by name
-//  after we've loaded the filename from disk...
-// Input  : &save - 
-//-----------------------------------------------------------------------------
-int CXenGrenadeRecipeManager::Save( ISave &save )
-{
-	int iret = BaseClass::Save( save );
-	if ( iret )
+#ifdef NEW_RESPONSE_SYSTEM
+	CUtlVector<AI_Response> pResponses;
+#else
+	CUtlVector<AI_Response*> pResponses;
+#endif
+	m_pInstancedResponseSystem->GetAllResponses( &pResponses );
+	if ( pResponses.Count() <= 0 )
 	{
-		bool doSave = m_pInstancedResponseSystem != NULL;
-		save.WriteBool( &doSave );
-		if ( doSave )
-		{
-			save.StartBlock( "InstancedResponseSystem" );
-			{
-				SaveRestoreFieldInfo_t fieldInfo = { &m_pInstancedResponseSystem, 0, NULL };
-				responseSystemSaveRestoreOps->Save( fieldInfo, &save );
-			}
-			save.EndBlock();
-		}
+		XenGrenadeDebugMsg( "Precache: No responses!?!?\n" );
+		return;
 	}
-	return iret;
-}
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-// Input  : &restore - 
-//-----------------------------------------------------------------------------
-int	CXenGrenadeRecipeManager::Restore( IRestore &restore )
-{
-	int iret = BaseClass::Restore( restore );
-	if ( iret )
+	char szRecipe[512];
+	int szRecipeSize = sizeof(szRecipe);
+	CUtlMap<string_t, string_t> recipeEntities;
+
+	SetDefLessFunc( recipeEntities );
+
+	CUtlSymbolTable precachedEntities;
+
+	for (int i = 0; i < pResponses.Count(); i++)
 	{
-		bool doRead = false;
-		restore.ReadBool( &doRead );
-		if ( doRead )
+		// Handle the response here...
+		pResponses[i].GetResponse( szRecipe, szRecipeSize );
+		GetXenGrenadeResponseFromSystem( szRecipe, szRecipeSize, m_pInstancedResponseSystem, szRecipe );
+
+		recipeEntities.EnsureCapacity( 16 );
+		ParseRecipe( szRecipe, recipeEntities );
+
+		for (unsigned int i2 = 0; i2 < recipeEntities.Count(); i2++)
 		{
-			char szResponseSystemBlockName[SIZE_BLOCK_NAME_BUF];
-			restore.StartBlock( szResponseSystemBlockName );
-			if ( !Q_stricmp( szResponseSystemBlockName, "InstancedResponseSystem" ) )
+			const char *pszClass = STRING( recipeEntities.Key( i2 ) );
+
+			if (g_debug_hopwire.GetBool())
 			{
-				if ( !m_pInstancedResponseSystem )
+				CUtlSymbol sym = precachedEntities.Find( pszClass );
+				if (!sym.IsValid())
 				{
-					m_pInstancedResponseSystem = PrecacheCustomResponseSystem( XEN_GRENADE_RECIPE_SCRIPT );
-					if ( m_pInstancedResponseSystem )
-					{
-						SaveRestoreFieldInfo_t fieldInfo =
-						{
-							&m_pInstancedResponseSystem,
-							0,
-							NULL
-						};
-						responseSystemSaveRestoreOps->Restore( fieldInfo, &restore );
-					}
+					precachedEntities.AddString( pszClass );
+					XenGrenadeDebugMsg( "Precache: Precaching %s (%i:%i)\n", pszClass, i, i2 );
+				}
+				else
+				{
+					XenGrenadeDebugMsg( "Precache: Symbol %s (%i:%i) already valid\n", pszClass, i, i2 );
 				}
 			}
-			restore.EndBlock();
+
+			UTIL_PrecacheXenVariant( pszClass );
 		}
+
+		recipeEntities.Purge();
 	}
-	return iret;
+
+	if (g_debug_hopwire.GetBool())
+	{
+		// List all of the entities we precached (reuse szRecipe)
+		Q_strncpy( szRecipe, "All Precached Entities:\n{\n", szRecipeSize );
+
+		for (int i = 0; i < precachedEntities.GetNumStrings(); i++)
+		{
+			precachedEntities.String( i );
+			Q_snprintf( szRecipe, sizeof( szRecipe ), "%s	%s\n", szRecipe, precachedEntities.String( i ) );
+		}
+
+		Q_snprintf( szRecipe, sizeof( szRecipe ), "%s}\n", szRecipe );
+
+		XenGrenadeDebugMsg( "%s", szRecipe );
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -270,7 +502,7 @@ bool CXenGrenadeRecipeManager::FindBestRecipe( char *szRecipe, size_t szRecipeSi
 // Purpose: 
 // Input  : *conceptName - 
 //-----------------------------------------------------------------------------
-bool CXenGrenadeRecipeManager::ParseRecipe( char *szRecipe, CGravityVortexController *pActivator )
+bool CXenGrenadeRecipeManager::ParseRecipe( char *szRecipe, CUtlMap<string_t, string_t> &spawnList )
 {
 	XenGrenadeDebugMsg( "	ParseRecipe: Start\n" );
 
@@ -281,7 +513,7 @@ bool CXenGrenadeRecipeManager::ParseRecipe( char *szRecipe, CGravityVortexContro
 	V_SplitString( szRecipe, ";", vecBlocks );
 	FOR_EACH_VEC( vecBlocks, i )
 	{
-		if (ParseRecipeBlock( vecBlocks[i], pActivator ))
+		if (ParseRecipeBlock( vecBlocks[i], spawnList ))
 			bSucceed = true;
 	}
 
@@ -292,7 +524,7 @@ bool CXenGrenadeRecipeManager::ParseRecipe( char *szRecipe, CGravityVortexContro
 // Purpose: 
 // Input  : *conceptName - 
 //-----------------------------------------------------------------------------
-bool CXenGrenadeRecipeManager::ParseRecipeBlock( char *szRecipe, CGravityVortexController *pActivator )
+bool CXenGrenadeRecipeManager::ParseRecipeBlock( char *szRecipe, CUtlMap<string_t, string_t> &spawnList )
 {
 	XenGrenadeDebugMsg( "	ParseRecipeBlock: Start \"%s\"\n", szRecipe );
 
@@ -349,30 +581,12 @@ bool CXenGrenadeRecipeManager::ParseRecipeBlock( char *szRecipe, CGravityVortexC
 	{
 		for (int i = 0; i < iNumEnts; i++)
 		{
-			pActivator->m_SpawnList.Insert( iszClass, kv );
+			spawnList.Insert( iszClass, kv );
 			XenGrenadeDebugMsg( "	ParseRecipeBlock: Added \"%s\" number %i to spawn list\n", STRING( iszClass ), iNumEnts );
 		}
 	}
 
 	return true;
-}
-
-void CreateRecipeManager()
-{
-	CBaseEntity *pEnt = CreateEntityByName( "xen_grenade_recipe_manager" );
-	if (pEnt)
-	{
-		DispatchSpawn( pEnt );
-		pEnt->Activate();
-		XenGrenadeDebugMsg( "Spawned xen_grenade_recipe_manager\n" );
-
-		// Now set in CXenGrenadeRecipeManager::Activate()
-		//g_hXenGrenadeRecipeManager = static_cast<CXenGrenadeRecipeManager*>(pEnt);
-	}
-	else
-	{
-		Error( "Unable to create xen_grenade_recipe_manager\n" );
-	}
 }
 
 // This is used for when an entity is close enough to be consumed, but shouldn't be consumed through
@@ -668,6 +882,8 @@ void CGravityVortexController::ConsumeEntity( CBaseEntity *pEnt )
 void CGravityVortexController::PullPlayersInRange( void )
 {
 	CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+	if (!pPlayer || !pPlayer->VPhysicsGetObject())
+		return;
 	
 	Vector	vecForce = GetAbsOrigin() - pPlayer->WorldSpaceCenter();
 	float	dist = VectorNormalize( vecForce );
@@ -841,10 +1057,7 @@ int	CGravityVortexController::Restore( IRestore &restore )
 //-----------------------------------------------------------------------------
 void CGravityVortexController::CreateXenLife()
 {
-	if (!g_hXenGrenadeRecipeManager)
-	{
-		CreateRecipeManager();
-	}
+	VerifyXenRecipeManager( GetClassname() );
 
 	// Create a list of conditions based on the consumed entities
 	AI_CriteriaSet set;
@@ -946,9 +1159,9 @@ void CGravityVortexController::CreateXenLife()
 	}
 
 	char szRecipe[512];
-	if (g_hXenGrenadeRecipeManager->FindBestRecipe(szRecipe, sizeof(szRecipe), set, this))
+	if (g_XenGrenadeRecipeManager.FindBestRecipe(szRecipe, sizeof(szRecipe), set, this))
 	{
-		if (g_hXenGrenadeRecipeManager->ParseRecipe(szRecipe, this))
+		if (g_XenGrenadeRecipeManager.ParseRecipe(szRecipe, m_SpawnList))
 			StartSpawning();
 	}
 }
@@ -1147,12 +1360,12 @@ bool CGravityVortexController::TryCreateRecipeNPC( const char *szClass, const ch
 	angSpawnAngles.y = RandomFloat(0, 360);
 	pEntity->SetAbsAngles( angSpawnAngles );
 
+	pEntity->SetEZVariant( EZ_VARIANT_XEN );
+
 	CAI_BaseNPC * baseNPC = pEntity->MyNPCPointer();
 	if (baseNPC)
 	{
 		baseNPC->AddSpawnFlags( SF_NPC_FALL_TO_GROUND );
-		baseNPC->m_tEzVariant = CAI_BaseNPC::EZ_VARIANT_XEN;
-
 
 		const char * squadnameContext = GetContextValue( "squadname" );
 
@@ -1169,10 +1382,6 @@ bool CGravityVortexController::TryCreateRecipeNPC( const char *szClass, const ch
 			DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadname );
 			baseNPC->SetSquadName( AllocPooledString( squadname ) );
 		}
-	}
-	else if (CItem *pItem = dynamic_cast<CItem*>(pEntity))
-	{
-		pItem->m_tEzVariant = CAI_BaseNPC::EZ_VARIANT_XEN;
 	}
 
 	if (szKV != NULL)
@@ -1515,7 +1724,7 @@ bool CGravityVortexController::TryCreateComplexNPC( const char *className, bool 
 	{
 		baseNPC->AddSpawnFlags( SF_NPC_FALL_TO_GROUND );
 	}
-	baseNPC->m_tEzVariant = CAI_BaseNPC::EZ_VARIANT_XEN;
+	baseNPC->m_tEzVariant = EZ_VARIANT_XEN;
 	// Set the squad name of a new Xen NPC to 'xenpc_headcrab', 'xenpc_bullsquid', etc
 	char * squadname = UTIL_VarArgs( "xe%s", className );
 	DevMsg( "Adding xenpc '%s' to squad '%s' \n", baseNPC->GetDebugName(), squadname );
@@ -2098,13 +2307,6 @@ void CGrenadeHopwire::Precache( void )
 
 	PrecacheMaterial( "sprites/rollermine_shock.vmt" );
 
-	UTIL_PrecacheXenVariant( "npc_headcrab" );
-	UTIL_PrecacheXenVariant( "npc_zombie" );
-	UTIL_PrecacheXenVariant( "npc_antlion" );
-	UTIL_PrecacheXenVariant( "npc_bullsquid" );
-	UTIL_PrecacheXenVariant( "npc_zombine" );
-	UTIL_PrecacheXenVariant( "npc_antlionguard" );
-
 	// Interactions
 	if (g_interactionXenGrenadePull == 0)
 	{
@@ -2115,6 +2317,8 @@ void CGrenadeHopwire::Precache( void )
 		g_interactionXenGrenadeHop = CBaseCombatCharacter::GetInteractionID();
 		g_interactionXenGrenadeRagdoll = CBaseCombatCharacter::GetInteractionID();
 	}
+
+	VerifyXenRecipeManager( GetClassname() );
 #endif
 
 	BaseClass::Precache();

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -423,7 +423,11 @@ void CXenGrenadeRecipeManager::PrecacheXenRecipes( void )
 	for (int i = 0; i < pResponses.Count(); i++)
 	{
 		// Handle the response here...
+#ifdef NEW_RESPONSE_SYSTEM
 		pResponses[i].GetResponse( szRecipe, szRecipeSize );
+#else
+		pResponses[i]->GetResponse( szRecipe, szRecipeSize );
+#endif
 		GetXenGrenadeResponseFromSystem( szRecipe, szRecipeSize, m_pInstancedResponseSystem, szRecipe );
 
 		recipeEntities.EnsureCapacity( 16 );

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -197,4 +197,8 @@ protected:
 
 CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, const Vector &velocity, const AngularImpulse &angVelocity, CBaseEntity *pOwner, float timer, const char * modelClosed = NULL, const char * modelOpen = NULL );
 
+#ifdef EZ2
+void VerifyXenRecipeManager( const char *pszActivator );
+#endif
+
 #endif // GRENADE_HOPWIRE_H

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -560,6 +560,8 @@ public:
 	DECLARE_CLASS( CWeaponEndGame, CWeaponHopwire );
 	DECLARE_SERVERCLASS();
 
+	void	Precache( void );
+
 	bool	ShouldDisplayHUDHint() { return true; }
 protected:
 	void	ThrowGrenade( CBasePlayer *pPlayer );
@@ -571,6 +573,15 @@ private:
 
 
 };
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CWeaponEndGame::Precache( void )
+{
+	// Skip Xen grenade precache
+	CBaseHLCombatWeapon::Precache();
+}
 
 void CWeaponEndGame::ThrowGrenade( CBasePlayer * pPlayer )
 {
@@ -597,9 +608,7 @@ IMPLEMENT_SERVERCLASS_ST( CWeaponEndGame, DT_WeaponEndGame )
 END_SEND_TABLE()
 
 LINK_ENTITY_TO_CLASS( weapon_endgame, CWeaponEndGame );
-#ifndef EZ2
 PRECACHE_WEAPON_REGISTER( weapon_endgame );
-#endif
 
 BEGIN_DATADESC( CWeaponEndGame )
 DEFINE_OUTPUT( m_OnEndGame, "OnEndGame" ),

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -99,7 +99,13 @@ IMPLEMENT_SERVERCLASS_ST(CWeaponHopwire, DT_WeaponHopwire)
 END_SEND_TABLE()
 
 LINK_ENTITY_TO_CLASS( weapon_hopwire, CWeaponHopwire );
+
+// In E:Z2, the hopwire's Xen spawning feature precaches a massive number of assets which shouldn't be used on levels which don't have Xen grenades.
+// As a result, the hopwire is precached in the same way as any other entity. (i.e. not precached at all times like other weapons are)
+#ifndef EZ2
 PRECACHE_WEAPON_REGISTER(weapon_hopwire);
+#endif
+
 CWeaponHopwire::CWeaponHopwire() :
 	CBaseHLCombatWeapon(),
 	m_bRedraw( false )
@@ -591,7 +597,9 @@ IMPLEMENT_SERVERCLASS_ST( CWeaponEndGame, DT_WeaponEndGame )
 END_SEND_TABLE()
 
 LINK_ENTITY_TO_CLASS( weapon_endgame, CWeaponEndGame );
+#ifndef EZ2
 PRECACHE_WEAPON_REGISTER( weapon_endgame );
+#endif
 
 BEGIN_DATADESC( CWeaponEndGame )
 DEFINE_OUTPUT( m_OnEndGame, "OnEndGame" ),

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -190,7 +190,7 @@ void CGonomeSpit::Shoot( CBaseEntity *pOwner, int nGonomeSpitSprite, CSprite * p
 	pSpit->SetAbsVelocity( vecVelocity );
 	pSpit->SetOwnerEntity( pOwner );
 
-	pSpit->m_bGoo = (pSpit->GetOwnerEntity() && pSpit->GetOwnerEntity()->IsNPC()) ? pSpit->GetOwnerEntity()->MyNPCPointer()->m_tEzVariant == CAI_BaseNPC::EZ_VARIANT_RAD : false;
+	pSpit->m_bGoo = (pSpit->GetOwnerEntity() && pSpit->GetOwnerEntity()->IsNPC()) ? pSpit->GetOwnerEntity()->MyNPCPointer()->m_tEzVariant == EZ_VARIANT_RAD : false;
 
 	pSpit->SetSprite( pSprite );
 

--- a/sp/src/game/server/gameinterface.cpp
+++ b/sp/src/game/server/gameinterface.cpp
@@ -161,6 +161,9 @@ CTimedEventMgr g_NetworkPropertyEventMgr;
 
 ISaveRestoreBlockHandler *GetEventQueueSaveRestoreBlockHandler();
 ISaveRestoreBlockHandler *GetCommentarySaveRestoreBlockHandler();
+#ifdef EZ2
+ISaveRestoreBlockHandler *GetXenRecipeSaveRestoreBlockHandler();
+#endif
 
 CUtlLinkedList<CMapEntityRef, unsigned short> g_MapEntityRefs;
 
@@ -699,6 +702,9 @@ bool CServerGameDLL::DLLInit( CreateInterfaceFn appSystemFactory,
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetEventQueueSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetAchievementSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetVScriptSaveRestoreBlockHandler() );
+#ifdef EZ2
+	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetXenRecipeSaveRestoreBlockHandler() );
+#endif
 
 	// The string system must init first + shutdown last
 	IGameSystem::Add( GameStringSystem() );

--- a/sp/src/game/server/hl2/item_ammo.cpp
+++ b/sp/src/game/server/hl2/item_ammo.cpp
@@ -623,11 +623,11 @@ public:
 	{
 		PrecacheParticleSystem( "combineball" );
 #ifdef EZ
-		SetModelName( AllocPooledString( pModelNames[m_tEzVariant] ) );
+		SetModelName( AllocPooledString( pModelNames[ GetEZVariant() ] ) );
 		PrecacheModel( STRING( GetModelName() ) );
 
 		// Goo-covered is just a separate skin of the Arbeit model
-		if (m_tEzVariant == CAI_BaseNPC::EZ_VARIANT_RAD)
+		if (GetEZVariant() == EZ_VARIANT_RAD)
 			m_nSkin = 1;
 #else
 		PrecacheModel ("models/items/combine_rifle_ammo01.mdl");
@@ -666,7 +666,7 @@ public:
 LINK_ENTITY_TO_CLASS( item_ammo_ar2_altfire, CItem_AR2AltFireRound );
 
 #ifdef EZ
-const char *CItem_AR2AltFireRound::pModelNames[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
+const char *CItem_AR2AltFireRound::pModelNames[EZ_VARIANT_COUNT] = {
 	"models/items/combine_rifle_ammo01.mdl",
 	"models/items/xen/combine_rifle_ammo01.mdl",
 	"models/items/arbeit/combine_rifle_ammo01.mdl", // Skin 1
@@ -1179,6 +1179,8 @@ public:
 			SetModelName( AllocPooledString( "models/items/xen_grenade_holder001a.mdl" ) );
 
 		PrecacheModel( STRING( GetModelName() ) );
+
+		UTIL_PrecacheOther( "weapon_hopwire" );
 	}
 
 	bool KeyValue( const char *szKeyName, const char *szValue )

--- a/sp/src/game/server/hl2/item_battery.cpp
+++ b/sp/src/game/server/hl2/item_battery.cpp
@@ -37,11 +37,11 @@ public:
 	void Precache( void )
 	{
 #ifdef EZ
-		SetModelName( AllocPooledString( pModelNames[m_tEzVariant] ) );
+		SetModelName( AllocPooledString( pModelNames[ GetEZVariant() ] ) );
 		PrecacheModel( STRING( GetModelName() ) );
 
 		// Goo-covered is just a separate skin of the Arbeit model
-		if (m_tEzVariant == CAI_BaseNPC::EZ_VARIANT_RAD)
+		if (GetEZVariant() == EZ_VARIANT_RAD)
 			m_nSkin = 1;
 #else
 		PrecacheModel ("models/items/battery.mdl");
@@ -61,7 +61,7 @@ LINK_ENTITY_TO_CLASS(item_battery, CItemBattery);
 PRECACHE_REGISTER(item_battery);
 
 #ifdef EZ
-const char *CItemBattery::pModelNames[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
+const char *CItemBattery::pModelNames[EZ_VARIANT_COUNT] = {
 	"models/items/battery.mdl",
 	"models/items/xen/battery.mdl",
 	"models/items/arbeit/battery.mdl", // Skin 1

--- a/sp/src/game/server/hl2/item_dynamic_resupply.cpp
+++ b/sp/src/game/server/hl2/item_dynamic_resupply.cpp
@@ -96,7 +96,8 @@ public:
 	float	GetDesiredHealthPercentage( void ) const { return m_flDesiredHealth[0]; }
 
 #ifdef EZ
-	CItem::EZ_VARIANT_ITEM m_tEzVariant;
+	EZ_VARIANT	GetEZVariant() { return m_tEzVariant; }
+	void		SetEZVariant( EZ_VARIANT variant ) { m_tEzVariant = variant; }
 #endif
 
 private:
@@ -123,6 +124,10 @@ private:
 	float	m_flDesiredAmmo[ NUM_AMMO_ITEMS ];
 
 	bool m_bIsMaster;
+
+#ifdef EZ
+	EZ_VARIANT m_tEzVariant;
+#endif
 
 #ifdef MAPBASE
 	COutputEHANDLE m_OnItem;
@@ -269,12 +274,20 @@ void CItem_DynamicResupply::Precache( void )
 	int i;
 	for ( i = 0; i < NUM_HEALTH_ITEMS; i++ )
 	{
+#ifdef EZ
+		UTIL_PrecacheEZVariant( g_DynamicResupplyHealthItems[i].sEntityName, m_tEzVariant );
+#else
 		UTIL_PrecacheOther( g_DynamicResupplyHealthItems[i].sEntityName );
+#endif
 	}
 
 	for ( i = 0; i < NUM_AMMO_ITEMS; i++ )
 	{
+#ifdef EZ
+		UTIL_PrecacheEZVariant( g_DynamicResupplyAmmoItems[i].sEntityName, m_tEzVariant );
+#else
 		UTIL_PrecacheOther( g_DynamicResupplyAmmoItems[i].sEntityName );
+#endif
 	}
 }
 
@@ -375,14 +388,11 @@ void CItem_DynamicResupply::SpawnFullItem( CItem_DynamicResupply *pMaster, CBase
 #ifdef MAPBASE
 #ifdef EZ
 			CBaseEntity *pItem = CreateNoSpawn( "item_healthvial", GetAbsOrigin(), GetAbsAngles(), this );
-
+			
 			// Give the item our E:Z variant
-			if (m_tEzVariant != CAI_BaseNPC::EZ_VARIANT_DEFAULT)
+			if (m_tEzVariant != EZ_VARIANT_DEFAULT)
 			{
-				if (CItem *pCItem = dynamic_cast<CItem*>(pItem))
-				{
-					pCItem->m_tEzVariant = m_tEzVariant;
-				}
+				pItem->SetEZVariant( m_tEzVariant );
 			}
 
 			DispatchSpawn( pItem );
@@ -414,14 +424,11 @@ void CItem_DynamicResupply::SpawnFullItem( CItem_DynamicResupply *pMaster, CBase
 #ifdef MAPBASE
 #ifdef EZ
 			CBaseEntity *pItem = CreateNoSpawn( g_DynamicResupplyAmmoItems[i].sEntityName, GetAbsOrigin(), GetAbsAngles(), this );
-
+			
 			// Give the item our E:Z variant
-			if (m_tEzVariant != CAI_BaseNPC::EZ_VARIANT_DEFAULT)
+			if (m_tEzVariant != EZ_VARIANT_DEFAULT)
 			{
-				if (CItem *pCItem = dynamic_cast<CItem*>(pItem))
-				{
-					pCItem->m_tEzVariant = m_tEzVariant;
-				}
+				pItem->SetEZVariant( m_tEzVariant );
 			}
 
 			DispatchSpawn( pItem );
@@ -613,12 +620,9 @@ bool CItem_DynamicResupply::SpawnItemFromRatio( int nCount, DynamicResupplyItems
 	CBaseEntity *pEnt = CBaseEntity::CreateNoSpawn( pItems[iSelectedIndex].sEntityName, *pVecSpawnOrigin, GetAbsAngles(), this );
 
 	// Give the item our E:Z variant
-	if (m_tEzVariant != CAI_BaseNPC::EZ_VARIANT_DEFAULT)
+	if (m_tEzVariant != EZ_VARIANT_DEFAULT)
 	{
-		if (CItem *pCItem = dynamic_cast<CItem*>(pEnt))
-		{
-			pCItem->m_tEzVariant = m_tEzVariant;
-		}
+		pEnt->SetEZVariant( m_tEzVariant );
 	}
 
 	DispatchSpawn( pEnt );

--- a/sp/src/game/server/hl2/item_healthkit.cpp
+++ b/sp/src/game/server/hl2/item_healthkit.cpp
@@ -41,7 +41,7 @@ LINK_ENTITY_TO_CLASS( item_healthkit, CHealthKit );
 PRECACHE_REGISTER(item_healthkit);
 
 #ifdef EZ
-const char *CHealthKit::pModelNames[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
+const char *CHealthKit::pModelNames[EZ_VARIANT_COUNT] = {
 	"models/items/healthkit.mdl",
 	"models/items/xen/healthkit.mdl",
 	"models/items/arbeit/healthkit.mdl", // Skin 1
@@ -49,7 +49,7 @@ const char *CHealthKit::pModelNames[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
 	"models/items/arbeit/healthkit.mdl",
 };
 
-const char *CHealthKit::pTouchSounds[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
+const char *CHealthKit::pTouchSounds[EZ_VARIANT_COUNT] = {
 	"HealthKit.Touch",
 	"HealthKit_Xen.Touch",
 	"HealthKit_Rad.Touch",
@@ -81,14 +81,14 @@ void CHealthKit::Spawn( void )
 void CHealthKit::Precache( void )
 {
 #ifdef EZ
-	SetModelName( AllocPooledString( pModelNames[m_tEzVariant] ) );
+	SetModelName( AllocPooledString( pModelNames[ GetEZVariant() ] ) );
 	PrecacheModel( STRING( GetModelName() ) );
 
 	// Goo-covered is just a separate skin of the Arbeit model
-	if (m_tEzVariant == CAI_BaseNPC::EZ_VARIANT_RAD)
+	if (GetEZVariant() == EZ_VARIANT_RAD)
 		m_nSkin = 1;
 
-	PrecacheScriptSound( pTouchSounds[m_tEzVariant] );
+	PrecacheScriptSound( pTouchSounds[ GetEZVariant() ] );
 #else
 	PrecacheModel("models/items/healthkit.mdl");
 
@@ -114,8 +114,8 @@ bool CHealthKit::MyTouch( CBasePlayer *pPlayer )
 		MessageEnd();
 
 #ifdef EZ
-		CPASAttenuationFilter filter( pPlayer, pTouchSounds[m_tEzVariant] );
-		EmitSound( filter, pPlayer->entindex(), pTouchSounds[m_tEzVariant] );
+		CPASAttenuationFilter filter( pPlayer, pTouchSounds[ GetEZVariant() ] );
+		EmitSound( filter, pPlayer->entindex(), pTouchSounds[ GetEZVariant() ] );
 #else
 		CPASAttenuationFilter filter( pPlayer, "HealthKit.Touch" );
 		EmitSound( filter, pPlayer->entindex(), "HealthKit.Touch" );
@@ -160,14 +160,14 @@ public:
 	void Precache( void )
 	{
 #ifdef EZ
-		SetModelName( AllocPooledString( pModelNames[m_tEzVariant] ) );
+		SetModelName( AllocPooledString( pModelNames[ GetEZVariant() ] ) );
 		PrecacheModel( STRING( GetModelName() ) );
 
 		// Goo-covered is just a separate skin of the Arbeit model
-		if (m_tEzVariant == CAI_BaseNPC::EZ_VARIANT_RAD)
+		if (GetEZVariant() == EZ_VARIANT_RAD)
 			m_nSkin = 1;
 
-		PrecacheScriptSound( pTouchSounds[m_tEzVariant] );
+		PrecacheScriptSound( pTouchSounds[ GetEZVariant() ] );
 #else
 		PrecacheModel( "models/healthvial.mdl" );
 
@@ -187,8 +187,8 @@ public:
 			MessageEnd();
 
 #ifdef EZ
-			CPASAttenuationFilter filter( pPlayer, pTouchSounds[m_tEzVariant] );
-			EmitSound( filter, pPlayer->entindex(), pTouchSounds[m_tEzVariant] );
+			CPASAttenuationFilter filter( pPlayer, pTouchSounds[ GetEZVariant() ] );
+			EmitSound( filter, pPlayer->entindex(), pTouchSounds[ GetEZVariant() ] );
 #else
 			CPASAttenuationFilter filter( pPlayer, "HealthVial.Touch" );
 			EmitSound( filter, pPlayer->entindex(), "HealthVial.Touch" );
@@ -219,7 +219,7 @@ LINK_ENTITY_TO_CLASS( item_healthvial, CHealthVial );
 PRECACHE_REGISTER( item_healthvial );
 
 #ifdef EZ
-const char *CHealthVial::pModelNames[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
+const char *CHealthVial::pModelNames[EZ_VARIANT_COUNT] = {
 	"models/healthvial.mdl",
 	"models/items/xen/healthvial.mdl",
 	"models/items/arbeit/healthvial.mdl", // Skin 1
@@ -227,7 +227,7 @@ const char *CHealthVial::pModelNames[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
 	"models/items/arbeit/healthvial.mdl",
 };
 
-const char *CHealthVial::pTouchSounds[CAI_BaseNPC::EZ_VARIANT_COUNT] = {
+const char *CHealthVial::pTouchSounds[EZ_VARIANT_COUNT] = {
 	"HealthVial.Touch",
 	"HealthVial_Xen.Touch",
 	"HealthVial_Rad.Touch",

--- a/sp/src/game/server/hl2/item_itemcrate.cpp
+++ b/sp/src/game/server/hl2/item_itemcrate.cpp
@@ -71,6 +71,9 @@ public:
 	virtual bool IsItemCrate() { return true; };
 
 	virtual void OnSpawnNPC( CBaseEntity * pEntity, CBaseCombatCharacter * pBreaker ){ }
+
+	EZ_VARIANT	GetEZVariant() { return m_tEzVariant; }
+	void		SetEZVariant( EZ_VARIANT variant ) { m_tEzVariant = variant; }
 #endif
 
 protected:
@@ -110,7 +113,7 @@ private:
 	CrateAppearance_t	m_CrateAppearance;
 
 #ifdef EZ2
-	CAI_BaseNPC::EZ_VARIANT m_tEzVariant;
+	EZ_VARIANT			m_tEzVariant;
 #endif
 
 	COutputEvent m_OnCacheInteraction;
@@ -456,16 +459,11 @@ void CItem_ItemCrate::OnBreak( const Vector &vecVelocity, const AngularImpulse &
 			return;
 
 #ifdef EZ2
+		pSpawn->SetEZVariant( m_tEzVariant );
+
 		if ( pSpawn->IsNPC() )
 		{
-			CAI_BaseNPC * pNPC =  pSpawn->MyNPCPointer();
-			pNPC->m_tEzVariant = m_tEzVariant;
-
-			OnSpawnNPC( pNPC, pBreaker->MyCombatCharacterPointer() );
-		}
-		else if ( CItem *pItem = dynamic_cast<CItem*>(pSpawn) )
-		{
-			pItem->m_tEzVariant = m_tEzVariant;
+			OnSpawnNPC( pSpawn, pBreaker->MyCombatCharacterPointer() );
 		}
 #endif
 

--- a/sp/src/game/server/items.h
+++ b/sp/src/game/server/items.h
@@ -104,9 +104,8 @@ public:
 #endif
 
 #ifdef EZ
-	// TODO: Maybe make EZ_VARIANT a shared enum instead of being within CAI_BaseNPC?
-	typedef CAI_BaseNPC::EZ_VARIANT EZ_VARIANT_ITEM;
-	EZ_VARIANT_ITEM m_tEzVariant;
+	EZ_VARIANT	GetEZVariant() { return m_tEzVariant; }
+	void		SetEZVariant( EZ_VARIANT variant ) { m_tEzVariant = variant; }
 #endif
 
 	DECLARE_DATADESC();
@@ -122,6 +121,10 @@ private:
 	QAngle		m_vOriginalSpawnAngles;
 
 	IPhysicsConstraint		*m_pConstraint;
+
+#ifdef EZ
+	EZ_VARIANT	m_tEzVariant;
+#endif
 };
 
 #endif // ITEMS_H

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -1632,7 +1632,7 @@ CBaseEntity *CreateServerRagdoll( CBaseAnimating *pAnimating, int forceBone, con
 	}
 
 	// Temporal ragdolls fade out!
-	if ( pAnimating->MyNPCPointer() && pAnimating->MyNPCPointer()->m_tEzVariant == CAI_BaseNPC::EZ_VARIANT_TEMPORAL )
+	if ( pAnimating->MyNPCPointer() && pAnimating->MyNPCPointer()->m_tEzVariant == EZ_VARIANT_TEMPORAL )
 	{
 		pRagdoll->SetContextThink( &CRagdollProp::TimeWarpThink, gpGlobals->curtime + 0.25f, "RagdollTimeShiftContext" );
 	}


### PR DESCRIPTION
This PR does two semi-interdependent things:

* Moves Entropy : Zero variants to `baseentity.h` and makes them universal among entities, not constrained to any particular class.
* Changes the Xen grenade recipe manager into a system which efficiently precaches recipes when certain conditions are met.
     * Xen grenade recipes are precached whenever a `weapon_hopwire`, `grenade_hopwire`, and/or `item_hopwire_holder` are precached, or when `sv_cheats` is enabled.