### PR TITLE
Fix goo cables not appearing on certain NPCs and spamming the console

### DIFF
--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -340,7 +340,6 @@ void CNPC_Gonome::Precache()
 			break;
 		case EZ_VARIANT_RAD:
 			SetModelName( AllocPooledString( "models/glownome.mdl" ) );
-			PrecacheMaterial( "cable/goocable.vmt" );
 			break;
 		default:
 			SetModelName( AllocPooledString( "models/gonome.mdl" ) );
@@ -355,6 +354,7 @@ void CNPC_Gonome::Precache()
 	{
 		PrecacheParticleSystem( "blood_impact_blue_01" );
 		m_nGonomeSpitSprite = PrecacheModel( "sprites/glownomespit.vmt" );// spit projectile.
+		PrecacheMaterial( "cable/goocable.vmt" );
 	}
 	else
 	{

--- a/sp/src/game/server/hl2/npc_turret_floor.cpp
+++ b/sp/src/game/server/hl2/npc_turret_floor.cpp
@@ -2574,7 +2574,6 @@ void CNPC_Arbeit_FloorTurret::Precache( void )
 		{
 			case EZ_VARIANT_RAD:
 				SetModelName( AllocPooledString( "models/props/glowturret_01.mdl" ) );
-				PrecacheMaterial( "cable/goocable.vmt" );
 				break;
 
 			// EZ_VARIANT_ARBEIT alternates between the two camo turret models.
@@ -2601,6 +2600,12 @@ void CNPC_Arbeit_FloorTurret::Precache( void )
 					SetModelName( AllocPooledString( "models/props/turret_01.mdl" ) );
 			} break;
 		}
+	}
+
+	if (m_tEzVariant == EZ_VARIANT_RAD)
+	{
+		// Must be outside the above code for save/restore
+		PrecacheMaterial( "cable/goocable.vmt" );
 	}
 
 	PrecacheScriptSound( "NPC_ArbeitTurret.DryFire" );


### PR DESCRIPTION
The goo cable material was only being precached when the NPCs involved have no model name, which means save/restore *(at which point the NPC already has the default model name as their model name)* skips the precache.