### PR TITLE
Make sure weapon_slam attach2 sequences play correctly

### DIFF
--- a/sp/src/game/shared/hl2mp/weapon_slam.cpp
+++ b/sp/src/game/shared/hl2mp/weapon_slam.cpp
@@ -517,7 +517,9 @@ void CWeapon_SLAM::StartTripmineAttach( void )
 	
 	m_flNextPrimaryAttack	= gpGlobals->curtime + SequenceDuration();
 	m_flNextSecondaryAttack	= gpGlobals->curtime + SequenceDuration();
-//	SetWeaponIdleTime( gpGlobals->curtime + SequenceDuration() );
+#ifdef EZ
+	SetWeaponIdleTime( gpGlobals->curtime + SequenceDuration() );
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -598,6 +600,10 @@ void CWeapon_SLAM::StartSatchelThrow( void )
 			m_bNeedDetonatorDraw	= true;
 		}
 	}
+
+#ifdef EZ
+	SetWeaponIdleTime( gpGlobals->curtime + SequenceDuration() );
+#endif
 	
 	m_bNeedReload		= true;
 	m_bThrowSatchel		= true;
@@ -725,6 +731,10 @@ void CWeapon_SLAM::StartSatchelAttach( void )
 				}
 #endif
 			}
+
+#ifdef EZ
+			SetWeaponIdleTime( gpGlobals->curtime + SequenceDuration() );
+#endif
 			
 			m_bNeedReload		= true;
 			m_bAttachSatchel	= true;
@@ -1173,7 +1183,7 @@ void CWeapon_SLAM::WeaponIdle( void )
 		}
 
 		// If I don't need to reload just do the appropriate idle
-		else
+		else if (iAnim == 0 )
 		{
 			switch( m_tSlamState)
 			{


### PR DESCRIPTION
This PR fixes a bug where the view model for the SLAMs would not retract the hand from where the SLAM is placed. This had the effect of creating a several second delay before another SLAM could be placed.