### PR TITLE
Bonus challenges in E:Z2

### DIFF
--- a/sp/src/game/client/cdll_client_int.cpp
+++ b/sp/src/game/client/cdll_client_int.cpp
@@ -329,6 +329,9 @@ public:
 
 ISaveRestoreBlockHandler *GetEntitySaveRestoreBlockHandler();
 ISaveRestoreBlockHandler *GetViewEffectsRestoreBlockHandler();
+#ifdef MAPBASE
+ISaveRestoreBlockHandler *GetCustomBonusSaveRestoreBlockHandler();
+#endif
 
 CUtlLinkedList<CDataChangedEvent, unsigned short> g_DataChangedEvents;
 ClientFrameStage_t g_CurFrameStage = FRAME_UNDEFINED;
@@ -1107,6 +1110,9 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	if ( !PhysicsDLLInit( physicsFactory ) )
 		return false;
 
+#ifdef MAPBASE
+	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetCustomBonusSaveRestoreBlockHandler() ); // In order for the HUD to get the right info, this must come before the entity block handler
+#endif
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetEntitySaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetPhysSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetViewEffectsRestoreBlockHandler() );
@@ -1227,6 +1233,9 @@ void CHLClient::Shutdown( void )
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetViewEffectsRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetPhysSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetEntitySaveRestoreBlockHandler() );
+#ifdef MAPBASE
+	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetCustomBonusSaveRestoreBlockHandler() );
+#endif
 #ifdef MAPBASE_VSCRIPT
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetVScriptSaveRestoreBlockHandler() );
 #endif

--- a/sp/src/game/client/client_ez2.vpc
+++ b/sp/src/game/client/client_ez2.vpc
@@ -33,6 +33,7 @@ $Project "Client (Entropy Zero 2)"
 		}
 		$Folder "EZ2 DLL"
 		{
+			$File	"ez2\achievements_EZ2_client.cpp"
 			$File	"ez2\c_ez2_player.cpp"
 			$File	"ez2\c_ez2_player.h"
 			$File	"ez2\c_npc_wilson.cpp"

--- a/sp/src/game/client/client_ez2.vpc
+++ b/sp/src/game/client/client_ez2.vpc
@@ -122,6 +122,7 @@ $Project "Client (Entropy Zero 2)"
 			$File	"hl2\hud_ammo.cpp"
 			$File	"hl2\hud_battery.cpp"
 			$File	"hl2\hud_blood.cpp"
+			$File	"hl2\hud_bonusprogress.cpp" // Unused in HL2
 			$File	"hl2\hud_credits.cpp"
 			$File	"hl2\hud_damageindicator.cpp"
 			$File	"hl2\hud_flashlight.cpp"

--- a/sp/src/game/client/ez2/achievements_EZ2_client.cpp
+++ b/sp/src/game/client/ez2/achievements_EZ2_client.cpp
@@ -1,0 +1,245 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: Achievements for Entropy : Zero 2.
+// The implementation is heavily based on the achievements from Entropy : Zero
+//
+//=============================================================================
+
+#include "cbase.h"
+
+#ifdef CLIENT_DLL
+
+#include "achievementmgr.h"
+#include "baseachievement.h"
+#include "point_bonusmaps_accessor.h"
+#include "hl2_shareddefs.h"
+
+//=============================================================================
+// 
+// THIS CODE IS DEACTIVATED!
+// (and these are not real achievements)
+// 
+// This is meant to demonstrate how new challenge map achievements could work
+// within E:Z2 and have most of the work needed for them immediately available.
+// 
+//=============================================================================
+#if 0
+
+#define NUM_CHALLENGE_MAPS 8
+#define NUM_CHALLENGES 99 // TODO
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+class CBaseAchievementEZ2ChallengeFullMedals : public CBaseAchievement
+{
+protected:
+
+	void Init() 
+	{
+		SetFlags( ACH_SAVE_GLOBAL );
+	}
+
+	virtual void ListenForEvents()
+	{
+		ListenForGameEvent( "challenge_update" );
+	}
+
+	void FireGameEvent_Internal( IGameEvent *event )
+	{
+		if ( 0 == Q_strcmp( event->GetName(), "challenge_update" ) )
+		{
+			int iChallenge = event->GetInt( "challenge", 0 );
+			if (iChallenge != BonusChallenge())
+				return;
+
+			int numMedals = event->GetInt( Medal(), 0 );
+			SetCount( numMedals );
+		}
+	}
+
+	// Show progress for this achievement
+	virtual bool ShouldShowProgressNotification() { return true; }
+
+	virtual int BonusChallenge() { return EZ_CHALLENGE_NONE; }
+	virtual const char *Medal() { return "numgold"; }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Get gold medals on all challenges of certain types
+////////////////////////////////////////////////////////////////////////////////////////////////////
+class CAchievementEZ2ChallengeDamageAllGold : public CBaseAchievementEZ2ChallengeFullMedals
+{
+protected:
+
+	void Init() 
+	{
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGE_MAPS );
+	}
+
+	virtual int BonusChallenge() { return EZ_CHALLENGE_DAMAGE; }
+	virtual const char *Medal() { return "numgold"; }
+};
+DECLARE_ACHIEVEMENT( CAchievementEZ2ChallengeDamageAllGold, ACHIEVEMENT_EZ2_CHALLENGE_DAMAGE_ALL_GOLD, "ACH_EZ2_CHALLENGE_DAMAGE_ALL_GOLD", 5 );
+
+class CAchievementEZ2ChallengeBulletsAllGold : public CBaseAchievementEZ2ChallengeFullMedals
+{
+protected:
+
+	void Init()
+	{
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGE_MAPS );
+	}
+
+	virtual int BonusChallenge() { return EZ_CHALLENGE_BULLETS; }
+	virtual const char *Medal() { return "numgold"; }
+};
+DECLARE_ACHIEVEMENT( CAchievementEZ2ChallengeBulletsAllGold, ACHIEVEMENT_EZ2_CHALLENGE_BULLETS_ALL_GOLD, "ACH_EZ2_CHALLENGE_BULLETS_ALL_GOLD", 5 );
+
+class CAchievementEZ2ChallengeTimeAllGold : public CBaseAchievementEZ2ChallengeFullMedals
+{
+protected:
+
+	void Init()
+	{
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGE_MAPS );
+	}
+
+	virtual int BonusChallenge() { return EZ_CHALLENGE_TIME; }
+	virtual const char *Medal() { return "numgold"; }
+};
+DECLARE_ACHIEVEMENT( CAchievementEZ2ChallengeTimeAllGold, ACHIEVEMENT_EZ2_CHALLENGE_TIME_ALL_GOLD, "ACH_EZ2_CHALLENGE_TIME_ALL_GOLD", 5 );
+
+class CAchievementEZ2ChallengeKillsAllGold : public CBaseAchievementEZ2ChallengeFullMedals
+{
+protected:
+
+	void Init()
+	{
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGE_MAPS );
+	}
+
+	virtual int BonusChallenge() { return EZ_CHALLENGE_KILLS; }
+	virtual const char *Medal() { return "numgold"; }
+};
+DECLARE_ACHIEVEMENT( CAchievementEZ2ChallengeKillsAllGold, ACHIEVEMENT_EZ2_CHALLENGE_KILLS_ALL_GOLD, "ACH_EZ2_CHALLENGE_KILLS_ALL_GOLD", 5 );
+
+class CAchievementEZ2ChallengeMassAllGold : public CBaseAchievementEZ2ChallengeFullMedals
+{
+protected:
+
+	void Init()
+	{
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGE_MAPS );
+	}
+
+	virtual int BonusChallenge() { return EZ_CHALLENGE_MASS; }
+	virtual const char *Medal() { return "numgold"; }
+};
+DECLARE_ACHIEVEMENT( CAchievementEZ2ChallengeMassAllGold, ACHIEVEMENT_EZ2_CHALLENGE_MASS_ALL_GOLD, "ACH_EZ2_CHALLENGE_MASS_ALL_GOLD", 5 );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Get bronze medals on all challenges
+////////////////////////////////////////////////////////////////////////////////////////////////////
+class CBaseAchievementEZ2ChallengesAllBronze : public CBaseAchievement
+{
+protected:
+
+	void Init() 
+	{
+		SetFlags( ACH_SAVE_GLOBAL );
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGES );
+	}
+
+	virtual void ListenForEvents()
+	{
+		ListenForGameEvent( "challenge_map_complete" );
+	}
+
+	void FireGameEvent_Internal( IGameEvent *event )
+	{
+		if ( 0 == Q_strcmp( event->GetName(), "challenge_map_complete" ) )
+		{
+			int numMedals = event->GetInt( "numbronze", 0 );
+			SetCount( numMedals );
+		}
+	}
+
+	// Show progress for this achievement
+	virtual bool ShouldShowProgressNotification() { return true; }
+};
+DECLARE_ACHIEVEMENT( CBaseAchievementEZ2ChallengesAllBronze, ACHIEVEMENT_EZ2_CHALLENGES_ALL_BRONZE, "ACH_EZ2_CHALLENGES_ALL_BRONZE", 5 );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Get silver medals on all challenges
+////////////////////////////////////////////////////////////////////////////////////////////////////
+class CBaseAchievementEZ2ChallengesAllSilver : public CBaseAchievement
+{
+protected:
+
+	void Init() 
+	{
+		SetFlags( ACH_SAVE_GLOBAL );
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGES );
+	}
+
+	virtual void ListenForEvents()
+	{
+		ListenForGameEvent( "challenge_map_complete" );
+	}
+
+	void FireGameEvent_Internal( IGameEvent *event )
+	{
+		if ( 0 == Q_strcmp( event->GetName(), "challenge_map_complete" ) )
+		{
+			int numMedals = event->GetInt( "numsilver", 0 );
+			SetCount( numMedals );
+		}
+	}
+
+	// Show progress for this achievement
+	virtual bool ShouldShowProgressNotification() { return true; }
+};
+DECLARE_ACHIEVEMENT( CBaseAchievementEZ2ChallengesAllSilver, ACHIEVEMENT_EZ2_CHALLENGES_ALL_SILVER, "ACH_EZ2_CHALLENGES_ALL_SILVER", 5 );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Get gold medals on all challenges
+////////////////////////////////////////////////////////////////////////////////////////////////////
+class CBaseAchievementEZ2ChallengesAllGold : public CBaseAchievement
+{
+protected:
+
+	void Init() 
+	{
+		SetFlags( ACH_SAVE_GLOBAL );
+		SetGameDirFilter( "EntropyZero2" );
+		SetGoal( NUM_CHALLENGES );
+	}
+
+	virtual void ListenForEvents()
+	{
+		ListenForGameEvent( "challenge_map_complete" );
+	}
+
+	void FireGameEvent_Internal( IGameEvent *event )
+	{
+		if ( 0 == Q_strcmp( event->GetName(), "challenge_map_complete" ) )
+		{
+			int numMedals = event->GetInt( "numgold", 0 );
+			SetCount( numMedals );
+		}
+	}
+
+	// Show progress for this achievement
+	virtual bool ShouldShowProgressNotification() { return true; }
+};
+DECLARE_ACHIEVEMENT( CBaseAchievementEZ2ChallengesAllGold, ACHIEVEMENT_EZ2_CHALLENGES_ALL_GOLD, "ACH_EZ2_CHALLENGES_ALL_GOLD", 5 );
+#endif
+
+#endif // CLIENT_DLL

