### PR TITLE
Combine squadmates have a rim glow colored based on their HP

### DIFF
--- a/sp/src/game/client/c_basecombatcharacter.cpp
+++ b/sp/src/game/client/c_basecombatcharacter.cpp
@@ -34,6 +34,10 @@ C_BaseCombatCharacter::C_BaseCombatCharacter()
 	m_pGlowEffect = NULL;
 	m_bGlowEnabled = false;
 	m_bOldGlowEnabled = false;
+	m_GlowColor.Init( 0.76f, 0.76f, 0.76f );
+	m_OldGlowColor = m_GlowColor;
+	m_GlowAlpha = 1.0f;
+	m_OldGlowAlpha = 1.0f;
 #endif // GLOWS_ENABLE
 }
 
@@ -66,6 +70,8 @@ void C_BaseCombatCharacter::OnPreDataChanged( DataUpdateType_t updateType )
 
 #ifdef GLOWS_ENABLE
 	m_bOldGlowEnabled = m_bGlowEnabled;
+	m_OldGlowColor = m_GlowColor;
+	m_OldGlowAlpha = m_GlowAlpha;
 #endif // GLOWS_ENABLE
 }
 
@@ -77,7 +83,7 @@ void C_BaseCombatCharacter::OnDataChanged( DataUpdateType_t updateType )
 	BaseClass::OnDataChanged( updateType );
 
 #ifdef GLOWS_ENABLE
-	if ( m_bOldGlowEnabled != m_bGlowEnabled )
+	if ( m_bOldGlowEnabled != m_bGlowEnabled || m_OldGlowColor != m_GlowColor || m_OldGlowAlpha != m_GlowAlpha )
 	{
 		UpdateGlowEffect();
 	}
@@ -106,11 +112,12 @@ void C_BaseCombatCharacter::DoMuzzleFlash()
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void C_BaseCombatCharacter::GetGlowEffectColor( float *r, float *g, float *b )
+void C_BaseCombatCharacter::GetGlowEffectColor( float *r, float *g, float *b, float *a )
 {
-	*r = 0.76f;
-	*g = 0.76f;
-	*b = 0.76f;
+	*r = m_GlowColor.x;
+	*g = m_GlowColor.y;
+	*b = m_GlowColor.z;
+	*a = m_GlowAlpha;
 }
 
 //-----------------------------------------------------------------------------
@@ -127,10 +134,10 @@ void C_BaseCombatCharacter::UpdateGlowEffect( void )
 	// create a new effect
 	if ( m_bGlowEnabled )
 	{
-		float r, g, b;
-		GetGlowEffectColor( &r, &g, &b );
+		float r, g, b, a;
+		GetGlowEffectColor( &r, &g, &b, &a );
 
-		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true );
+		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), a, true );
 	}
 }
 
@@ -161,6 +168,8 @@ BEGIN_RECV_TABLE(C_BaseCombatCharacter, DT_BaseCombatCharacter)
 	RecvPropArray3( RECVINFO_ARRAY(m_hMyWeapons), RecvPropEHandle( RECVINFO( m_hMyWeapons[0] ) ) ),
 #ifdef GLOWS_ENABLE
 	RecvPropBool( RECVINFO( m_bGlowEnabled ) ),
+	RecvPropVector( RECVINFO( m_GlowColor ) ),
+	RecvPropFloat( RECVINFO( m_GlowAlpha ) ),
 #endif // GLOWS_ENABLE
 
 #ifdef INVASION_CLIENT_DLL

--- a/sp/src/game/client/c_basecombatcharacter.h
+++ b/sp/src/game/client/c_basecombatcharacter.h
@@ -96,7 +96,7 @@ public:
 
 #ifdef GLOWS_ENABLE
 	CGlowObject			*GetGlowObject( void ){ return m_pGlowEffect; }
-	virtual void		GetGlowEffectColor( float *r, float *g, float *b );
+	virtual void		GetGlowEffectColor( float *r, float *g, float *b, float *a );
 #endif // GLOWS_ENABLE
 
 public:
@@ -124,6 +124,10 @@ private:
 	bool				m_bGlowEnabled;
 	bool				m_bOldGlowEnabled;
 	CGlowObject			*m_pGlowEffect;
