### PR TITLE
EZ2 specific NPC features more configurable with keyvalues

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -12084,8 +12084,8 @@ BEGIN_DATADESC( CAI_BaseNPC )
 #ifdef EZ
 		DEFINE_KEYFIELD( m_tEzVariant,			FIELD_INTEGER, "ezvariant" ),
 		DEFINE_KEYFIELD( m_bNoGlow,				FIELD_BOOLEAN, "noglow" ),
+		DEFINE_KEYFIELD( m_bInvestigateSounds,	FIELD_BOOLEAN, "investigatesounds" ),
 #endif
-
 
 #ifdef MAPBASE
 	DEFINE_KEYFIELD( m_FriendlyFireOverride,	FIELD_INTEGER, "FriendlyFireOverride" ),

--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -1116,11 +1116,13 @@ public:
 	virtual float		HearingSensitivity( void )		{ return 1.0;	}
 	virtual bool		ShouldIgnoreSound( CSound * )	{ return false; }
 	bool				SoundIsVisible( CSound *pSound );
-	virtual bool		ShouldInvestigateSounds(void)	{ return false; }; // If true, this NPC will investigate sounds instead of facing them
+	virtual bool		ShouldInvestigateSounds(void)	{ return m_bInvestigateSounds; }; // If true, this NPC will investigate sounds instead of facing them
 
 protected:
 	virtual void		ClearSenseConditions( void );
 	
+	bool				m_bInvestigateSounds;
+
 private:
 	void				LockBestSound();
 	void				UnlockBestSound();

--- a/sp/src/game/server/hl2/npc_antlion.cpp
+++ b/sp/src/game/server/hl2/npc_antlion.cpp
@@ -196,6 +196,11 @@ CNPC_Antlion::CNPC_Antlion( void )
 	m_bForcedStuckJump = false;
 	m_nBodyBone = -1;
 	m_bSuppressUnburrowEffects = false;
+
+#ifdef EZ
+	// Antlions should investigate sounds in EZ2
+	m_bInvestigateSounds = true;
+#endif
 }
 
 LINK_ENTITY_TO_CLASS( npc_antlion, CNPC_Antlion );

--- a/sp/src/game/server/hl2/npc_antlion.h
+++ b/sp/src/game/server/hl2/npc_antlion.h
@@ -119,10 +119,6 @@ public:
 	bool		ShouldHearBugbait( void ) { return ( m_bIgnoreBugbait == false ); }
 	int			SelectSchedule( void );
 
-#ifdef EZ
-	bool		ShouldInvestigateSounds(void) { return true; } // 1upD - Antlions should investigate sounds in EZ2
-#endif
-
 	void		Touch( CBaseEntity *pOther );
 
 	virtual int		RangeAttack1Conditions( float flDot, float flDist );

--- a/sp/src/game/server/hl2/npc_citizen17.h
+++ b/sp/src/game/server/hl2/npc_citizen17.h
@@ -88,6 +88,9 @@ public:
 		, m_iWillpowerModifier( 0 )
 #endif
 	{
+#ifdef EZ2
+		m_bInvestigateSounds = true; // Rebels should investigate sounds
+#endif
 	}
 
 	//---------------------------------
@@ -166,10 +169,6 @@ public:
 	int				DrawDebugTextOverlays( void );
 
 	virtual const char *SelectRandomExpressionForState( NPC_STATE state );
-
-#ifdef EZ2
-	bool	ShouldInvestigateSounds(void) { return true; } // 1upD - Rebels should investigate sounds
-#endif // EZ2
 
 #ifdef EZ
 	// Blixibon - Lets citizens ignite from gas cans, etc.
@@ -356,6 +355,10 @@ public:
 	void			InputSetSurrenderFlags( inputdata_t &inputdata );
 	void			InputAddSurrenderFlags( inputdata_t &inputdata );
 	void			InputRemoveSurrenderFlags( inputdata_t &inputdata );
+	void			InputSetWillpowerModifier( inputdata_t &inputdata );
+	void			InputSetWillpowerDisabled( inputdata_t &inputdata );
+	void			InputSetSuppressiveFireDisabled( inputdata_t &inputdata );
+	void			InputForcePanic( inputdata_t &inputdata );
 #endif
 
 	//---------------------------------


### PR DESCRIPTION
Citizen willpower and suppressive fire are new features added to npc_citizen in EZ2. Additionally, some NPCs including citizens and antlions are set to always investigate combat sounds. These features need to be configurable by mappers in case there are situations in which it would benefit to not have citizens investigate sounds or fire on the players' position without directly attacking. Additionally, I have added an input to force citizens to panic. This will be useful in the final last stand scene and the cabin scene.