### PR TITLE
Improved Xen grenade precache conditions

### DIFF
--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -120,6 +120,9 @@ void CWeaponHopwire::Precache( void )
 {
 	BaseClass::Precache();
 
+#ifdef EZ2
+	VerifyXenRecipeManager( GetClassname() );
+#endif
 	UTIL_PrecacheOther( "npc_grenade_hopwire" );
 
 	PrecacheScriptSound( "WeaponFrag.Throw" );

--- a/sp/src/game/server/hl2/item_ammo.cpp
+++ b/sp/src/game/server/hl2/item_ammo.cpp
@@ -1279,6 +1279,8 @@ void CItem_AmmoCrate::InputKill( inputdata_t &data )
 
 #define XEN_GRENADE_SLOTS 3
 
+extern void VerifyXenRecipeManager( const char *pszActivator );
+
 // ==================================================================
 // Xen grenade holder
 // ==================================================================
@@ -1326,6 +1328,7 @@ public:
 
 		PrecacheModel( STRING( GetModelName() ) );
 
+		VerifyXenRecipeManager( GetClassname() );
 		UTIL_PrecacheOther( "weapon_hopwire" );
 	}
 

--- a/sp/src/game/server/hl2/item_dynamic_resupply.cpp
+++ b/sp/src/game/server/hl2/item_dynamic_resupply.cpp
@@ -225,6 +225,9 @@ CItem_DynamicResupply::CItem_DynamicResupply( void )
 	m_flDesiredAmmo[7] = 0;		// 357
 	m_flDesiredAmmo[8] = 0;		// Crossbow
 	m_flDesiredAmmo[9] = 0;		// AR2 alt-fire
+#ifdef EZ2
+	m_flDesiredAmmo[10] = 0;	// Xen Grenade
+#endif
 #ifdef CSS_WEAPONS_IN_HL2
 	m_flDesiredAmmo[11] = 0;	// .45 ACP
 	m_flDesiredAmmo[12] = 0;	// .357 SIG
@@ -303,7 +306,9 @@ void CItem_DynamicResupply::Precache( void )
 	for ( i = 0; i < NUM_HEALTH_ITEMS; i++ )
 	{
 #ifdef EZ
-		UTIL_PrecacheEZVariant( g_DynamicResupplyHealthItems[i].sEntityName, m_tEzVariant );
+		// Don't precache unless we might spawn this
+		if (m_flDesiredHealth[i] > 0.0f)
+			UTIL_PrecacheEZVariant( g_DynamicResupplyHealthItems[i].sEntityName, m_tEzVariant );
 #else
 		UTIL_PrecacheOther( g_DynamicResupplyHealthItems[i].sEntityName );
 #endif
@@ -312,7 +317,9 @@ void CItem_DynamicResupply::Precache( void )
 	for ( i = 0; i < NUM_AMMO_ITEMS; i++ )
 	{
 #ifdef EZ
-		UTIL_PrecacheEZVariant( g_DynamicResupplyAmmoItems[i].sEntityName, m_tEzVariant );
+		// Don't precache unless we might spawn this
+		if (m_flDesiredAmmo[i] > 0.0f)
+			UTIL_PrecacheEZVariant( g_DynamicResupplyAmmoItems[i].sEntityName, m_tEzVariant );
 #else
 		UTIL_PrecacheOther( g_DynamicResupplyAmmoItems[i].sEntityName );
 #endif


### PR DESCRIPTION
* `item_dynamic_resupply` no longer precaches Xen unless it has a probability of spawning Xen grenades.
* `weapon_hopwire` and `item_hopwire_holder` will now identify themselves during debugging as the ones who precached Xen.