+	Vector				m_GlowColor;
+	Vector				m_OldGlowColor;
+	float				m_GlowAlpha;
+	int					m_OldGlowAlpha;
 #endif // GLOWS_ENABLE
 
 private:

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -293,6 +293,8 @@ END_SEND_TABLE();
 IMPLEMENT_SERVERCLASS_ST(CBaseCombatCharacter, DT_BaseCombatCharacter)
 #ifdef GLOWS_ENABLE
 	SendPropBool( SENDINFO( m_bGlowEnabled ) ),
+	SendPropVector( SENDINFO( m_GlowColor ), 8, 0, 0, 1 ),
+	SendPropFloat( SENDINFO( m_GlowAlpha ) ),
 #endif // GLOWS_ENABLE
 	// Data that only gets sent to the local player.
 	SendPropDataTable( "bcc_localdata", 0, &REFERENCE_SEND_TABLE(DT_BCCLocalPlayerExclusive), SendProxy_SendBaseCombatCharacterLocalDataTable ),
@@ -887,6 +889,8 @@ CBaseCombatCharacter::CBaseCombatCharacter( void )
 
 #ifdef GLOWS_ENABLE
 	m_bGlowEnabled.Set( false );
+	m_GlowColor.GetForModify().Init( 0.76f, 0.76f, 0.76f );
+	m_GlowAlpha.Set(1.0f);
 #endif // GLOWS_ENABLE
 }
 
@@ -4130,6 +4134,12 @@ void CBaseCombatCharacter::RemoveGlowEffect( void )
 bool CBaseCombatCharacter::IsGlowEffectActive( void )
 {
 	return m_bGlowEnabled;
+}
+
+void CBaseCombatCharacter::SetGlowColor( float red, float green, float blue, float alpha )
+{
+	m_GlowColor.GetForModify().Init( red, green, blue );
+	m_GlowAlpha.Set( alpha );
 }
 #endif // GLOWS_ENABLE
 

--- a/sp/src/game/server/basecombatcharacter.h
+++ b/sp/src/game/server/basecombatcharacter.h
@@ -533,6 +533,7 @@ public:
 	void				AddGlowEffect( void );
 	void				RemoveGlowEffect( void );
 	bool				IsGlowEffectActive( void );
+	void				SetGlowColor( float red, float green, float blue, float alpha );
 #endif // GLOWS_ENABLE
 
 #ifdef INVASION_DLL
@@ -577,6 +578,8 @@ public:
 #ifdef GLOWS_ENABLE
 protected:
 	CNetworkVar( bool, m_bGlowEnabled );
+	CNetworkVector( m_GlowColor );
+	CNetworkVar( float, m_GlowAlpha );
 #endif // GLOWS_ENABLE
 
 private:
@@ -584,7 +587,6 @@ private:
 
 	void				UpdateGlowEffect( void );
 	void				DestroyGlowEffect( void );