--- a/sp/src/game/client/ez2/c_ez2_player.cpp
+++ b/sp/src/game/client/ez2/c_ez2_player.cpp
@@ -1,5 +1,7 @@
 #include "cbase.h"
 #include "c_EZ2_player.h"
+#include "point_bonusmaps_accessor.h"
+#include "achievementmgr.h"
 
 #if defined( CEZ2Player )
 	#undef CEZ2Player
@@ -7,6 +9,7 @@
 
 
 IMPLEMENT_CLIENTCLASS_DT( C_EZ2_Player, DT_EZ2_Player, CEZ2_Player )
+	RecvPropBool( RECVINFO( m_bBonusChallengeUpdate ) ),
 END_RECV_TABLE()
 
 BEGIN_PREDICTION_DATA( C_EZ2_Player )
@@ -16,7 +19,30 @@ C_EZ2_Player::C_EZ2_Player()
 {
 }
 
-
 C_EZ2_Player::~C_EZ2_Player()
 {
+}
+
+void C_EZ2_Player::OnDataChanged( DataUpdateType_t updateType )
+{
+	BaseClass::OnDataChanged( updateType );
+
+	if ( updateType == DATA_UPDATE_DATATABLE_CHANGED && m_bBonusChallengeUpdate )
+	{
+		// Borrow the achievement manager for this
+		CAchievementMgr *pAchievementMgr = dynamic_cast<CAchievementMgr *>(engine->GetAchievementMgr());
+		if (pAchievementMgr)
+		{
+			if (pAchievementMgr->WereCheatsEverOn())
+				return;
+		}
+
+		char szChallengeFileName[128];
+		char szChallengeMapName[128];
+		char szChallengeName[128];
+		BonusMapChallengeNames( szChallengeFileName, szChallengeMapName, szChallengeName );
+		BonusMapChallengeUpdate( szChallengeFileName, szChallengeMapName, szChallengeName, GetBonusProgress() );
+
+		m_bBonusChallengeUpdate = false;
+	}
 }

--- a/sp/src/game/client/ez2/c_ez2_player.h
+++ b/sp/src/game/client/ez2/c_ez2_player.h
@@ -16,6 +16,9 @@ public:
 	C_EZ2_Player();
 	~C_EZ2_Player();
 
+	void OnDataChanged( DataUpdateType_t updateType );
+
+	bool m_bBonusChallengeUpdate;
 };
 
 

--- a/sp/src/game/client/hl2/hud_bonusprogress.cpp
+++ b/sp/src/game/client/hl2/hud_bonusprogress.cpp
@@ -31,11 +31,18 @@ using namespace vgui;
 
 #include "convar.h"
 
+#ifdef MAPBASE
+#include "point_bonusmaps_accessor.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
 #define INIT_BONUS_PROGRESS -1
 
+#ifdef MAPBASE
+ConVar hud_bonus_progress_enhanced( "hud_bonus_progress_enhanced", "1", FCVAR_NONE, "Enables some enhancements for the bonus progress HUD element." );
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: BonusProgress panel
@@ -51,6 +58,12 @@ public:
 	virtual void Reset( void );
 	virtual void OnThink();
 
+protected:
+
+#ifdef MAPBASE
+	bool UsesUniqueSecondaryColor() const { return true; }
+#endif
+
 private:
 	void SetChallengeLabel( void );
 
@@ -59,6 +72,27 @@ private:
 	int		m_iBonusProgress;
 
 	int		m_iLastChallenge;
+
+#ifdef MAPBASE
+	int		m_iBronze, m_iSilver, m_iGold;
+	int		m_iCurrentGoal;
+	bool	m_bReverse;
+
+	enum
+	{
+		GOAL_NONE,
+		GOAL_BRONZE,
+		GOAL_SILVER,
+		GOAL_GOLD,
+	};
+
+	CPanelAnimationVarAliasType( float, goal_xpos, "goal_xpos", "64", "proportional_float" );
+	CPanelAnimationVarAliasType( float, goal_ypos, "goal_ypos", "16", "proportional_float" );
+
+	//CPanelAnimationVar( Color, m_BronzeColor, "BronzeColor", "164 108 64 224" );
+	//CPanelAnimationVar( Color, m_SilverColor, "SilverColor", "205 235 255 224" );
+	//CPanelAnimationVar( Color, m_GoldColor, "GoldColor", "255 205 100 224" );
+#endif
 };	
 
 DECLARE_HUDELEMENT( CHudBonusProgress );
@@ -68,7 +102,11 @@ DECLARE_HUDELEMENT( CHudBonusProgress );
 //-----------------------------------------------------------------------------
 CHudBonusProgress::CHudBonusProgress( const char *pElementName ) : CHudElement( pElementName ), CHudNumericDisplay(NULL, "HudBonusProgress")
 {
+#ifdef MAPBASE
+	SetHiddenBits( HIDEHUD_BONUS_PROGRESS | HIDEHUD_PLAYERDEAD );
+#else
 	SetHiddenBits( HIDEHUD_BONUS_PROGRESS );
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -91,6 +129,19 @@ void CHudBonusProgress::Reset()
 		m_iLastChallenge = local->GetBonusChallenge();
 
 	SetChallengeLabel();
+
+#ifdef MAPBASE
+	if (local)
+	{
+		BonusMapChallengeObjectives( m_iBronze, m_iSilver, m_iGold );
+		m_bReverse = m_iBronze <= 0;
+		if (m_bReverse)
+		{
+			m_iBronze = -m_iBronze; m_iSilver = -m_iSilver; m_iGold = -m_iGold;
+		}
+		m_iCurrentGoal = GOAL_NONE;
+	}
+#endif
 
 	SetDisplayValue(m_iBonusProgress);
 }
@@ -127,23 +178,120 @@ void CHudBonusProgress::OnThink()
 	}
 
 	// Never below zero
+#ifdef MAPBASE
+	newBonusProgress = m_bReverse ? -local->GetBonusProgress() : MAX( local->GetBonusProgress(), 0 );
+#else
 	newBonusProgress = MAX( local->GetBonusProgress(), 0 );
+#endif
 	iBonusChallenge = local->GetBonusChallenge();
 
 	// Only update the fade if we've changed bonusProgress
+#ifdef MAPBASE
+	if ( newBonusProgress == m_iBonusProgress && m_iLastChallenge == iBonusChallenge && gpGlobals->curtime > 6.5f )
+#else
 	if ( newBonusProgress == m_iBonusProgress && m_iLastChallenge == iBonusChallenge )
+#endif
 	{
 		return;
 	}
 
 	m_iBonusProgress = newBonusProgress;
 
