### PR TITLE
Pulse Pistol fires configurable number of shots when charged; fires with a wider firing cone

### DIFF
--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -437,6 +437,7 @@ ConVar sk_plr_dmg_pulse_lance( "sk_plr_dmg_pulse_lance", "15" );
 ConVar sv_pulse_pistol_style( "sv_pulse_pistol_style", "0", FCVAR_NONE, "Style of pulse pistol altfire: 0) Default 1) Charge 2) Lance" );
 ConVar sv_pulse_lance_style( "sv_pulse_lance_style", "0", FCVAR_NONE, "Style of pulse lance: 0) Vortigaunt 1) Stalker" );
 ConVar sv_pulse_pistol_charge_per_extra_shot( "sv_pulse_pistol_charge_per_extra_shot", "5", FCVAR_NONE, "How many ammo charges equals one bullet" );
+ConVar sv_pulse_pistol_slide_return_charge( "sv_pulse_pistol_slide_return_charge", "10", FCVAR_NONE, "How much charge to restore when racking the slide on the pulse pistol" );
 
 //-----------------------------------------------------------------------------
 // CWeaponPulsePistol, the famous melee replacement taken to a separate class.
@@ -477,7 +478,7 @@ public:
 			1.0f );
 
 		// We lerp from very accurate to inaccurate over time
-		VectorLerp( VECTOR_CONE_4DEGREES, VECTOR_CONE_20DEGREES, ramp, cone );
+		VectorLerp( VECTOR_CONE_4DEGREES, VECTOR_CONE_15DEGREES, ramp, cone );
 
 		return cone;
 	}
