### PR TITLE
Pit Drone doesn't spawn reinforcements immediately following creation from Xen

### DIFF
--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -452,13 +452,18 @@ extern int g_interactionXenGrenadeCreate;
 
 bool CNPC_PitDrone::HandleInteraction( int interactionType, void * data, CBaseCombatCharacter * sourceEnt )
 {
+	// First do the normal interaction handling, then Pit Drone exceptions
+	bool bReturn = BaseClass::HandleInteraction( interactionType, data, sourceEnt );
+	
+	// If the interaction is 'created by Xen grenade', change some of the properties set by default
 	if ( interactionType == g_interactionXenGrenadeCreate )
 	{
-		InputSetWanderAlways( inputdata_t() );
-		InputEnableSpawning( inputdata_t() );
+		SetReadyToSpawn( false ); // Not ready to call reinforcements yet
+		SetHungryTime( gpGlobals->curtime ); // Be ready to eat as soon as we come through
+		SetTimesFed( 0 ); // Not fed yet
 	}
-
-	return BaseClass::HandleInteraction( interactionType, data, sourceEnt );
+	
+	return bReturn;
 }
 
 //=========================================================


### PR DESCRIPTION
There was a bug found in Entropy : Zero 2 Beta 1.6.1 where Pit Drones would spawn infinite reinforcements if they were created from a creature crate or Xen grenade. This was because of a mistake in a previous change that led them to inherit interaction handling from basepredator.

This PR is a fix for that bug.