### PR TITLE
Fixes for Bad Cop and Wilson speech

### DIFF
--- a/sp/src/game/server/ai_playerally.cpp
+++ b/sp/src/game/server/ai_playerally.cpp
@@ -1920,7 +1920,7 @@ void CAI_PlayerAlly::InputDisableSpeakWhileScripting( inputdata_t &inputdata )
 void CAI_PlayerAlly::InputAnswerConcept( inputdata_t &inputdata )
 {
 	// Complex Q&A
-	ConceptResponseAnswer( inputdata.pActivator, inputdata.value.String() );
+	ConceptResponseAnswer_PlayerAlly( inputdata.pActivator, inputdata.value.String() );
 }
 #endif
 

--- a/sp/src/game/server/ez2/ai_concept_response.h
+++ b/sp/src/game/server/ez2/ai_concept_response.h
@@ -29,4 +29,15 @@
 		SpeakIfAllowed(TLK_CONCEPT_ANSWER, modifiers); \
 	} \
 
+// Uses bRespondingToPlayer in the third parameter
+// (important for back-and-forth TLK_CONCEPT_ANSWERs)
+#define ConceptResponseAnswer_PlayerAlly(target, concept) \
+	if (target) \
+	{ \
+		AI_CriteriaSet modifiers; \
+		SetSpeechTarget(target); \
+		modifiers.AppendCriteria("speechtarget_concept", concept); \
+		SpeakIfAllowed(TLK_CONCEPT_ANSWER, modifiers, target->IsPlayer()); \
+	} \
+
 #endif

--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -411,6 +411,16 @@ void CEZ2_Player::Spawn( void )
 
 	SetModel( "models/bad_cop.mdl" );
 
+	Activate();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CEZ2_Player::Activate( void )
+{
+	BaseClass::Activate();
+
 	ListenForGameEvent( "zombie_scream" );
 	ListenForGameEvent( "vehicle_overturned" );
 }
@@ -1711,6 +1721,24 @@ bool CEZ2_Player::HandleRemoveFromPlayerSquad( CAI_BaseNPC *pNPC )
 	SetSpeechTarget(pNPC);
 
 	return SpeakIfAllowed(TLK_COMMAND_REMOVE);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CEZ2_Player::Weapon_HandleEquip( CBaseCombatWeapon *pWeapon )