+#ifdef MAPBASE
+	if ( m_iLastChallenge != iBonusChallenge )
+	{
+		m_iLastChallenge = iBonusChallenge;
+		SetChallengeLabel();
+		BonusMapChallengeObjectives( m_iBronze, m_iSilver, m_iGold );
+		m_bReverse = m_iBronze <= 0;
+		if (m_bReverse)
+		{
+			m_iBronze = -m_iBronze; m_iSilver = -m_iSilver; m_iGold = -m_iGold;
+		}
+		m_iCurrentGoal = GOAL_NONE;
+	}
+#else
 	if ( m_iLastChallenge != iBonusChallenge )
 	{
 		m_iLastChallenge = iBonusChallenge;
 		SetChallengeLabel();
 	}
+#endif
 
+#ifdef MAPBASE
+	if (hud_bonus_progress_enhanced.GetBool())
+	{
+		// If the bonus progress is greater than bronze, turn red to indicate this isn't getting a medal
+		if (m_iBonusProgress >= m_iBronze && !m_bReverse)
+		{
+			if (m_iCurrentGoal != GOAL_NONE)
+			{
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressSpoil" );
+				m_iCurrentGoal = GOAL_NONE;
+			}
+			SetShouldDisplaySecondaryValue( false );
+		}
+		else
+		{
+			// Use the goal as the secondary value
+			SetShouldDisplaySecondaryValue( true );
+
+			int iShowGoalProgress = m_iBonusProgress;
+			int iLastGoal, iNextGoal;
+
+			if (gpGlobals->curtime <= 6.0f)
+			{
+				// Cycle through each goal at the start of a level
+				if (gpGlobals->curtime <= 3.0f)
+					iShowGoalProgress = 0; // Gold
+				else if (gpGlobals->curtime <= 4.0f)
+					iShowGoalProgress = m_iGold; // Silver
+				else if (gpGlobals->curtime <= 5.0f)
+					iShowGoalProgress = m_iBronze; // Bronze
+			}
+
+			if (m_bReverse ? iShowGoalProgress < m_iBronze : iShowGoalProgress >= m_iSilver)
+			{
+				if (m_iCurrentGoal != GOAL_BRONZE)
+				{
+					SetSecondaryValue( m_iBronze );
+					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressNewGoalBronze" ); //m_Ammo2Color = m_BronzeColor;
+					m_iCurrentGoal = GOAL_BRONZE;
+				}
+				iLastGoal = m_iSilver; iNextGoal = m_iBronze;
+			}
+			else if (m_bReverse ? iShowGoalProgress < m_iSilver : iShowGoalProgress >= m_iGold)
+			{
+				if (m_iCurrentGoal != GOAL_SILVER)
+				{
+					SetSecondaryValue( m_iSilver );
+					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressNewGoalSilver" ); //m_Ammo2Color = m_SilverColor;
+					m_iCurrentGoal = GOAL_SILVER;
+				}
+				iLastGoal = m_iGold; iNextGoal = m_iSilver;
+			}
+			else
+			{
+				if (m_iCurrentGoal != GOAL_GOLD)
+				{
+					SetSecondaryValue( m_iGold );
+					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressNewGoalGold" ); //m_Ammo2Color = m_GoldColor;
+					m_iCurrentGoal = GOAL_GOLD;
+				}
+				iLastGoal = 0; iNextGoal = m_iGold;
+			}
+
+			// If 75% of the way to the next goal, flash red
+			if (!m_bReverse && ((float)(iLastGoal - m_iBonusProgress) / (float)(iLastGoal - iNextGoal)) >= 0.75f)
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressFlashRed" );
+			else if (m_iBonusProgress == iLastGoal)
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressFlashNewGoal" );
+			else
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressFlash" );
+		}
+	}
+	else
+#endif
 	g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("BonusProgressFlash");
 
 	if ( pGameRules->IsBonusChallengeTimeBased() )

--- a/sp/src/game/client/hl2/hud_bonusprogress.cpp
+++ b/sp/src/game/client/hl2/hud_bonusprogress.cpp
@@ -35,6 +35,10 @@ using namespace vgui;
 #include "point_bonusmaps_accessor.h"
 #endif
 
+#ifdef EZ
+#include "hl2_shareddefs.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -57,6 +61,10 @@ public:
 	virtual void VidInit( void );
 	virtual void Reset( void );
 	virtual void OnThink();
+
+#ifdef EZ
+	virtual void Paint();
+#endif
 
 protected:
 
@@ -308,6 +316,25 @@ void CHudBonusProgress::OnThink()
 	SetDisplayValue(m_iBonusProgress);
 }
 
+#ifdef EZ
+//-----------------------------------------------------------------------------
+// Purpose: renders the vgui panel
+//-----------------------------------------------------------------------------
+void CHudBonusProgress::Paint()
+{
+	// For special challenges, count the maximum value as a sign this challenge doesn't use a counter
+	if (m_iLastChallenge >= EZ_CHALLENGE_SPECIAL && m_iBonusProgress == 65536)
+	{
+		// Only draw the label
+		PaintLabel();
+	}
+	else
+	{
+		BaseClass::Paint();
+	}
+}
+#endif
+
 void CHudBonusProgress::SetChallengeLabel( void )
 {
 	// Blank for no challenge
@@ -316,6 +343,18 @@ void CHudBonusProgress::SetChallengeLabel( void )
 		SetLabelText(L"");
 		return;
 	}
+
+#ifdef EZ
+	if (m_iLastChallenge == EZ_CHALLENGE_MASS)
+	{
+		// Give the number enough room
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressExpandToMassChallenge" );
+	}
+	else
+	{
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "BonusProgressExpandToNormal" );
+	}
+#endif
 
 	char szBonusTextName[] = "#Valve_Hud_BONUS_PROGRESS00";
 

--- a/sp/src/game/client/hud_numericdisplay.cpp
+++ b/sp/src/game/client/hud_numericdisplay.cpp
@@ -188,7 +188,12 @@ void CHudNumericDisplay::Paint()
 	// total ammo
 	if (m_bDisplaySecondaryValue)
 	{
+#ifdef MAPBASE
+		// Bonus progress uses this now (was previously unused)
+		surface()->DrawSetTextColor( UsesUniqueSecondaryColor() ? m_Ammo2Color : GetFgColor() );
+#else
 		surface()->DrawSetTextColor(GetFgColor());
+#endif
 		PaintNumbers(m_hSmallNumberFont, digit2_xpos, digit2_ypos, m_iSecondaryValue);
 	}
 

--- a/sp/src/game/client/hud_numericdisplay.h
+++ b/sp/src/game/client/hud_numericdisplay.h
@@ -43,6 +43,10 @@ protected:
 
 	virtual void PaintNumbers(vgui::HFont font, int xpos, int ypos, int value);
 
+#ifdef MAPBASE
+	virtual bool UsesUniqueSecondaryColor() const { return false; }
+#endif
+
 protected:
 
 	int m_iValue;

--- a/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
+++ b/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
@@ -38,6 +38,7 @@
 #include "physics_saverestore.h"
 #include "weapon_physcannon.h"
 #include "eventqueue.h"
+#include "hl2_shareddefs.h"
 #endif
 
 #ifdef EZ2
@@ -1761,6 +1762,17 @@ void CPropDrivableAPC::FireMachineGun( void )
 	DoMuzzleFlash();
 
 	EmitSound( "Weapon_AR2.Single" );
+
+#ifdef EZ
+	if (GetDriver() && GetDriver()->IsPlayer())
+	{
+		CBasePlayer *pPlayer = ((CBasePlayer*)GetDriver());
+		if (pPlayer->GetBonusChallenge() == EZ_CHALLENGE_BULLETS)
+		{
+			pPlayer->SetBonusProgress( pPlayer->GetBonusProgress() + BulletInfo.m_iShots );
+		}
+	}
+#endif
 }
 
 

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -25,6 +25,7 @@
 #include "saverestore.h"
 #include "saverestore_utlmap.h"
 #include "items.h"
+#include "hl2_shareddefs.h"
 
 #include "ai_hint.h"
 #include "ai_network.h"
@@ -875,6 +876,17 @@ void CGravityVortexController::ConsumeEntity( CBaseEntity *pEnt )
 	}
 
 	pEnt->RemoveDeferred();
+
+	if (GetThrower() && GetThrower()->IsPlayer())
+	{
+		CBasePlayer *pPlayer = ((CBasePlayer *)GetThrower());
+		if (pPlayer->GetBonusChallenge() == EZ_CHALLENGE_MASS)
+		{
+			// Add this mass to the bonus progress
+			// TODO: Prevent Xen spawns from contributing to this value?
+			pPlayer->SetBonusProgress( pPlayer->GetBonusProgress() - flMass );
+		}
+	}
 #else
 	UTIL_Remove( pEnt );
 #endif

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -187,6 +187,16 @@ public:
 
 	void			FireGameEvent( IGameEvent *event );
 
+	void			InputFinishBonusChallenge( inputdata_t &inputdata );
+	bool			HasCheated();
+
+	void			HUDMaskInterrupt();
+	void			HUDMaskRestore();
+
+	bool			HidingBonusProgressHUD();
+
+	void			FireBullets( const FireBulletsInfo_t &info );
+
 	// Blixibon - StartScripting for gag replacement
 	bool				IsInAScript( void ) { return m_bInAScript; }
 	inline void			SetInAScript( bool bScript ) { m_bInAScript = bScript; }
@@ -290,6 +300,10 @@ private:
 
 	// See PlayerCriteria_t
 	int				m_iCriteriaAppended;