-
 protected:
 	int			m_bloodColor;			// color of blood particless
 

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -64,6 +64,13 @@ ConVar npc_combine_new_cover_behavior( "npc_combine_new_cover_behavior", "1", FC
 ConVar npc_combine_give_enabled( "npc_combine_give_enabled", "1", FCVAR_NONE, "Allows players to \"give\" weapons to Combine soldiers in their squad by holding one in front of them for a few seconds." );
 ConVar npc_combine_give_stare_dist( "npc_combine_give_stare_dist", "112", FCVAR_NONE, "The distance needed for soldiers to consider the possibility the player wants to give them a weapon." );
 ConVar npc_combine_give_stare_time( "npc_combine_give_stare_time", "1", FCVAR_NONE, "The amount of time the player needs to be staring at a soldier in order for them to pick up a weapon they're holding." );
+
+ConVar	sv_squadmate_glow( "sv_squadmate_glow", "1", FCVAR_REPLICATED, "If 1, Combine soldier squadmates will glow when they are in the player's squad. The color of the glow represents their HP." );
+ConVar	sv_squadmate_glow_style( "sv_squadmate_glow_style", "1", FCVAR_REPLICATED, "Different colors for Combine squadmate glows. 0: Green means 100 HP, red means 0 HP\t1: White means 100 HP, red means 0 HP");
+ConVar	sv_squadmate_glow_alpha( "sv_squadmate_glow_alpha", "0.6", FCVAR_REPLICATED, "On a scale of 0-1, how much alpha should the squadmate glow have" );
+
+#define COMBINE_GLOW_STYLE_REDGREEN	0
+#define COMBINE_GLOW_STYLE_REDWHITE	1
 #endif
 
 #define COMBINE_SKIN_DEFAULT		0
@@ -659,6 +666,44 @@ void CNPC_Combine::FixupPlayerSquad()
 	m_bHoldPositionGoal = false;
 
 	ToggleSquadCommand();
+
+	UpdateSquadGlow();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Update glow effects on this soldier
+//-----------------------------------------------------------------------------
+void CNPC_Combine::UpdateSquadGlow()
+{
+	if ( m_bGlowEnabled )
+		RemoveGlowEffect();
+
+	if( sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad())
+	{
+		float healthPercentage = ((float)m_iHealth / ((float)m_iMaxHealth));
+
+		float red = 0;
+		float blue = 0;
+		float green = 0;
+
+		switch (sv_squadmate_glow_style.GetInt()) 
+		{
+		case COMBINE_GLOW_STYLE_REDGREEN:
+			red = 1.0f - healthPercentage;
+			green = healthPercentage;
+			blue = 0.0f;
+			break;
+		case COMBINE_GLOW_STYLE_REDWHITE:
+			red = 1.0f;
+			green = healthPercentage;
+			blue = healthPercentage;
+			break;
+		}
+
+		DevMsg( "%s - CNPC_Combine::UpdateSquadGlow() - r:%f\tg:%f\tb:%f\ta:%f\n", GetDebugName(), red, green, blue, sv_squadmate_glow_alpha.GetFloat() );
+		SetGlowColor( red, green, blue, sv_squadmate_glow_alpha.GetFloat() );
+		AddGlowEffect();
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -720,6 +765,8 @@ void CNPC_Combine::RemoveFromPlayerSquad()
 	{
 		SetCommandGoal( vec3_invalid );
 	}
+
+	UpdateSquadGlow();
 }
 
 //-----------------------------------------------------------------------------
@@ -2545,6 +2592,14 @@ bool CNPC_Combine::PassesDamageFilter( const CTakeDamageInfo &info )
 
 	return BaseClass::PassesDamageFilter(info);
 }
+
+// Overridden to update glow effects when taking damage
+int CNPC_Combine::OnTakeDamage_Alive( const CTakeDamageInfo & info )
+{
+	int ret = BaseClass::OnTakeDamage_Alive(info);
+	UpdateSquadGlow();
+	return ret;
+}
 #endif
 
 //-----------------------------------------------------------------------------
@@ -4334,6 +4389,9 @@ void CNPC_Combine::PainSound ( void )
 //=========================================================
 void CNPC_Combine::RegenSound()
 {
+	// Putting this here for convenience - every time we test regen sound, also check the glow
+	UpdateSquadGlow();
+
 	// Don't call out regeneration immediately after taking damage 
 	if (gpGlobals->curtime <= m_flNextPainSoundTime)
 	{

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -675,10 +675,17 @@ void CNPC_Combine::FixupPlayerSquad()
 //-----------------------------------------------------------------------------
 void CNPC_Combine::UpdateSquadGlow()
 {
-	if ( m_bGlowEnabled )
+	bool shouldGlow = sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad();
+	if ( !m_bGlowEnabled.Get() && shouldGlow )
+	{
+		AddGlowEffect();
+	}
+	else if ( m_bGlowEnabled.Get() && !shouldGlow )
+	{
 		RemoveGlowEffect();
+	}
 
-	if( sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad())
+	if ( m_bGlowEnabled.Get() )
 	{
 		float healthPercentage = ((float)m_iHealth / ((float)m_iMaxHealth));
 
@@ -686,7 +693,7 @@ void CNPC_Combine::UpdateSquadGlow()
 		float blue = 0;
 		float green = 0;
 
-		switch (sv_squadmate_glow_style.GetInt()) 
+		switch (sv_squadmate_glow_style.GetInt())
 		{
 		case COMBINE_GLOW_STYLE_REDGREEN:
 			red = 1.0f - healthPercentage;
@@ -700,9 +707,7 @@ void CNPC_Combine::UpdateSquadGlow()
 			break;
 		}
 
-		DevMsg( "%s - CNPC_Combine::UpdateSquadGlow() - r:%f\tg:%f\tb:%f\ta:%f\n", GetDebugName(), red, green, blue, sv_squadmate_glow_alpha.GetFloat() );
 		SetGlowColor( red, green, blue, sv_squadmate_glow_alpha.GetFloat() );
-		AddGlowEffect();
 	}
 }
 
@@ -1503,6 +1508,13 @@ void CNPC_Combine::PrescheduleThink()
 #ifdef EZ
 	// 1upD - Copied from citizen
 	UpdateFollowCommandPoint();
+
+
+	// Update glow if we are commandable
+	if ( sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad() && ( !m_bGlowEnabled.Get() || ( GetHealth() < GetMaxHealth() && ShouldRegenerateHealth() ) ) )
+	{
+		UpdateSquadGlow();
+	}
 #endif
 
 	// Speak any queued sentences
@@ -4389,9 +4401,6 @@ void CNPC_Combine::PainSound ( void )
 //=========================================================
 void CNPC_Combine::RegenSound()
 {
-	// Putting this here for convenience - every time we test regen sound, also check the glow
-	UpdateSquadGlow();
-
 	// Don't call out regeneration immediately after taking damage 
 	if (gpGlobals->curtime <= m_flNextPainSoundTime)
 	{

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -671,11 +671,11 @@ void CNPC_Combine::FixupPlayerSquad()
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: Update glow effects on this soldier
+// Purpose: Add or remove glow effects as necessary, then update the color
 //-----------------------------------------------------------------------------
 void CNPC_Combine::UpdateSquadGlow()
 {
-	bool shouldGlow = sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad();
+	bool shouldGlow = ShouldSquadGlow();
 	if ( !m_bGlowEnabled.Get() && shouldGlow )
 	{
 		AddGlowEffect();
@@ -709,6 +709,11 @@ void CNPC_Combine::UpdateSquadGlow()
 
 		SetGlowColor( red, green, blue, sv_squadmate_glow_alpha.GetFloat() );
 	}
+}
+
+bool CNPC_Combine::ShouldSquadGlow()
+{
+	return sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad();
 }
 
 //-----------------------------------------------------------------------------
@@ -1511,7 +1516,7 @@ void CNPC_Combine::PrescheduleThink()
 
 
 	// Update glow if we are commandable
-	if ( sv_squadmate_glow.GetBool() && IsCommandable() && IsInPlayerSquad() && ( !m_bGlowEnabled.Get() || ( GetHealth() < GetMaxHealth() && ShouldRegenerateHealth() ) ) )
+	if ( ShouldSquadGlow() && ( !m_bGlowEnabled.Get() || ( GetHealth() < GetMaxHealth() && ShouldRegenerateHealth() ) ) )
 	{
 		UpdateSquadGlow();
 	}

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -102,6 +102,7 @@ public:
 	void Event_KilledOther( CBaseEntity *pVictim, const CTakeDamageInfo &info );
 
 	virtual bool	PassesDamageFilter( const CTakeDamageInfo &info );
+	virtual int 	OnTakeDamage_Alive( const CTakeDamageInfo &info );
 #endif
 
 	void SetActivity( Activity NewActivity );
@@ -162,6 +163,7 @@ public:
 	virtual void	AddToPlayerSquad();
 	virtual void	RemoveFromPlayerSquad();
 	virtual void	FixupPlayerSquad();
+	virtual void	UpdateSquadGlow();
 	virtual bool	ShouldRegenerateHealth(void);
 	virtual void	UpdateFollowCommandPoint();
 	virtual bool	IsFollowingCommandPoint();

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -164,6 +164,7 @@ public:
 	virtual void	RemoveFromPlayerSquad();
 	virtual void	FixupPlayerSquad();
 	virtual void	UpdateSquadGlow();
+	virtual bool    ShouldSquadGlow();
 	virtual bool	ShouldRegenerateHealth(void);
 	virtual void	UpdateFollowCommandPoint();
 	virtual bool	IsFollowingCommandPoint();


### PR DESCRIPTION
Players have had a lot of difficulty telling which soldiers are or are not in their squad. Additionally, the player is not given any state information (particularly HP) about their squadmates in combat. Finally, you can't tell where a squadmate is if they are occluded by the environment.

This PR adds a glow to Combine soldiers in the player's squad. It will glow with a color based on the squadmate's health. This way players will be able to tell who is or isn't in their squad, and where the squad is at all times.

Known issues: Sometimes squad glow doesn't apply immediately after going through a level transition. Still investigating.