+{
+	BaseClass::Weapon_HandleEquip( pWeapon );
+
+	// Make sure Wilson doesn't remind us of our special weapons for at least 20 minutes
+	if (FClassnameIs( pWeapon, "weapon_hopwire" ))
+	{
+		AddContext( "xen_grenade_thrown", "1", 1200.0f );
+	}
+	else if (FClassnameIs( pWeapon, "weapon_displacer_pistol" ))
+	{
+		AddContext( "displacer_used", "1", 1200.0f );
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -887,6 +887,18 @@ void CEZ2_Player::ModifyOrAppendCriteria(AI_CriteriaSet& criteriaSet)
 	if (pWilson)
 	{
 		criteriaSet.AppendCriteria("wilson_distance", CFmtStrN<32>( "%f.3", sqrt(flBestDistSqr) ));
+
+		// Record whether Wilson is speaking
+		if (pWilson->IsSpeaking())
+		{
+			criteriaSet.AppendCriteria( "wilson_speaking", "1" );
+		}
+		else
+		{
+			criteriaSet.AppendCriteria( "wilson_speaking", "0" );
+		}
+
+		pWilson->AppendContextToCriteria( criteriaSet, "wilson_" );
 	}
 	else
 	{
@@ -1229,7 +1241,8 @@ bool CEZ2_Player::IsAllowedToSpeak(AIConcept_t concept)
 		return false;
 
 	// Don't say anything if we're running a scene
-	if ( IsTalkingInAScriptedScene( this, true ) )
+	// (instanced scenes aren't ignored because they could be Wilson scenes)
+	if ( IsTalkingInAScriptedScene( this, false ) )
 	{
 		return false;
 	}

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -111,6 +111,7 @@ public:
 
 	void			Precache( void );
 	void			Spawn( void );
+	void			Activate( void );
 	void			UpdateOnRemove( void );
 
 	virtual void    ModifyOrAppendCriteria(AI_CriteriaSet& criteriaSet);
@@ -176,6 +177,8 @@ public:
 	void			Event_SeeEnemy( CBaseEntity *pEnemy );
 	bool			HandleAddToPlayerSquad( CAI_BaseNPC *pNPC );
 	bool			HandleRemoveFromPlayerSquad( CAI_BaseNPC *pNPC );
+
+	void			Weapon_HandleEquip( CBaseCombatWeapon *pWeapon );
 
 	void			Event_FirstDrawWeapon( CBaseCombatWeapon *pWeapon );
 	void			Event_ThrewGrenade( CBaseCombatWeapon *pWeapon );

--- a/sp/src/game/server/ez2/npc_wilson.cpp
+++ b/sp/src/game/server/ez2/npc_wilson.cpp
@@ -204,7 +204,7 @@ CNPC_Wilson::CNPC_Wilson( void ) :
 	// So we don't think we haven't seen the player in a while
 	// when in fact we were just spawned
 	// (it's funny, but still)
-	m_flLastSawPlayerTime = gpGlobals->curtime;
+	m_flLastSawPlayerTime = -1.0f;
 
 	m_flPlayerNearbyTime = -1.0f;
 }
@@ -949,7 +949,7 @@ void CNPC_Wilson::OnSeeEntity( CBaseEntity *pEntity )
 			SetSpeechTarget( pEntity );
 			SpeakIfAllowed( TLK_ALLY_IN_BARNACLE );
 		}
-		else if (gpGlobals->curtime - m_flLastSawPlayerTime > 60.0f /*&& m_flCarryTime < m_flLastSawPlayerTime*/)
+		else if (gpGlobals->curtime - m_flLastSawPlayerTime > 60.0f && m_flLastSawPlayerTime != -1.0f /*&& m_flCarryTime < m_flLastSawPlayerTime*/)
 		{
 			// Oh, hey, Bad Cop! Long time no see!
 			// Needs to be Speak() to override any currently running speech

--- a/sp/src/game/server/ez2/npc_wilson.cpp
+++ b/sp/src/game/server/ez2/npc_wilson.cpp
@@ -79,7 +79,7 @@ CNPC_Wilson *CNPC_Wilson::GetBestWilson( float &flBestDistSqr, const Vector *vec
 
 ConVar npc_wilson_depressing_death("npc_wilson_depressing_death", "0", FCVAR_NONE, "Makes Will-E shut down and die into an empty husk rather than explode.");
 
-ConVar npc_wilson_clearance_speed_threshold( "npc_wilson_clearance_speed_threshold", "500.0", FCVAR_NONE, "The speed at which Will-E starts to think he's gonna get knocked off if approaching a surface." );
+ConVar npc_wilson_clearance_speed_threshold( "npc_wilson_clearance_speed_threshold", "250.0", FCVAR_NONE, "The speed at which Will-E starts to think he's gonna get knocked off if approaching a surface." );
 ConVar npc_wilson_clearance_debug( "npc_wilson_clearance_debug", "0", FCVAR_NONE, "Debugs Will-E's low clearance detection." );
 
 static const char *g_DamageZapContext = "DamageZapEffect";
@@ -476,6 +476,7 @@ int CNPC_Wilson::OnTakeDamage( const CTakeDamageInfo &info )
 	{
 		AI_CriteriaSet modifiers;
 		ModifyOrAppendDamageCriteria(modifiers, info);
+		modifiers.AppendCriteria("hitgroup", UTIL_VarArgs("%i", LastHitGroup()));
 		SpeakIfAllowed( TLK_WOUND, modifiers );
 	}
 
@@ -789,8 +790,7 @@ void CNPC_Wilson::PrescheduleThink( void )
 		// Make sure we can see the direction we're going in
 		if (velocity.LengthSqr() >= Square(npc_wilson_clearance_speed_threshold.GetFloat()) && vecForward.Dot(velocity) > 0.0f)
 		{
-			// For approximating the front of the APC
-			Vector vecOrigin = GetAbsOrigin() + (velocity);
+			Vector vecOrigin = GetAbsOrigin();
 
 			CTraceFilterSkipTwoEntities pFilter(this, m_hAttachedVehicle, COLLISION_GROUP_NONE);
 			trace_t tr;

--- a/sp/src/game/server/ez2/npc_wilson.cpp
+++ b/sp/src/game/server/ez2/npc_wilson.cpp
@@ -1698,6 +1698,16 @@ void CNPC_Wilson::ModifyOrAppendCriteria(AI_CriteriaSet& set)
 		{
 			set.AppendCriteria( "player_in_vehicle", "0" );
 		}
+
+		// Record whether the player is speaking
+		if (pPlayer->GetExpresser() && pPlayer->GetExpresser()->IsSpeaking())
+		{
+			set.AppendCriteria( "player_speaking", "1" );
+		}
+		else
+		{
+			set.AppendCriteria( "player_speaking", "0" );
+		}
 	}
 	else
 	{
@@ -1784,7 +1794,7 @@ bool CNPC_Wilson::IsOkToSpeak( ConceptCategory_t category, bool fRespondingToPla
 	if ( fRespondingToPlayer )
 	{
 		// If we're responding to the player, don't respond if the scene has speech in it
-		if ( IsRunningScriptedSceneWithSpeechAndNotPaused( this ) )
+		if ( IsRunningScriptedSceneWithSpeechAndNotPaused( this, false ) )
 		{
 			return false;
 		}
@@ -1792,7 +1802,7 @@ bool CNPC_Wilson::IsOkToSpeak( ConceptCategory_t category, bool fRespondingToPla
 	else
 	{
 		// If we're not responding to the player, don't talk if running a logic_choreo
-		if ( IsRunningScriptedSceneAndNotPaused( this ) )
+		if ( IsRunningScriptedSceneAndNotPaused( this, false ) )
 		{
 			return false;
 		}

--- a/sp/src/game/server/ez2/npc_wilson.h
+++ b/sp/src/game/server/ez2/npc_wilson.h
@@ -145,8 +145,6 @@ public:
 	virtual CAI_Expresser *CreateExpresser(void);
 	virtual CAI_Expresser *GetExpresser() { return m_pExpresser;  }
 
-	inline bool		CanSpeakGoodbye() { return (GetExpresser()->GetTimeSpokeConcept(TLK_FOUNDPLAYER) >= GetExpresser()->GetTimeSpokeConcept(TLK_GOODBYE)); }
-
 	bool			GetGameTextSpeechParams( hudtextparms_t &params );
 
 	bool			IsOmniscient() { return m_bOmniscient; }
@@ -227,6 +225,10 @@ protected:
 
 	// See CNPC_Wilson::NPCThink()
 	bool	m_bPlayerLeftPVS;
+
+	// How long the player has spent around Wilson
+	// (for goodbyes)
+	float	m_flPlayerNearbyTime;
 
 	// For when Wilson is meant to be non-interactive (e.g. background maps, dev commentary)
 	// This makes Wilson unmovable and deactivates/doesn't precache a few miscellaneous things.


### PR DESCRIPTION
Small fixes for various minor issues in Bad Cop and Wilson's response dialogue and interactions.

Rough summary:

* Fixed Bad Cop and Wilson interrupting each other's responses.
* Fixed `TLK_VEHICLE_OVERTURNED` and `TLK_ZOMBIE_SCREAM` not playing properly after loading a save.
* Fixed Wilson using `TLK_FOUNDPLAYER` before he's met the player.
* Fixed Wilson's `TLK_GOODBYE` playing upon loading a save and improved the detection of departure conditions.
* Made `TLK_CONCEPT_ANSWER` on player ally NPCs *(especially Wilson)* use `bRespondingToPlayer`, which allows NPCs to speak sooner and is needed for when a concept answer answers another concept answer to their own concept.
* Fixed `TLK_REMIND_PLAYER` causing Wilson to remind the player when they would not have had a chance to use their weapons.