+
+	// These don't need to be saved
+	CNetworkVar( bool, m_bBonusChallengeUpdate );
+	bool m_bMaskInterrupt;
 };
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/gameinterface.cpp
+++ b/sp/src/game/server/gameinterface.cpp
@@ -161,6 +161,9 @@ CTimedEventMgr g_NetworkPropertyEventMgr;
 
 ISaveRestoreBlockHandler *GetEventQueueSaveRestoreBlockHandler();
 ISaveRestoreBlockHandler *GetCommentarySaveRestoreBlockHandler();
+#ifdef MAPBASE
+ISaveRestoreBlockHandler *GetCustomBonusSaveRestoreBlockHandler();
+#endif
 
 CUtlLinkedList<CMapEntityRef, unsigned short> g_MapEntityRefs;
 
@@ -699,6 +702,9 @@ bool CServerGameDLL::DLLInit( CreateInterfaceFn appSystemFactory,
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetEventQueueSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetAchievementSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetVScriptSaveRestoreBlockHandler() );
+#ifdef MAPBASE
+	g_pGameSaveRestoreBlockSet->AddBlockHandler( GetCustomBonusSaveRestoreBlockHandler() );
+#endif
 
 	// The string system must init first + shutdown last
 	IGameSystem::Add( GameStringSystem() );
@@ -786,6 +792,9 @@ void CServerGameDLL::DLLShutdown( void )
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetAISaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetPhysSaveRestoreBlockHandler() );
 	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetEntitySaveRestoreBlockHandler() );
+#ifdef MAPBASE
+	g_pGameSaveRestoreBlockSet->RemoveBlockHandler( GetCustomBonusSaveRestoreBlockHandler() );
+#endif
 
 	char *pFilename = g_TextStatsMgr.GetStatsFilename();
 	if ( !pFilename || !pFilename[0] )

--- a/sp/src/game/server/hl2/func_tank.cpp
+++ b/sp/src/game/server/hl2/func_tank.cpp
@@ -48,6 +48,10 @@
 #include "hl2_player.h"
 #endif //HL2_DLL
 
+#ifdef EZ
+#include "hl2_shareddefs.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -2971,6 +2975,17 @@ void CFuncTankGun::Fire( int bulletCount, const Vector &barrelEnd, const Vector 
 		}
 	}
 #endif // HL2_EPISODIC
+
+#ifdef EZ
+	if (pAttacker && pAttacker->IsPlayer())
+	{
+		CBasePlayer *pPlayer = ((CBasePlayer*)pAttacker);
+		if (pPlayer->GetBonusChallenge() == EZ_CHALLENGE_BULLETS)
+		{
+			pPlayer->SetBonusProgress( pPlayer->GetBonusProgress() + info.m_iShots );
+		}
+	}
+#endif
 
 	CFuncTank::Fire( bulletCount, barrelEnd, forward, pAttacker, bIgnoreSpread );
 }

--- a/sp/src/game/server/player.cpp
+++ b/sp/src/game/server/player.cpp
@@ -90,6 +90,10 @@
 #include "mapbase/vscript_funcs_shared.h"
 #endif
 
+#ifdef MAPBASE
+#include "point_bonusmaps_accessor.h"
+#endif
+
 ConVar autoaim_max_dist( "autoaim_max_dist", "2160" ); // 2160 = 180 feet
 ConVar autoaim_max_deflect( "autoaim_max_deflect", "0.99" );
 
@@ -540,6 +544,11 @@ BEGIN_ENT_SCRIPTDESC( CBasePlayer, CBaseCombatCharacter, "The player entity." )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetEyeForward, "GetEyeForward", "Gets the player's forward eye vector." )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetEyeRight, "GetEyeRight", "Gets the player's right eye vector." )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetEyeUp, "GetEyeUp", "Gets the player's up eye vector." )
+
+	DEFINE_SCRIPTFUNC( GetBonusProgress, "Returns the player's bonus progress." )
+	DEFINE_SCRIPTFUNC( GetBonusChallenge, "Returns the player's bonus challenge." )
+	DEFINE_SCRIPTFUNC( SetBonusProgress, "Sets the player's bonus progress." )
+	DEFINE_SCRIPTFUNC( SetBonusChallenge, "Sets the player's bonus challenge." )
 
 	// 
 	// Hooks
@@ -5198,6 +5207,9 @@ void CBasePlayer::Spawn( void )
 
 	m_iBonusChallenge = sv_bonus_challenge.GetInt();
 	sv_bonus_challenge.SetValue( 0 );
+#ifdef MAPBASE
+	ResolveCustomBonusChallenge( this );
+#endif
 
 	if ( m_iPlayerSound == SOUNDLIST_EMPTY )
 	{
@@ -7212,7 +7224,11 @@ void CBasePlayer::UpdateClientData( void )
 	// Check if the bonus progress HUD element should be displayed
 	if ( m_iBonusChallenge == 0 && m_iBonusProgress == 0 && !( m_Local.m_iHideHUD & HIDEHUD_BONUS_PROGRESS ) )
 		m_Local.m_iHideHUD |= HIDEHUD_BONUS_PROGRESS;
+#ifdef MAPBASE
+	if ( ( m_iBonusChallenge != 0 )&& ( m_Local.m_iHideHUD & HIDEHUD_BONUS_PROGRESS ) && !HidingBonusProgressHUD() )
+#else
 	if ( ( m_iBonusChallenge != 0 )&& ( m_Local.m_iHideHUD & HIDEHUD_BONUS_PROGRESS ) )
+#endif
 		m_Local.m_iHideHUD &= ~HIDEHUD_BONUS_PROGRESS;
 
 	// Let any global rules update the HUD, too

--- a/sp/src/game/server/player.h
+++ b/sp/src/game/server/player.h
@@ -732,6 +732,10 @@ public:
 	void	SetArmorValue( int value );
 	void	IncrementArmorValue( int nCount, int nMaxValue = -1 );
 
+#ifdef MAPBASE
+	virtual bool	HidingBonusProgressHUD() { return false; }
+#endif
+
 	void	SetConnected( PlayerConnectedState iConnected ) { m_iConnected = iConnected; }
 	virtual void EquipSuit( bool bPlayEffects = true );
 	virtual void RemoveSuit( void );

--- a/sp/src/game/server/triggers.cpp
+++ b/sp/src/game/server/triggers.cpp
@@ -1466,6 +1466,9 @@ public:
 	void Spawn( void );
 	void Activate( void );
 	bool KeyValue( const char *szKeyName, const char *szValue );
+#ifdef EZ
+	bool GetKeyValue( const char *szKeyName, char *szValue, int iMaxLen );
+#endif
 
 	static int ChangeList( levellist_t *pLevelList, int maxList );
 
@@ -1572,6 +1575,23 @@ bool CChangeLevel::KeyValue( const char *szKeyName, const char *szValue )
 
 	return true;
 }
+
+#ifdef EZ
+bool CChangeLevel::GetKeyValue( const char *szKeyName, char *szValue, int iMaxLen )
+{
+	if ( FStrEq( szKeyName, "map" ) )
+	{
+		Q_snprintf( szValue, iMaxLen, "%s", m_szMapName );
+		return true;
+	}
+	else  if ( FStrEq( szKeyName, "landmark" ) )
+	{
+		Q_snprintf( szValue, iMaxLen, "%s", m_szLandmarkName );
+		return true;
+	}
+	return BaseClass::GetKeyValue( szKeyName, szValue, iMaxLen );
+}
+#endif
 
 
 

--- a/sp/src/game/shared/hl2/hl2_gamerules.cpp
+++ b/sp/src/game/shared/hl2/hl2_gamerules.cpp
@@ -2529,6 +2529,23 @@ bool CHalfLife2::FPlayerCanRespawn( CBasePlayer *pPlayer )
 
 #endif//CLIENT_DLL
 
+#ifdef EZ
+//---------------------------------------------------------
+//---------------------------------------------------------
+bool CHalfLife2::IsBonusChallengeTimeBased()
+{
+#ifdef CLIENT_DLL
+	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+#else
+	CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+#endif
+	if (!pPlayer)
+		return false;
+
+	return pPlayer->GetBonusChallenge() == EZ_CHALLENGE_TIME;
+}
+#endif
+
 //---------------------------------------------------------
 //---------------------------------------------------------
 bool CHalfLife2::ShouldUseRobustRadiusDamage(CBaseEntity *pEntity)

--- a/sp/src/game/shared/hl2/hl2_gamerules.h
+++ b/sp/src/game/shared/hl2/hl2_gamerules.h
@@ -170,6 +170,10 @@ private:
 #endif
 
 #endif
+
+#ifdef EZ
+	virtual bool IsBonusChallengeTimeBased( void );
+#endif
 };
 
 

--- a/sp/src/game/shared/hl2/hl2_shareddefs.h
+++ b/sp/src/game/shared/hl2/hl2_shareddefs.h
@@ -45,5 +45,24 @@ enum
 #define DMG_MISSILEDEFENSE	(DMG_LASTGENERICFLAG<<2)	// The only kind of damage missiles take. (special missile defense)
 
 
