### PR TITLE
ai_playerally response concept TLK_SMELL has criteria

### DIFF
--- a/sp/src/game/server/ai_playerally.cpp
+++ b/sp/src/game/server/ai_playerally.cpp
@@ -739,10 +739,12 @@ bool CAI_PlayerAlly::SelectAlertSpeech( AISpeechSelection_t *pSelection )
 #endif
 
 #ifdef EZ2
+	CBaseEntity *pSmellTarget = FindSpeechTarget( AIST_PLAYERS | AIST_NPCS );
 	// NPCs can comment on smells in EZ2
-	if ( HasCondition( COND_SMELL ) && GetExpresser()->CanSpeakConcept( TLK_SMELL ) && SelectSpeechResponse( TLK_SMELL, NULL, this, pSelection ) )
+	if ( pSmellTarget && HasCondition( COND_SMELL ) && GetExpresser()->CanSpeakConcept( TLK_SMELL ) )
 	{
-		return true;
+		if( SelectSpeechResponse( TLK_SMELL, UTIL_VarArgs("distancetosmell:%f", GetAbsOrigin().DistTo( GetBestScent()->GetSoundReactOrigin() ) ), pSmellTarget, pSelection ) )
+			return true;
 	}
 #endif
 

--- a/sp/src/game/server/ai_playerally.cpp
+++ b/sp/src/game/server/ai_playerally.cpp
@@ -741,7 +741,7 @@ bool CAI_PlayerAlly::SelectAlertSpeech( AISpeechSelection_t *pSelection )
 #ifdef EZ2
 	CBaseEntity *pSmellTarget = FindSpeechTarget( AIST_PLAYERS | AIST_NPCS );
 	// NPCs can comment on smells in EZ2
-	if ( pSmellTarget && HasCondition( COND_SMELL ) && GetExpresser()->CanSpeakConcept( TLK_SMELL ) )
+	if ( pSmellTarget && HasCondition( COND_SMELL ) && GetBestScent() && GetExpresser() && GetExpresser()->CanSpeakConcept( TLK_SMELL ) )
 	{
 		if( SelectSpeechResponse( TLK_SMELL, UTIL_VarArgs("distancetosmell:%f", GetAbsOrigin().DistTo( GetBestScent()->GetSoundReactOrigin() ) ), pSmellTarget, pSelection ) )
 			return true;


### PR DESCRIPTION
Clearly the highest priority feature for EZ2: better smell reactions from NPCs.

Citizens and Vortigaunts have been commenting too frequently on smells. Smells tend to travel a very long distance so that bullsquids, pit drones, and other aliens can pick up on them. This PR adds a context to the smell response "distancetosmell" that will allow responses to filter for the relatively insensitive noses of sapient species.

It also ensures that a player ally NPC (which includes enemies in EZ2, namely vortigaunts and citizens) commenting on spells has a valid speech target.