### PR TITLE
Rebels do not fire into their own cover if ai_debug_rebel_suppressing_fire is 0

### DIFF
--- a/sp/src/game/server/hl2/npc_citizen17.cpp
+++ b/sp/src/game/server/hl2/npc_citizen17.cpp
@@ -2565,9 +2565,10 @@ bool CNPC_Citizen::FindDecoyObject(void)
 
 			// One more trace - let's make sure there's nothing immediately in front of the NPC to occlude this firing vector
 			AI_TraceLine( vecBulletOrigin, vecDecoyTarget, MASK_SHOT, this, COLLISION_GROUP_NONE, &blockTr );
-			if (ai_debug_rebel_suppressing_fire.GetBool() && blockTr.fraction < ai_suppression_distance_ratio.GetFloat())
+			if ( blockTr.fraction < ai_suppression_distance_ratio.GetFloat())
 			{
-				DevMsg( "NPC_Citizen::FindDecoyObject: %s covering fire doesn't cover sufficent ratio at: %f\n", GetDebugName(), blockTr.fraction );
+				if(ai_debug_rebel_suppressing_fire.GetBool())
+					DevMsg( "NPC_Citizen::FindDecoyObject: %s covering fire doesn't cover sufficent ratio at: %f\n", GetDebugName(), blockTr.fraction );
 			}
 			else
 			{


### PR DESCRIPTION
I found a mistake which causes rebels to erroneously treat suppressing fire positions as valid if the debug setting is off. This has hampered rebel performance in fights when they are suppressing at a distance.