+#ifdef EZ
+//--------------
+// ENTROPY : ZERO DEFINITIONS
+//--------------
+enum
+{
+	EZ_CHALLENGE_NONE,
+	EZ_CHALLENGE_DAMAGE,
+	EZ_CHALLENGE_BULLETS,
+	EZ_CHALLENGE_TIME,
+	EZ_CHALLENGE_KILLS,
+	EZ_CHALLENGE_MASS,
+
+	// Special Challenges
+	// These are VScript-driven challenges which can be defined by users.
+	EZ_CHALLENGE_SPECIAL = 100,
+};
+#endif
+
 
 #endif // HL2_SHAREDDEFS_H

--- a/sp/src/game/shared/point_bonusmaps_accessor.cpp
+++ b/sp/src/game/shared/point_bonusmaps_accessor.cpp
@@ -11,6 +11,10 @@
 #include "GameUI/IGameUI.h"
 #include "fmtstr.h"
 #include "igameevents.h"
+#ifdef MAPBASE
+#include "filesystem.h"
+#include "saverestore.h"
+#endif
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -95,6 +99,14 @@ void CPointBonusMapsAccessor::InputSave( inputdata_t& inputdata )
 
 #endif
 
+#ifdef MAPBASE
+void CustomBMSystem_UpdateChallenges( const char *pchFileName, const char *pchMapName, const char *pchChallengeName, int iBest );
+
+bool CustomBMSystem_OverridingInterface();
+void CustomBMSystem_BonusMapChallengeNames( char *pchFileName, char *pchMapName, char *pchChallengeName );
+void CustomBMSystem_BonusMapChallengeObjectives( int &iBronze, int &iSilver, int &iGold );
+#endif
+
 void BonusMapChallengeUpdate( const char *pchFileName, const char *pchMapName, const char *pchChallengeName, int iBest )
 {
 	CreateInterfaceFn gameUIFactory = g_GameUI.GetFactory();
@@ -116,12 +128,25 @@ void BonusMapChallengeUpdate( const char *pchFileName, const char *pchMapName, c
 				event->SetInt( "numgold", piNumMedals[ 2 ] );
 				gameeventmanager->FireEvent( event );
 			}
+
+#ifdef MAPBASE
+			CustomBMSystem_UpdateChallenges( pchFileName, pchMapName, pchChallengeName, iBest );
+#endif
 		}	
 	}
 }
 
 void BonusMapChallengeNames( char *pchFileName, char *pchMapName, char *pchChallengeName )
 {
+#ifdef MAPBASE
+	// This accounts for cases where challenges are "skipped", which causes the data from GameUI to get desynced
+	if (CustomBMSystem_OverridingInterface())
+	{
+		CustomBMSystem_BonusMapChallengeNames( pchFileName, pchMapName, pchChallengeName );
+		return;
+	}
+#endif
+
 	CreateInterfaceFn gameUIFactory = g_GameUI.GetFactory();
 	if ( gameUIFactory )
 	{
@@ -135,6 +160,15 @@ void BonusMapChallengeNames( char *pchFileName, char *pchMapName, char *pchChall
 
 void BonusMapChallengeObjectives( int &iBronze, int &iSilver, int &iGold )
 {
+#ifdef MAPBASE
+	// This accounts for cases where challenges are "skipped", which causes the data from GameUI to get desynced
+	if (CustomBMSystem_OverridingInterface())
+	{
+		CustomBMSystem_BonusMapChallengeObjectives( iBronze, iSilver, iGold );
+		return;
+	}
+#endif
+
 	CreateInterfaceFn gameUIFactory = g_GameUI.GetFactory();
 	if ( gameUIFactory )
 	{
@@ -145,3 +179,771 @@ void BonusMapChallengeObjectives( int &iBronze, int &iSilver, int &iGold )
 		}
 	}
 }
+
+#ifdef MAPBASE
+#ifdef CLIENT_DLL
+// This is so that the client can access the bonus challenge before it's moved to the player without any complex networking.
+ConVar sv_bonus_challenge( "sv_bonus_challenge", "0", FCVAR_REPLICATED | FCVAR_HIDDEN );
+#else
+extern ConVar sv_bonus_challenge;
+#endif
+
+//-----------------------------------------------------------------------------
+// Purpose: A wrapper-like system which tries to make up for the bonus maps framework being hardcoded into GameUI.
+// 			At the moment, this system mostly involves restoring bonus challenges and allowing them to be used in mods.
+// 
+// This aims to resolve or work around the following specific issues:
+// 
+// - A limitation where challenge types cannot go beyond the number of image boxes defined in the .res file.
+//      - Not a complete workaround. They still have to occupy a valid image box, but different types can be used for one image.
+// - A bug where "skipped" challenge types in a level will cause a desync between the GameUI and the player/cvar's value.
+// - A bug where challenges with negative scores do not count as completed.
+//      - Negative scores themselves are a workaround for allowing challenges which require the "most of" something rather than the "least of" something,
+// 		  as the bonus maps framework normally only recognizes the latter.
+//      - May not appear immediately since this fix can be overwritten by GameUI under some circumstances.
+// - A bug/limitation where challenge information didn't save/restore after restarting the game.
+// 
+// The system also offers the following enhancements:
+// 
+// - Two new game events for monitoring challenge progress for maps and challenge types in particular. They're useful
+// if you want to have achievements (or at least progress monitoring) for specific maps or challenge types, as the
+// existing events only covered all challenges in the game.
+// - VScript functions for accessing bonus map and challenge values.
+// 
+//-----------------------------------------------------------------------------
+class CCustomBonusMapSystem : public CAutoGameSystem
+{
+public:
+	DECLARE_DATADESC();
+
+	CCustomBonusMapSystem() : CAutoGameSystem( "CCustomBonusMapSystem" )
+	{
+		m_pKV_CurrentBonusData = NULL;
+		m_pKV_SaveData = NULL;
+		m_bUpdatedChallenges = false;
+	}
+
+	virtual bool Init()
+	{
+		return true;
+	}
+
+	virtual void Shutdown()
+	{
+		RefreshSaveAdjustments();
+	}
+
+	virtual void LevelInitPreEntity()
+	{
+		CreateInterfaceFn gameUIFactory = g_GameUI.GetFactory();
+		if ( gameUIFactory )
+		{
+			m_pGameUI = (IGameUI *) gameUIFactory(GAMEUI_INTERFACE_VERSION, NULL );
+		}
+
+		// Get the GameUI's values to override its interface (covers cases where GameUI's challenge information has desynced)
+		if (m_pGameUI)
+		{
+			m_pGameUI->BonusMapChallengeNames( m_szChallengeFileName, m_szChallengeMapName, m_szChallengeName );
+			m_pGameUI->BonusMapChallengeObjectives( m_iBronze, m_iSilver, m_iGold );
+			LoadBonusDataKV( m_szChallengeFileName );
+
+//#ifndef CLIENT_DLL
+			if (sv_bonus_challenge.GetInt() != 0)
+			{
+				VerifyChallengeValues( sv_bonus_challenge.GetInt() );
+			}
+//#endif
+		}
+	}
+
+	virtual void LevelInitPostEntity()
+	{
+	}
+
+	virtual void LevelShutdownPreEntity()
+	{
+	}
+
+	virtual void LevelShutdownPostEntity()
+	{
+		// Destroy KV
+		if (m_pKV_CurrentBonusData)
+		{
+			m_pKV_CurrentBonusData->deleteThis();
+			m_pKV_CurrentBonusData = NULL;
+		}
+
+		if (m_pKV_SaveData)
+		{
+			m_pKV_SaveData->deleteThis();
+			m_pKV_SaveData = NULL;
+		}
+
+		m_bUpdatedChallenges = false;
+		m_bOverridingInterface = false;
+
+		RefreshSaveAdjustments();
+	}
+
+	virtual void OnRestore()
+	{
+		// No longer necessary due to datadesc and save/restore handler
+		/*
+#ifdef CLIENT_DLL
+		C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+#else
+		CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+#endif
+		if (pPlayer && pPlayer->GetBonusChallenge() != 0)
+		{
+			if (m_pGameUI)
+			{
+				m_pGameUI->BonusMapChallengeNames( m_szChallengeFileName, m_szChallengeMapName, m_szChallengeName );
+				m_pGameUI->BonusMapChallengeObjectives( m_iBronze, m_iSilver, m_iGold );
+				LoadBonusDataKV( m_szChallengeFileName );
+
+				VerifyChallengeValues( pPlayer->GetBonusChallenge() );
+			}
+		}
+		*/
+	}
+
+	//------------------------------------------------------------------------------------
+	
+	void LoadBonusDataKV( const char *pchFileName )
+	{
+		// Destroy KV if we have any
+		if (m_pKV_CurrentBonusData)
+		{
+			m_pKV_CurrentBonusData->deleteThis();
+			m_pKV_CurrentBonusData = NULL;
+		}
+
+		// Reload the database
+		m_pKV_CurrentBonusData = new KeyValues( "CurrentBonusMapData" );
+		m_pKV_CurrentBonusData->LoadFromFile( g_pFullFileSystem, pchFileName, NULL );
+	}
+	
+	void LoadSaveDataKV( bool bRefreshData = false )
+	{
+		if (bRefreshData)
+		{
+			// Destroy KV if we have any
+			if (m_pKV_SaveData)
+			{
+				m_pKV_SaveData->deleteThis();
+				m_pKV_SaveData = NULL;
+			}
+
+			// Save the database
+			m_pGameUI->BonusMapDatabaseSave();
+		}
+		else if (m_pKV_SaveData)
+		{
+			return;
+		}
+
+		// Reload the database
+		m_pKV_SaveData = new KeyValues( "SavedBonusMapData" );
+		m_pKV_SaveData->LoadFromFile( g_pFullFileSystem, "save/bonus_maps_data.bmd", "MOD" );
+	}
+
+	//------------------------------------------------------------------------------------
+
+	void UpdateChallenges( const char *pchFileName, const char *pchMapName, const char *pchChallengeName, int iBest )
+	{
+		if ( !m_pGameUI || m_bUpdatedChallenges )
+			return;
+
+		LoadSaveDataKV( true );
+
+		//----------------------------------------
+
+		Msg( "Updating challenges\n" );
+
+		KeyValues *pBonusFiles = m_pKV_SaveData->FindKey( "bonusfiles" );
+		if (!pBonusFiles)
+		{
+			Warning( "Can't find bonus files\n" );
+			return;
+		}
+
+		// Can't use FindKey for file paths
+		KeyValues *pFile = NULL;
+		for (KeyValues *key = pBonusFiles->GetFirstSubKey(); key != NULL; key = key->GetNextKey())
+		{
+			if ( !Q_stricmp( key->GetName(), pchFileName ) )
+			{
+				pFile = key;
+				break;
+			}
+		}
+
+		// Identify when all bonus challenges on this map are complete
+		if (pFile)
+		{
+			// Since we have saved data, get a list of this map's challenges
+			LoadBonusDataKV( pchFileName );
+
+			CUtlVector<int> iAllScores;
+
+			for (KeyValues *pBDMap = m_pKV_CurrentBonusData; pBDMap != NULL; pBDMap = pBDMap->GetNextKey())
+			{
+				KeyValues *pChallenges = pBDMap->FindKey( "challenges" );
+				if (pChallenges)
+				{
+					KeyValues *pSaveMap = pFile->FindKey( pBDMap->GetName() );
+					if (!pSaveMap)
+						continue;
+
+					KeyValues *pThisChallenge = pChallenges->FindKey( pchChallengeName );
+					if (pThisChallenge)
+					{
+						KeyValues *pSavedChallenge = pSaveMap->FindKey( pchChallengeName );
+						if (!pSavedChallenge)
+						{
+							iAllScores.AddToTail( 0 );
+							continue;
+						}
+
+						// Add to progress vector
+						if (pSavedChallenge->GetInt() < pThisChallenge->GetInt( "gold" ))
+							iAllScores.AddToTail( 3 );
+						else if (pSavedChallenge->GetInt() < pThisChallenge->GetInt( "silver" ))
+							iAllScores.AddToTail( 2 );
+						else if (pSavedChallenge->GetInt() < pThisChallenge->GetInt( "bronze" ))
+							iAllScores.AddToTail( 1 );
+						else
+							iAllScores.AddToTail( 0 );
+					}
+
+					// Only do the rest if it's the map we just completed
+					if (!Q_stricmp( pBDMap->GetName(), pchMapName ))
+					{
+						CUtlDict<int> iScores;
+
+						// Compare all challenges to the saved data
+						for (KeyValues *challenge = pChallenges->GetFirstSubKey(); challenge != NULL; challenge = challenge->GetNextKey())
+						{
+							KeyValues *pSavedChallenge = pSaveMap->FindKey( challenge->GetName() );
+							if (!pSavedChallenge)
+							{
+								iScores.Insert( challenge->GetName(), 0 );
+								continue;
+							}
+
+							// Add to progress vector
+							if (pSavedChallenge->GetInt() < challenge->GetInt("gold"))
+								iScores.Insert( challenge->GetName(), 3 );
+							else if (pSavedChallenge->GetInt() < challenge->GetInt("silver"))
+								iScores.Insert( challenge->GetName(), 2 );
+							else if (pSavedChallenge->GetInt() < challenge->GetInt("bronze"))
+								iScores.Insert( challenge->GetName(), 1 );
+							else
+								iScores.Insert( challenge->GetName(), 0 );
+						}
+
+						int iNumMedals[3] = { 0, 0, 0 };
+						for (unsigned int i = 0; i < iScores.Count(); i++)
+						{
+							switch (iScores[i])
+							{
+								// These are supposed to fall through into each other
+								case 3:		iNumMedals[2]++; // Gold
+								case 2:		iNumMedals[1]++; // Silver
+								case 1:		iNumMedals[0]++; // Bronze
+							}
+						}
+
+						// Fire an expanded map update event with more map-specific values
+						// 
+						// 	"challenge_map_update"
+						// 	{
+						// 		"challenge"	"short"
+						// 		"challengescore"	"short"
+						// 		"challengebest"	"short"
+						// 		"numbronze"	"short"
+						// 		"numsilver"	"short"
+						// 		"numgold"	"short"
+						// 	}
+						// 
+						IGameEvent *event = gameeventmanager->CreateEvent( "challenge_map_update", true );
+						if ( event )
+						{
+
+							Msg("CHALLENGE MAP UPDATE:\n	Map: %s, Challenge: %s\nChallenge Score: %i\n	Ratio Bronze: %f, Ratio Silver: %f, Ratio Gold: %f\n",
+								pchMapName, pchChallengeName, iScores.Find( pchChallengeName ),
+								(float)iNumMedals[0] / (float)iScores.Count(), (float)iNumMedals[1] / (float)iScores.Count(), (float)iNumMedals[2] / (float)iScores.Count() );
+
+#ifdef CLIENT_DLL
+							C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+#else
+							CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+#endif
+
+							event->SetInt( "challenge", pPlayer ? pPlayer->GetBonusChallenge() : -1 );
+							event->SetInt( "challengescore", iBest );
+							event->SetInt( "challengebest", iScores.Find( pchChallengeName ) );
+							event->SetInt( "numbronze", iNumMedals[0] );
+							event->SetInt( "numsilver", iNumMedals[1] );
+							event->SetInt( "numgold", iNumMedals[2] );
+#ifdef CLIENT_DLL
+							gameeventmanager->FireEventClientSide( event );
+#else
+							gameeventmanager->FireEvent( event );
+#endif
+						}
+					}
+				}
+
+
+				//if (pSaveMap->FindKey( "complete", false ))
+			}
+
+			// Fire an event for the challenge itself
+			// 	
+			// 	"challenge_update"
+			// 	{
+			// 		"challenge"	"short"
+			// 		"numbronze"	"short"
+			// 		"numsilver"	"short"
+			// 		"numgold"	"short"
+			// 	}
+			// 
+			IGameEvent *event = gameeventmanager->CreateEvent( "challenge_update", true );
+			if ( event )
+			{
+				int iNumMedals[3] = { 0, 0, 0 };
+				for (int i = 0; i < iAllScores.Count(); i++)
+				{
+					switch (iAllScores[i])
+					{
+						// These are supposed to fall through into each other
+						case 3:		iNumMedals[2]++; // Gold
+						case 2:		iNumMedals[1]++; // Silver
+						case 1:		iNumMedals[0]++; // Bronze
+					}
+				}
+
+				Msg("CHALLENGE UPDATE:\n	Ratio Bronze: %f, Ratio Silver: %f, Ratio Gold: %f\n",
+					(float)iNumMedals[0] / (float)iAllScores.Count(), (float)iNumMedals[1] / (float)iAllScores.Count(), (float)iNumMedals[2] / (float)iAllScores.Count() );
+
+#ifdef CLIENT_DLL
+				C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+#else
+				CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+#endif
+
+				event->SetInt( "challenge", pPlayer ? pPlayer->GetBonusChallenge() : -1 );
+				event->SetInt( "numbronze", iNumMedals[0] );
+				event->SetInt( "numsilver", iNumMedals[1] );
+				event->SetInt( "numgold", iNumMedals[2] );
+#ifdef CLIENT_DLL
+				gameeventmanager->FireEventClientSide( event );
+#else
+				gameeventmanager->FireEvent( event );
+#endif
+			}
+		}
+
+		m_bUpdatedChallenges = true;
+	}
+
+	void RefreshSaveAdjustments()
+	{
+		if ( !m_pGameUI )
+			return;
+
+		LoadSaveDataKV( true );
+
+		//----------------------------------------
+
+		KeyValues *pBonusFiles = m_pKV_SaveData->FindKey( "bonusfiles" );
+		if (!pBonusFiles)
+		{
+			Warning( "Can't find bonus files\n" );
+			return;
+		}
+
+		bool bChanged = true;
+
+		// Go through all maps we have save data for
+		for (KeyValues *pFile = pBonusFiles->GetFirstSubKey(); pFile != NULL; pFile = pFile->GetNextKey())
+		{
+			// Get a list of this map's challenges
+			LoadBonusDataKV( pFile->GetName() );
+
+			CUtlVector<int> iAllScores;
+
+			for (KeyValues *pBDMap = m_pKV_CurrentBonusData; pBDMap != NULL; pBDMap = pBDMap->GetNextKey())
+			{
+				KeyValues *pChallenges = pBDMap->FindKey( "challenges" );
+				if (pChallenges)
+				{
+					KeyValues *pSaveMap = pFile->FindKey( pBDMap->GetName() );
+					if (!pSaveMap)
+						continue;
+
+					CUtlDict<int> iScores;
+
+					// Compare all challenges to the saved data
+					for (KeyValues *challenge = pChallenges->GetFirstSubKey(); challenge != NULL; challenge = challenge->GetNextKey())
+					{
+						KeyValues *pSavedChallenge = pSaveMap->FindKey( challenge->GetName() );
+						if (!pSavedChallenge)
+						{
+							iScores.Insert( challenge->GetName(), 0 );
+							continue;
+						}
+
+						// Add to progress vector
+						if (pSavedChallenge->GetInt() < challenge->GetInt("gold"))
+							iScores.Insert( challenge->GetName(), 3 );
+						else if (pSavedChallenge->GetInt() < challenge->GetInt("silver"))
+							iScores.Insert( challenge->GetName(), 2 );
+						else if (pSavedChallenge->GetInt() < challenge->GetInt("bronze"))
+							iScores.Insert( challenge->GetName(), 1 );
+						else
+							iScores.Insert( challenge->GetName(), 0 );
+					}
+
+					int iNumMedals[3] = { 0, 0, 0 };
+					for (unsigned int i = 0; i < iScores.Count(); i++)
+					{
+						switch (iScores[i])
+						{
+							// These are supposed to fall through into each other
+							case 3:		iNumMedals[2]++; // Gold
+							case 2:		iNumMedals[1]++; // Silver
+							case 1:		iNumMedals[0]++; // Bronze
+						}
+					}
+
+					// Is the map completed?
+					if (iNumMedals[2] >= (int)iScores.Count())
+					{
+						// Make sure the completion key is there. If it's not, there was a problem with the database code
+						// (This typically happens when the scores are negative)
+						if (pSaveMap && pSaveMap->FindKey( "complete" ) == NULL)
+						{
+							// Create the completion key and save
+							pSaveMap->SetBool( "complete", true );
+							bChanged = true;
+						}
+					}
+				}
+			}
+		}
+
+		if (bChanged)
+			m_pKV_SaveData->SaveToFile( g_pFullFileSystem, "save/bonus_maps_data.bmd", "MOD" );
+	}
+
+	//------------------------------------------------------------------------------------
+
+	bool OverridingInterface() { return m_bOverridingInterface; }
+
+	void VerifyChallengeValues( int iTrueChallenge )
+	{
+		// Use sv_bonus_challenge to find this map and challenge in the file
+		for (KeyValues *pBDMap = m_pKV_CurrentBonusData; pBDMap != NULL; pBDMap = pBDMap->GetNextKey())
+		{
+			if (Q_stricmp( pBDMap->GetName(), m_szChallengeMapName ) != 0)
+				continue;
+			
+			KeyValues *pChallenges = pBDMap->FindKey( "challenges" );
+			if (pChallenges)
+			{
+				KeyValues *pGameUIChallenge = pChallenges->FindKey( m_szChallengeName );
+				KeyValues *pConVarChallenge = NULL;
+
+				for (KeyValues *challenge = pChallenges->GetFirstSubKey(); challenge != NULL; challenge = challenge->GetNextKey())
+				{
+					if (challenge->GetInt( "type", -1 )+1 == iTrueChallenge)
+					{
+						pConVarChallenge = challenge;
+						break;
+					}
+				}
+
+				// Begin overriding GameUI
+				m_bOverridingInterface = true;
+
+				if (pGameUIChallenge != pConVarChallenge && pConVarChallenge)
+				{
+					// This indicates there was a desync within GameUI
+
+					//Msg( "****************** OVERRIDING GAME UI BONUS MAP INFO ******************\n%i -> %i --- %s -> %s\n******************************************************\n",
+					//	pGameUIChallenge->GetInt( "type" ), iTrueChallenge,
+					//	m_szChallengeName, pConVarChallenge->GetName() );
+
+					Msg( "Overriding GameUI bonus map info!!! (%i -> %i) (%s -> %s)\n", pGameUIChallenge->GetInt( "type" ), iTrueChallenge, m_szChallengeName, pConVarChallenge->GetName() );
+
+					Q_strncpy( m_szChallengeName, pConVarChallenge->GetName(), sizeof( m_szChallengeName ) );
+
+					m_iBronze = pConVarChallenge->GetInt( "bronze", 0 );
+					m_iSilver = pConVarChallenge->GetInt( "silver", 0 );
+					m_iGold = pConVarChallenge->GetInt( "gold", 0 );
+				}
+			}
+
+			break;
+		}
+	}
+
+	void CustomBonusMapChallengeNames( char *pchFileName, char *pchMapName, char *pchChallengeName )
+	{
+		Q_strncpy( pchFileName, m_szChallengeFileName, sizeof( m_szChallengeFileName ) );
+		Q_strncpy( pchMapName, m_szChallengeMapName, sizeof( m_szChallengeMapName ) );
+		Q_strncpy( pchChallengeName, m_szChallengeName, sizeof( m_szChallengeName ) );
+	}
+
+	void CustomBonusMapChallengeObjectives( int &iBronze, int &iSilver, int &iGold )
+	{
+		iBronze = m_iBronze; iSilver = m_iSilver; iGold = m_iGold;
+	}
+
+#ifdef GAME_DLL
+	// Allows a challenge to turn into another type in-game, allowing multiple challenges of the same "type" and
+	// getting around issues connected to too many challenge types in the dialog
+	void ResolveCustomBonusChallenge( CBasePlayer *pPlayer )
+	{
+		for (KeyValues *pBDMap = m_pKV_CurrentBonusData; pBDMap != NULL; pBDMap = pBDMap->GetNextKey())
+		{
+			//Msg( "Bonus map data has map %s\n", pBDMap->GetName() );
+
+			// Only do the rest if it's the map we just completed
+			if (!Q_stricmp( pBDMap->GetName(), m_szChallengeMapName ))
+			{
+				KeyValues *pChallenges = pBDMap->FindKey( "challenges" );
+				if (pChallenges)
+				{
+					KeyValues *pThisChallenge = pChallenges->FindKey( m_szChallengeName );
+					if (pThisChallenge)
+					{
+						// Get the hacky "type_game"
+						int iTypeGame = pThisChallenge->GetInt( "type_game", 0 );
+						if (iTypeGame != 0)
+							pPlayer->SetBonusChallenge( iTypeGame );
+					}
+				}
+			}
+		}
+	}
+#endif
+
+	//------------------------------------------------------------------------------------
+
+#ifdef MAPBASE_VSCRIPT
+	virtual void RegisterVScript()
+	{
+		g_pScriptVM->RegisterInstance( this, "BonusMaps" );
+	}
+#endif
+
+	//------------------------------------------------------------------------------------
+
+	const char *GetChallengeFileName()
+	{
+		return m_szChallengeFileName;
+	}
+
+	const char *GetChallengeMapName()
+	{
+		return m_szChallengeMapName;
+	}
+
+	const char *GetChallengeName()
+	{
+		return m_szChallengeName;
+	}
+
+	int GetBronze()
+	{
+		return m_iBronze;
+	}
+
+	int GetSilver()
+	{
+		return m_iSilver;
+	}
+
+	int GetGold()
+	{
+		return m_iGold;
+	}
+
+	//------------------------------------------------------------------------------------
+
+	inline bool BonusChallengesActive()
+	{
+#ifdef CLIENT_DLL
+		C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+#else
+		CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+#endif
+		if (pPlayer && pPlayer->GetBonusChallenge() != 0)
+		{
+			return true;
+		}
+		else
+		{
+			return sv_bonus_challenge.GetInt() != 0;
+		}
+	}
+
+private:
+
+	bool	m_bUpdatedChallenges;
+
+	//-------------------------------------------
+
+	bool	m_bOverridingInterface;
+
+	char	m_szChallengeFileName[MAX_PATH];
+	char	m_szChallengeMapName[48];
+	char	m_szChallengeName[48];
+
+	int		m_iBronze, m_iSilver, m_iGold;
+
+	//-------------------------------------------
+
+	KeyValues	*m_pKV_CurrentBonusData;
+	KeyValues	*m_pKV_SaveData;
+
+	IGameUI *m_pGameUI;
+};
+
+CCustomBonusMapSystem	g_CustomBonusMapSystem;
+
+BEGIN_DATADESC_NO_BASE( CCustomBonusMapSystem )
+	DEFINE_FIELD( m_bOverridingInterface, FIELD_BOOLEAN ),
+
+	DEFINE_AUTO_ARRAY( m_szChallengeFileName, FIELD_CHARACTER ),
+	DEFINE_AUTO_ARRAY( m_szChallengeMapName, FIELD_CHARACTER ),
+	DEFINE_AUTO_ARRAY( m_szChallengeName, FIELD_CHARACTER ),
+
+	DEFINE_FIELD( m_iBronze, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iSilver, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iGold, FIELD_INTEGER ),
+END_DATADESC()
+
+#ifdef MAPBASE_VSCRIPT
+BEGIN_SCRIPTDESC_ROOT( CCustomBonusMapSystem, SCRIPT_SINGLETON "A custom bonus map tracking system." )
+	DEFINE_SCRIPTFUNC( OverridingInterface, "Returns true if the custom bonus map system is overriding the GameUI interface." )
+
+	DEFINE_SCRIPTFUNC( GetChallengeFileName, "Gets the .bns file this bonus map originates from." )
+	DEFINE_SCRIPTFUNC( GetChallengeMapName, "Gets the name of this bonus map from the .bns file. This is the literal name of the bonus map as it appears in the menu, which may be a user-friendly title and/or a localization token." )
+	DEFINE_SCRIPTFUNC( GetChallengeName, "If a challenge is active, this gets its name. This is the literal name of the challenge as it appears in the menu, which may be a user-friendly title and/or a localization token." )
+	
+	DEFINE_SCRIPTFUNC( GetBronze, "If a challenge is active, this gets its Bronze goal value." )
+	DEFINE_SCRIPTFUNC( GetSilver, "If a challenge is active, this gets its Silver goal value." )
+	DEFINE_SCRIPTFUNC( GetGold, "If a challenge is active, this gets its Gold goal value." )
+END_SCRIPTDESC();
+#endif
+
+//------------------------------------------------------------------------------------
+
+inline void CustomBMSystem_UpdateChallenges( const char *pchFileName, const char *pchMapName, const char *pchChallengeName, int iBest )
+{
+	g_CustomBonusMapSystem.UpdateChallenges( pchFileName, pchMapName, pchChallengeName, iBest );
+}
+
+inline bool CustomBMSystem_OverridingInterface()
+{
+	return g_CustomBonusMapSystem.OverridingInterface();
+}
+
+inline void CustomBMSystem_BonusMapChallengeNames( char *pchFileName, char *pchMapName, char *pchChallengeName )
+{
+	g_CustomBonusMapSystem.CustomBonusMapChallengeNames( pchFileName, pchMapName, pchChallengeName );
+}
+
+void CustomBMSystem_BonusMapChallengeObjectives( int &iBronze, int &iSilver, int &iGold )
+{
+	g_CustomBonusMapSystem.CustomBonusMapChallengeObjectives( iBronze, iSilver, iGold );
+}
+
+#ifdef GAME_DLL
+void ResolveCustomBonusChallenge( CBasePlayer *pPlayer )
+{
+	g_CustomBonusMapSystem.ResolveCustomBonusChallenge( pPlayer );
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// Custom Bonus System Save/Restore
+//-----------------------------------------------------------------------------
+static short CUSTOM_BONUS_SAVE_RESTORE_VERSION = 1;
+
+class CCustomBonusSaveRestoreBlockHandler : public CDefSaveRestoreBlockHandler
+{
+public:
+	const char *GetBlockName()
+	{
+		return "CustomBonusMapSystem";
+	}
+
+	//---------------------------------
+
+	void Save( ISave *pSave )
+	{
+		// We only use this to save challenge info at the moment
+		bool bDoSave = g_CustomBonusMapSystem.BonusChallengesActive();
+
+		pSave->WriteBool( &bDoSave );
+		if ( bDoSave )
+		{
+			pSave->WriteAll( &g_CustomBonusMapSystem, g_CustomBonusMapSystem.GetDataDescMap() );
+		}
+	}
+
+	//---------------------------------
+
+	void WriteSaveHeaders( ISave *pSave )
+	{
+		pSave->WriteShort( &CUSTOM_BONUS_SAVE_RESTORE_VERSION );
+	}
+
+	//---------------------------------
+
+	void ReadRestoreHeaders( IRestore *pRestore )
+	{
+		// No reason why any future version shouldn't try to retain backward compatability. The default here is to not do so.
+		short version;
+		pRestore->ReadShort( &version );
+		m_fDoLoad = ( version == CUSTOM_BONUS_SAVE_RESTORE_VERSION );
+	}
+
+	//---------------------------------
+
+	void Restore( IRestore *pRestore, bool createPlayers )
+	{
+		if ( m_fDoLoad )
+		{
+			bool bDoRestore = false;
+
+			pRestore->ReadBool( &bDoRestore );
+			if ( bDoRestore )
+			{
+				pRestore->ReadAll( &g_CustomBonusMapSystem, g_CustomBonusMapSystem.GetDataDescMap() );
+			}
+		}
+	}
+
+private:
+	bool m_fDoLoad;
+};
+
+//-----------------------------------------------------------------------------
+
+CCustomBonusSaveRestoreBlockHandler g_CustomBonusSaveRestoreBlockHandler;
+
+//-------------------------------------
+
+ISaveRestoreBlockHandler *GetCustomBonusSaveRestoreBlockHandler()
+{
+	return &g_CustomBonusSaveRestoreBlockHandler;
+}
+#endif

--- a/sp/src/game/shared/point_bonusmaps_accessor.h
+++ b/sp/src/game/shared/point_bonusmaps_accessor.h
@@ -17,5 +17,9 @@ void BonusMapChallengeUpdate( const char *pchFileName, const char *pchMapName, c
 void BonusMapChallengeNames( char *pchFileName, char *pchMapName, char *pchChallengeName );
 void BonusMapChallengeObjectives( int &iBronze, int &iSilver, int &iGold );
 
+#ifdef MAPBASE
+void ResolveCustomBonusChallenge( CBasePlayer *pPlayer );
+#endif
+
 
 #endif		// POINT_BONUSMAPS_ACCESSOR_H


### PR DESCRIPTION
This branch adds bonus challenges to Entropy : Zero 2. It's based on a new Mapbase branch containing a bunch of fixes and enhancements for bonus maps and bonus challenges.

---

### Challenges in Portal

In **Portal**, "Challenge Maps" are a set of bonus maps which challenges players to complete test chambers from the original game under a certain countable condition, which may be *"Least Portals"*, *"Least Steps"*, or *"Least Time"*. Players may get Bronze, Silver, or Gold medals based on how well they did on the challenge *(e.g. how few portals they placed)*. Challenge Maps are unlocked after players complete the game and there are 3 achievements for players to get Bronze, Silver, or Gold medals respectively on each challenge in every map.

### Challenges in E:Z2

With this PR, challenges in E:Z2 work much the same way.

The following 5 challenges are available by default:

1. **Least Damage** — *Take as little damage as possible!*
2. **Least Bullets** — *Fire as few bullets as possible!*
     * Encourages more creative weaponry like SLAMs, frag/Xen grenades, energy balls, etc.
3. **Least Time** — *Reach the end of the level as quickly as possible!*
4. **Least Kills** — *Kill as few enemies as possible!*
     * Rebel surrender behavior comes in handy for this.
     * Kills from squadmates don't count, although soldiers don't last long without you, so this isn't as big of a deal as it sounds.
5. **Most Mass** — *Use Xen grenades to suck up as much mass from the level as possible!*
     * This *should* exclude Xen variants to avoid cheating by spawning and sucking up antlion guards over and over again, but it does not do this at the moment due to maps like the Xentarium not providing a clear distinction between Xen spawns and map enemies. This can be returned to later.

Additional VScript-driven challenges called "special challenges" can be defined by users for custom gameplay under the same framwork, possibly via workshop addons.

I've selected 8 maps which I thought were the easiest and most fun to add and play through challenges for:

1. `c2_2`
2. `c2_3`
3. `c4_2`
4. `c4_2a`
5. `c4_3a`
6. `c4_5b`
7. `c5_2a`
8. `c6_2`

This list is not final. 

Like in Portal, challenge maps are set to unlock as a post-game bonus by having a global_env script in the credits map which unlocks them when the map loads. The "Bonus Maps" button in the menu will automatically begin blinking after players are sent to the main menu/after players pause the game to get their attention until they open it.

---

#### In-Game

When a challenge begins, players are loaded into the selected map and given an indicator on the HUD using a number relevant to the current challenge, like the amount of damage taken. They must reach the end of the level with as high/low of a score as possible, depending on the challenge. Once they reach the end of the level, a mask cache interrupt screen appears (similar to the demo) and the results of the challenge are shown via auto-generated `game_text` messages.

If any of the following events occur, the challenge will be aborted and a similar screen will boot the player back to the menu:
1. The player enables cheats
2. The player changes the difficulty to a level other than Hard/Combine Elite
3. The player tries to backtrack to a previous level

Most of this logic is VScript-driven and not included in this PR.

---

Note that the challenge indicator HUD was originally used in Portal, but it stayed unused in the SDK and has been reactivated. Some changes have been made to make it more clear and useful in HL2, including showing the next valid medal, flashing when the value changes (or when getting close to a medal), and turning red when it's no longer possible to win a medal.

---

#### Draft Achievements

We could add achievements for these challenges in the same way Portal does, although they don't have to work in the exact same way. Portal just has achievements for getting bronze/silver/gold medals on every challenge in every map, but the code from the new Mapbase branch allows us to be more granular if needed. For example, we could have an achievement for getting gold medals on all "Most Mass" challenges.

I added some deactivated code which shows how achievements like this could be done. If we think they're worth adding, we can use or draw from that code at any time.