@@ -640,7 +641,7 @@ void CWeaponPulsePistol::Operator_HandleAnimEvent( animevent_t * pEvent, CBaseCo
 	{
 	case AE_WPN_INCREMENTAMMO:
 	case AE_SLIDERETURN:
-		m_iClip1 = MAX( m_iClip1, 10 );
+		m_iClip1 = MAX( m_iClip1, sv_pulse_pistol_slide_return_charge.GetInt() );
 		WeaponSound( RELOAD, m_flNextPrimaryAttack );
 		break;
 	}
@@ -857,6 +858,13 @@ void CWeaponPulsePistol::PrimaryAttack( void )
 //-----------------------------------------------------------------------------
 void CWeaponPulsePistol::ChargeAttack( void )
 {
+	// Play the slide rack animation if we're trying to charge but have no ammo
+	if ( m_iClip1 <= 10 && m_nChargeAttackAmmo <= 0 ) {
+		if( m_flNextPrimaryAttack <= gpGlobals->curtime )
+			DryFire();
+		return;
+	}
+
 	int nMaxCharge = 40;
 	// If there is only one shot left or the charge has reached maximum, do not charge!
 	if (m_iClip1 <= 10 || m_nChargeAttackAmmo == nMaxCharge)

--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -423,7 +423,7 @@ void CWeaponPistol::AddViewKick( void )
 #ifdef EZ2
 #define	PULSE_PISTOL_FASTEST_REFIRE_TIME		0.4f
 #define	PULSE_PISTOL_FASTEST_DRY_REFIRE_TIME	1.5f
-#define	PULSE_PISTOL_ACCURACY_MAXIMUM_PENALTY_TIME	3.5f
+#define	PULSE_PISTOL_ACCURACY_MAXIMUM_PENALTY_TIME	10.0f
 
 enum PulsePistolStyle
 {
@@ -436,6 +436,7 @@ enum PulsePistolStyle
 ConVar sk_plr_dmg_pulse_lance( "sk_plr_dmg_pulse_lance", "15" );
 ConVar sv_pulse_pistol_style( "sv_pulse_pistol_style", "0", FCVAR_NONE, "Style of pulse pistol altfire: 0) Default 1) Charge 2) Lance" );
 ConVar sv_pulse_lance_style( "sv_pulse_lance_style", "0", FCVAR_NONE, "Style of pulse lance: 0) Vortigaunt 1) Stalker" );
+ConVar sv_pulse_pistol_charge_per_extra_shot( "sv_pulse_pistol_charge_per_extra_shot", "5", FCVAR_NONE, "How many ammo charges equals one bullet" );
 
 //-----------------------------------------------------------------------------
 // CWeaponPulsePistol, the famous melee replacement taken to a separate class.
@@ -469,22 +470,14 @@ public:
 
 		static Vector cone;
 
-		if (pistol_use_new_accuracy.GetBool())
-		{
-			float ramp = RemapValClamped( m_flAccuracyPenalty,
-				0.0f,
-				PULSE_PISTOL_ACCURACY_MAXIMUM_PENALTY_TIME,
-				0.0f,
-				1.0f );
+		float ramp = RemapValClamped( m_flAccuracyPenalty,
+			0.0f,
+			PULSE_PISTOL_ACCURACY_MAXIMUM_PENALTY_TIME,
+			0.0f,
+			1.0f );
 
-			// We lerp from very accurate to inaccurate over time
-			VectorLerp( VECTOR_CONE_1DEGREES, VECTOR_CONE_6DEGREES, ramp, cone );
-		}
-		else
-		{
-			// Old value
-			cone = VECTOR_CONE_4DEGREES;
-		}
+		// We lerp from very accurate to inaccurate over time
+		VectorLerp( VECTOR_CONE_4DEGREES, VECTOR_CONE_20DEGREES, ramp, cone );
 
 		return cone;
 	}
@@ -779,14 +772,23 @@ void CWeaponPulsePistol::PrimaryAttack( void )
 		int iBulletsToFire = 0;
 		float fireRate = GetFireRate();
 
+		int iExtraChargeBullets = m_nChargeAttackAmmo / sv_pulse_pistol_charge_per_extra_shot.GetInt();
+
+		// The pulse pistol fires one extra round per ten ammo charged
+		iBulletsToFire += iExtraChargeBullets;
+
+		if (iExtraChargeBullets > 0)
+		{
+			// Add the accuracy penalty for extra shots BEFORE firing to increase spread
+			m_flAccuracyPenalty += PISTOL_ACCURACY_SHOT_PENALTY_TIME * iExtraChargeBullets;
+		}
+
 		// MUST call sound before removing a round from the clip of a CHLMachineGun
 		while (m_flNextPrimaryAttack <= gpGlobals->curtime)
 		{
 			m_flNextPrimaryAttack = m_flNextPrimaryAttack + fireRate;
 			// Pulse pistol fires two bullets
 			iBulletsToFire += 2;
-			// The pulse pistol fires one extra round per ten ammo charged
-			iBulletsToFire += m_nChargeAttackAmmo / 10;
 
 			// If the shot is charged, play a special sound
 			if ( iBulletsToFire >= 4 )
@@ -814,8 +816,7 @@ void CWeaponPulsePistol::PrimaryAttack( void )
 		info.m_iShots = iBulletsToFire;
 		info.m_vecSrc = pPlayer->Weapon_ShootPosition();
 		info.m_vecDirShooting = pPlayer->GetAutoaimVector( AUTOAIM_SCALE_DEFAULT );
-		//info.m_vecSpread = pPlayer->GetAttackSpread(this);
-		info.m_vecSpread = VECTOR_CONE_1DEGREES;
+		info.m_vecSpread = pPlayer->GetAttackSpread(this);
 		info.m_flDistance = MAX_TRACE_LENGTH;
 		info.m_iAmmoType = m_iPrimaryAmmoType;
 		info.m_iTracerFreq = 1;
@@ -839,6 +840,9 @@ void CWeaponPulsePistol::PrimaryAttack( void )
 
 		// Register a muzzleflash for the AI
 		pPlayer->SetMuzzleFlashTime( gpGlobals->curtime + 0.5 );
+
+		// Add to the accuracy penalty just like standard pistol
+		m_flAccuracyPenalty += PISTOL_ACCURACY_SHOT_PENALTY_TIME;
 
 		m_iPrimaryAttacks++;
 		gamestats->Event_WeaponFired( pPlayer, true, GetClassname() );

--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -478,7 +478,7 @@ public:
 			1.0f );
 
 		// We lerp from very accurate to inaccurate over time
-		VectorLerp( VECTOR_CONE_4DEGREES, VECTOR_CONE_15DEGREES, ramp, cone );
+		VectorLerp( VECTOR_CONE_2DEGREES, VECTOR_CONE_15DEGREES, ramp, cone );
 
 		return cone;
 	}

--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -438,6 +438,8 @@ ConVar sv_pulse_pistol_style( "sv_pulse_pistol_style", "0", FCVAR_NONE, "Style o
 ConVar sv_pulse_lance_style( "sv_pulse_lance_style", "0", FCVAR_NONE, "Style of pulse lance: 0) Vortigaunt 1) Stalker" );
 ConVar sv_pulse_pistol_charge_per_extra_shot( "sv_pulse_pistol_charge_per_extra_shot", "5", FCVAR_NONE, "How many ammo charges equals one bullet" );
 ConVar sv_pulse_pistol_slide_return_charge( "sv_pulse_pistol_slide_return_charge", "10", FCVAR_NONE, "How much charge to restore when racking the slide on the pulse pistol" );
+ConVar sv_pulse_pistol_no_charge_hold( "sv_pulse_pistol_no_charge_hold", "0", FCVAR_NONE, "If 1, fully charged shots will fire automatically" );
+ConVar sv_pulse_pistol_max_charge( "sv_pulse_pistol_max_charge", "40", FCVAR_NONE, "Maximum ammo to charge in one shot. For a 50 charge pulse pistol, it should be 40" );
 
 //-----------------------------------------------------------------------------
 // CWeaponPulsePistol, the famous melee replacement taken to a separate class.
@@ -451,6 +453,7 @@ public:
 
 	void	Activate( void );
 	void	Precache();
+	bool	IsChargePressed( int chargeButton, CBasePlayer * pOwner );
 	void	ItemPostFrame( void );
 	void	PrimaryAttack( void );
 	void	SecondaryAttack();
@@ -555,6 +558,19 @@ void CWeaponPulsePistol::UpdateOnRemove( void )
 	BaseClass::UpdateOnRemove();
 }
 
+bool CWeaponPulsePistol::IsChargePressed( int chargeButton, CBasePlayer * pOwner )
+{
+	// If "no charge hold" is set, and we're at the maximum charge, treat it as though the player let go of the attack button
+	if (sv_pulse_pistol_no_charge_hold.GetBool() && m_nChargeAttackAmmo >= sv_pulse_pistol_max_charge.GetFloat())
+		return false;
+
+	// If "no charge hold" is set, we're out of ammo, but we have a charge, treat it as though the player let go of the attack button
+	if (sv_pulse_pistol_no_charge_hold.GetBool() && m_nChargeAttackAmmo > 0 && m_iClip1 <= 10)
+		return false;
+
+	return (pOwner->m_nButtons & chargeButton) > 0;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Recharge ammo before handling post-frame
 //-----------------------------------------------------------------------------
@@ -567,7 +583,7 @@ void CWeaponPulsePistol::ItemPostFrame( void )
 	switch ( sv_pulse_pistol_style.GetInt() )
 	{
 	case PRIMARY_CHARGE:
-		chargePressed = (pOwner->m_nButtons & IN_ATTACK) > 0;
+		chargePressed = IsChargePressed( IN_ATTACK, pOwner );
 		break;
 	case LANCE_NO_CHARGE:
 		break;
@@ -576,7 +592,7 @@ void CWeaponPulsePistol::ItemPostFrame( void )
 		DevMsg( "Select fire mode not implemented yet!\n" );
 		break;
 	default:
-		chargePressed = (pOwner->m_nButtons & IN_ATTACK2) > 0;
+		chargePressed = IsChargePressed( IN_ATTACK2, pOwner );
 		break;
 	}
 
@@ -685,7 +701,7 @@ bool CWeaponPulsePistol::Holster( CBaseCombatWeapon *pSwitchingTo )
 void CWeaponPulsePistol::RechargeAmmo( void )
 {
 	// If there is a fully charged shot waiting, don't recharge
-	if (m_nChargeAttackAmmo >= 40)
+	if (m_nChargeAttackAmmo >= sv_pulse_pistol_max_charge.GetFloat())
 	{
 		return;
 	}
@@ -804,7 +820,7 @@ void CWeaponPulsePistol::PrimaryAttack( void )
 		}
 
 		// Subtract the charge
-		m_iClip1 = m_iClip1 - 10;
+		m_iClip1 = MAX(m_iClip1 - 10, 1); // Never drop the charge below 1
 		m_nChargeAttackAmmo = 0;
 
 		m_iPrimaryAttacks++;
@@ -865,7 +881,7 @@ void CWeaponPulsePistol::ChargeAttack( void )
 		return;
 	}
 
-	int nMaxCharge = 40;
+	int nMaxCharge = sv_pulse_pistol_max_charge.GetFloat();
 	// If there is only one shot left or the charge has reached maximum, do not charge!
 	if (m_iClip1 <= 10 || m_nChargeAttackAmmo == nMaxCharge)
 	{
@@ -891,7 +907,7 @@ void CWeaponPulsePistol::ChargeAttack( void )
 	int nAmmoToAdd = (int)m_flChargeRemainder;
 	m_flChargeRemainder -= nAmmoToAdd;
 	m_nChargeAttackAmmo += nAmmoToAdd;
-	m_iClip1 -= nAmmoToAdd;
+	m_iClip1 = MAX( m_iClip1 - nAmmoToAdd, 1); // Never drop the charge below 1
 	if (m_nChargeAttackAmmo > nMaxCharge)
 	{
 		m_nChargeAttackAmmo = nMaxCharge;


### PR DESCRIPTION
We had some discussions about player feedback regarding the pulse pistol. It's a precarious situation because the weapon is sort of a fallback weapon, meant to be weaker than the rest of the arsenal. But it's also known to be unsatisfying to use, particularly with the charge function. To remedy this, two changes are being made to the game code.
1. The number of shots fired by the charge fire is configurable with a convar sv_pulse_pistol_charge_per_extra_shot.
2. The accuracy of the pulse pistol is lower and the spread widens with repeated shots. For charged shots, every additional shot increases the cone of fire. That means that fully charged shots fire more similarly to a shotgun.