### PR TITLE
New animations, choreo support, behavior, etc. for the advisor NPC

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -9846,6 +9846,21 @@ void CAI_BaseNPC::HandleAnimEvent( animevent_t *pEvent )
 			}
 			else if ( pEvent->event == AE_NPC_RAGDOLL )
 			{
+#ifdef EZ
+				// Drop a serverside ragdoll instead if needed
+				if ( m_bForceServerRagdoll == true )
+				{
+					if ( CanBecomeServerRagdoll() == false )
+						return;
+
+					CBaseEntity *pRagdoll = CreateServerRagdoll( this, m_nForceBone, CTakeDamageInfo(), COLLISION_GROUP_INTERACTIVE_DEBRIS, true );
+					FixupBurningServerRagdoll( pRagdoll );
+					m_hDeathRagdoll = pRagdoll;
+					RemoveDeferred();
+					return;
+				}
+#endif
+
 				// Convert to ragdoll immediately
 				BecomeRagdollOnClient( vec3_origin );
 				return;

--- a/sp/src/game/server/episodic/npc_advisor.cpp
+++ b/sp/src/game/server/episodic/npc_advisor.cpp
@@ -41,6 +41,11 @@
 #ifdef EZ2
 #include "grenade_hopwire.h"
 #include "npc_scanner.h"
+#include "bone_setup.h"
+#include "npc_turret_floor.h"
+#include "IEffects.h"
+#include "collisionutils.h"
+#include "scripted.h"
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -63,6 +68,7 @@ ConVar sk_advisor_pin_speed( "sk_advisor_pin_speed", "32" );
 ConVar sk_advisor_pin_throw_cooldown( "sk_advisor_pin_throw_cooldown", "3" );
 
 // Think contexts
+static const char * ADVISOR_FLY_THINK = "FlyThink";
 static const char * ADVISOR_PARTICLE_THINK = "AdvisorParticle";
 #endif
 
@@ -81,6 +87,32 @@ ConVar advisor_throw_max_mass( "advisor_throw_max_mass", "220" );
 #ifdef EZ2
 ConVar advisor_throw_stage_min_mass( "advisor_throw_stage_min_mass", "20" );
 ConVar advisor_throw_stage_max_mass( "advisor_throw_stage_max_mass", "220" );
+
+ConVar advisor_head_debounce( "advisor_head_debounce", "0.7" );
+ConVar advisor_camera_influence( "advisor_camera_influence", "1.0" );
+ConVar advisor_camera_debounce( "advisor_camera_debounce", "0.2" );
+
+ConVar advisor_use_facing_override( "advisor_use_facing_override", "1" );
+ConVar advisor_use_flyer_poses( "advisor_use_flyer_poses", "1" );
+ConVar advisor_update_yaw( "advisor_update_yaw", "1" );
+
+ConVar advisor_hurt_pose( "advisor_hurt_pose", "0" );
+ConVar advisor_camera_flash_health_ratio( "advisor_camera_flash_health_ratio", "0.35" );
+//ConVar advisor_bleed_health_ratio( "advisor_bleed_health_ratio", "0.25" );
+
+ConVar advisor_sparks_health_ratio_max( "advisor_sparks_health_ratio_max", "0.5" );
+ConVar advisor_sparks_health_ratio_min( "advisor_sparks_health_ratio_min", "0.1" );
+
+//ConVar advisor_push_max_radius( "advisor_push_max_radius", "224.0" );
+//ConVar advisor_push_delta( "advisor_push_delta", "4.0" );
+//ConVar advisor_push_max_force_scale( "advisor_push_max_force_scale", "0.1" );
+
+Activity ACT_ADVISOR_OBJECT_R_HOLD;
+Activity ACT_ADVISOR_OBJECT_R_THROW;
+Activity ACT_ADVISOR_OBJECT_L_HOLD;
+Activity ACT_ADVISOR_OBJECT_L_THROW;
+Activity ACT_ADVISOR_OBJECT_BOTH_HOLD;
+Activity ACT_ADVISOR_OBJECT_BOTH_THROW;
 #endif
 
 // how long it will take an object to get hauled to the staging point
@@ -98,6 +130,11 @@ ConVar advisor_throw_stage_max_mass( "advisor_throw_stage_max_mass", "220" );
 //
 #define ADVISOR_MELEE_LEFT					( 3 )
 #define ADVISOR_MELEE_RIGHT					( 4 )
+
+#ifdef EZ2
+int ADVISOR_AE_DETACH_R_ARM;
+int ADVISOR_AE_DETACH_L_ARM;
+#endif
 
 // Skins
 #ifdef EZ2
@@ -117,6 +154,7 @@ enum
 	SCHED_ADVISOR_TOSS_PLAYER,
 #ifdef EZ2
 	SCHED_ADVISOR_STAGGER,
+	SCHED_ADVISOR_MELEE_ATTACK1,
 #endif
 };
 
@@ -135,6 +173,8 @@ enum
 
 #ifdef EZ2
 	TASK_ADVISOR_STAGGER,
+
+	TASK_ADVISOR_WAIT_FOR_ACTIVITY,
 #endif
 };
 
@@ -201,6 +241,14 @@ public:
 
 	bool	UpdateEnemyMemory( CBaseEntity *pEnemy, const Vector &position, CBaseEntity *pInformer = NULL );
 
+	virtual void StartTask( const Task_t *pTask );
+
+	float	GetGoalDistance( void );
+	float	MinGroundDist( void );
+
+	Vector		VelocityToAvoidObstacles( float flInterval );
+	void		MoveExecute_Alive( float flInterval );
+
 	// The Advisor flyer isn't a real enemy
 	bool		CanBeAnEnemyOf( CBaseEntity *pEnemy ) { return false; }
 	bool		CanBeSeenBy( CAI_BaseNPC *pNPC ) { return false; }
@@ -213,7 +261,6 @@ public:
 
 	virtual char		*GetEngineSound( void ) { return "NPC_AdvisorFlyer.FlyLoop"; }
 	virtual char		*GetScannerSoundPrefix( void ) { return "NPC_AdvisorFlyer"; }
-
 };
 
 void CNPC_AdvisorFlyer::Spawn( void )
@@ -224,6 +271,11 @@ void CNPC_AdvisorFlyer::Spawn( void )
 	AddEffects( EF_NOSHADOW );
 	SetHullType( HULL_LARGE_CENTERED );
 	SetHullSizeNormal();
+
+	if (GetOwnerEntity())
+	{
+		SetMass( GetOwnerEntity()->GetMass() );
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -254,6 +306,10 @@ Disposition_t CNPC_AdvisorFlyer::IRelationType( CBaseEntity * pTarget )
 		CAI_BaseNPC * pNPC = GetOwnerEntity()->MyNPCPointer();
 		if ( pNPC )
 		{
+			// Ignore targets which are not my advisor's enemy
+			if ( pTarget && pNPC->GetEnemy() != pTarget )
+				return D_NU;
+
 			return pNPC->IRelationType( pTarget );
 		}
 	}
@@ -278,7 +334,260 @@ bool CNPC_AdvisorFlyer::UpdateEnemyMemory( CBaseEntity *pEnemy, const Vector &po
 	return false;
 }
 
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+void CNPC_AdvisorFlyer::StartTask( const Task_t *pTask )
+{
+	switch ( pTask->iTask )
+	{
+		// Advisor flyers do not dive bomb
+		case TASK_SCANNER_SET_FLY_DIVE:
+			TaskComplete();
+			break;
+
+		default:
+		{
+			BaseClass::StartTask( pTask );
+		}
+	}
+}
+
+extern void GetAvoidanceForcesForAdvisor( Vector &vecOutForce, CBaseEntity *pEntity, float flEntityRadius, float flAvoidTime );
+
+//------------------------------------------------------------------------------
+// Purpose :
+// Input   :
+// Output  :
+//------------------------------------------------------------------------------
+Vector CNPC_AdvisorFlyer::VelocityToAvoidObstacles(float flInterval)
+{
+	if (!GetOwnerEntity())
+		return BaseClass::VelocityToAvoidObstacles( flInterval );
+
+	Vector vBounce = vec3_origin;
+
+	GetAvoidanceForcesForAdvisor( vBounce, this, GetOwnerEntity()->BoundingRadius() * 2.0f, flInterval );
+
+	// --------------------------------
+	//  Avoid banging into stuff
+	// --------------------------------
+	trace_t tr;
+	Vector vTravelDir = m_vCurrentVelocity*flInterval*4.0f;
+	Vector endPos = GetAbsOrigin() + vTravelDir;
+	AI_TraceEntity( GetOwnerEntity(), GetAbsOrigin(), endPos, MASK_NPCSOLID|CONTENTS_WATER, &tr);
+	if (tr.fraction != 1.0)
+	{	
+		// Bounce off in normal 
+		vBounce += tr.plane.normal * 0.5 * m_vCurrentVelocity.Length();
+		return (vBounce);
+	}
+	
+	// --------------------------------
+	// Try to remain above the ground.
+	// --------------------------------
+	float flMinGroundDist = MinGroundDist();
+	AI_TraceLine( GetAbsOrigin(), GetAbsOrigin() + Vector(0, 0, -flMinGroundDist),
+		MASK_NPCSOLID_BRUSHONLY|CONTENTS_WATER, this, COLLISION_GROUP_NONE, &tr);
+	if (tr.fraction < 1)
+	{
+		// Clamp veloctiy
+		if (tr.fraction < 0.1)
+		{
+			tr.fraction = 0.1;
+		}
+
+		vBounce += Vector(0, 0, 50/tr.fraction);
+	}
+
+	return vBounce;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+void CNPC_AdvisorFlyer::MoveExecute_Alive(float flInterval)
+{
+	// Amount of noise to add to flying
+	float noiseScale = 3.0f;
+
+	// -------------------------------------------
+	//  Avoid obstacles
+	// -------------------------------------------
+	SetCurrentVelocity( GetCurrentVelocity() + VelocityToAvoidObstacles(flInterval) );
+
+	IPhysicsObject *pPhysics = VPhysicsGetObject();
+
+	if ( pPhysics && pPhysics->IsAsleep() )
+	{
+		pPhysics->Wake();
+	}
+
+	if (GetOwnerEntity() && GetOwnerEntity()->MyNPCPointer())
+	{
+		Vector vecDir;
+		AngleVectors( GetAbsAngles(), &vecDir );
+		float flYaw = UTIL_VecToYaw( vecDir );
+
+		if (GetOwnerEntity()->MyNPCPointer()->GetMotor()->GetIdealYaw() != flYaw)
+		{
+			// Ideal yaw is sometimes used by the advisor's base AI functions, like melee attacks
+			// Make sure the flyer matches this
+			m_fHeadYaw = flYaw;
+		}
+	}
+
+	// Add time-coherent noise to the current velocity so that it never looks bolted in place.
+	AddNoiseToVelocity( noiseScale );
+
+	AdjustScannerVelocity();
+
+	float maxSpeed = GetEnemy() ? ( GetMaxSpeed() * 2.0f ) : GetMaxSpeed();
+	if ( m_nFlyMode == SCANNER_FLY_DIVE )
+	{
+		maxSpeed = -1;
+	}
+
+	// Limit fall speed
+	LimitSpeed( maxSpeed );
+
+	// Blend out desired velocity when launched by the physcannon
+	BlendPhyscannonLaunchSpeed();
+
+	PlayFlySound();
+}
+
 LINK_ENTITY_TO_CLASS( npc_advisor_flyer, CNPC_AdvisorFlyer );
+
+//-----------------------------------------------------------------------------
+//
+// Purpose: A unique motor for the advisor which allows it to rotate on a full XYZ axis.
+//			It also sets angular velocity instead of setting angles, which is much smoother for its movetype.
+//
+//-----------------------------------------------------------------------------
+class CAI_AdvisorMotor : public CAI_BlendedMotor
+{
+public:
+	CAI_AdvisorMotor( CAI_BaseNPC *pOuter )
+		: CAI_BlendedMotor( pOuter )
+	{}
+
+	// Run the current or specified timestep worth of rotation
+	virtual	void		UpdateYaw( int speed = -1 );
+
+	void 				SetIdealYawAndPitchToTarget( const Vector &target, float noise = 0.0, float offset = 0.0 );
+	
+	float 				GetIdealPitch() const					{ return m_IdealPitch; 	}
+	void 				SetIdealPitch( float idealYaw)		{ m_IdealPitch = idealYaw; 	}
+
+	float				GetPitchSpeed() const;
+	
+	CNPC_Advisor			*GetAdvisorOuter();
+	const CNPC_Advisor		*GetAdvisorOuter() const;
+	CNPC_AdvisorFlyer		*GetAdvisorFlyer();
+	const CNPC_AdvisorFlyer	*GetAdvisorFlyer() const;
+
+private:
+	float				m_IdealPitch;	// TODO: Save this value?
+};
+
+void CAI_AdvisorMotor::UpdateYaw( int yawSpeed )
+{
+	// Don't do this if we're locked
+	if ( IsYawLocked() )
+		return;
+
+	// Advisors are designed to face the enemy outside of regular AI facing tasks.
+	// However, if the yaw is updated during a facing task, this could result in the yaw being updated
+	// multiple times per think, which causes jittering.
+	// Under these circumstances, GetLastThink() usually returns as being greater than curtime.
+	if (gpGlobals->curtime < GetLastThink())
+		return;
+
+	GetOuter()->UpdateTurnGesture( );
+
+	GetOuter()->SetUpdatedYaw();
+	
+	if ( yawSpeed == -1 )
+		yawSpeed = GetYawSpeed();
+
+	int pitchSpeed = GetPitchSpeed();
+
+	// We would normally use UTIL_AngleMod(), but this causes problems when we bring other dimensions into play.
+	// There's most likely a specific way of using it which would work, but for now, we can do without it.
+
+	QAngle ideal;
+	QAngle current;
+
+	QAngle angles = GetLocalAngles();
+	current[0] = angles.x; // UTIL_AngleMod
+	current[1] = angles.y; // UTIL_AngleMod
+	current[2] = angles.z; // UTIL_AngleMod
+
+	ideal[0] = GetIdealPitch(); // UTIL_AngleMod
+	ideal[1] = GetIdealYaw(); // UTIL_AngleMod
+
+	// Base the roll on how quickly we're changing our yaw
+	CNPC_AdvisorFlyer *pFlyer = GetAdvisorFlyer();
+	ideal[2] = -AngleDistance( ideal[1], current[1] ) * (pFlyer ? 1.0f : 0.5f);
+
+	float dt = MIN( 0.2, gpGlobals->curtime - GetLastThink() );
+
+	for (int i = 0; i < 3; i++)
+	{
+		// We're setting angular velocity, so don't clamp yaw
+		//float newAng = AI_ClampYaw( (float)yawSpeed * 10.0, current[i], ideal[i], dt );
+
+		if (ideal[i] != current[i])
+		{
+			float speed;
+			switch (i)
+			{
+				// Pitch/Roll
+				case 0:
+				case 2: speed = (float)pitchSpeed * dt; break;
+
+				// Yaw
+				default:
+				case 1: speed = (float)yawSpeed * dt; break;
+			}
+
+			speed *= 10.0f;
+
+			float move = AngleDiff( ideal[i], current[i] );
+
+			angles[i] = move;
+
+			//if (i == 1)
+			//	Msg( "Yaw changed: newAng %f, current %f, ideal %f, dt %f, yawSpeed %i\n", angles[i], current[i], ideal[i], dt, yawSpeed );
+			//else if (i == 0)
+			//	Msg( "Pitch changed: newAng %f, current %f, ideal %f, dt %f, pitchSpeed %i\n", angles[i], current[i], ideal[i], dt, pitchSpeed );
+		}
+	}
+	
+	// MOVETYPE_FLY doesn't interpolate angle changes, so we must change its velocity instead
+	float flAdvisorRotateSpeed = pFlyer ? 5.0f : 2.0f;
+	GetOuter()->SetLocalAngularVelocity( angles * flAdvisorRotateSpeed );
+}
+
+//-----------------------------------------------------------------------------
+
+void CAI_AdvisorMotor::SetIdealYawAndPitchToTarget( const Vector &target, float noise, float offset )
+{ 
+	float base = CalcIdealYaw( target );
+	float baseP = UTIL_VecToPitch( target - GetLocalOrigin() ) * 0.75f;
+	base += offset;
+	if ( noise > 0 )
+	{
+		noise *= 0.5;
+		base += random->RandomFloat( -noise, noise );
+		if ( base < 0 )
+			base += 360;
+		else if ( base >= 360 )
+			base -= 360;
+	}
+	SetIdealYaw( base );
+	SetIdealPitch( baseP );
+}
 #endif
 
 //-----------------------------------------------------------------------------
@@ -306,19 +615,102 @@ public:
 	virtual int DrawDebugTextOverlays();
 
 #ifdef EZ2
+	virtual void		SetModel( const char *szModelName );
+	
+	virtual CSprite		*GetGlowSpritePtr( int i );
+	virtual void		SetGlowSpritePtr( int i, CSprite *sprite );
+	virtual EyeGlow_t	*GetEyeGlowData( int i );
+	virtual int			GetNumGlows() { return 2; }
+
+	//-----------------------------------------------------------------------------
+
+	enum AdvisorEyeState_t
+	{
+		ADVISOR_EYE_NORMAL,		// Regular cyan
+		ADVISOR_EYE_CHARGE,		// Turn yellow
+
+		// Eye "flags" (not real flags; can be turned into real flags if needed)
+		ADVISOR_EYE_DAMAGED,	// Start flashing
+		ADVISOR_EYE_UNDAMAGED,	// Stop flashing
+	};
+
+	void				SetEyeState( AdvisorEyeState_t state );
+
+	//-----------------------------------------------------------------------------
+
 	virtual bool		GetGameTextSpeechParams( hudtextparms_t &params );
+	virtual	float		GetHeadDebounce( void ); // how much of previous head turn to use
+	virtual void		MaintainLookTargets( float flInterval );
+
+	//-----------------------------------------------------------------------------
+
+	CBaseEntity *GetFollowTarget() { return m_hFollowTarget; }
+	
+	const CNPC_AdvisorFlyer		*GetAdvisorFlyer() const { return static_cast<const CNPC_AdvisorFlyer*>(m_hAdvisorFlyer.Get()); }
+	CNPC_AdvisorFlyer			*GetAdvisorFlyer()		 { return static_cast<CNPC_AdvisorFlyer*>(m_hAdvisorFlyer.Get()); }
+	
+	const CAI_AdvisorMotor *GetAdvisorMotor() const { return assert_cast<const CAI_AdvisorMotor *>(this->GetMotor()); }
+	CAI_AdvisorMotor *		GetAdvisorMotor()		{ return assert_cast<CAI_AdvisorMotor *>(this->GetMotor()); }
+
+	CAI_Motor *CreateMotor()
+	{
+		MEM_ALLOC_CREDIT();
+		return new CAI_AdvisorMotor( this );
+	}
+
+	virtual float LineOfSightDist( const Vector &vecDir = vec3_invalid, float zEye = FLT_MAX );
+
+	//-----------------------------------------------------------------------------
+
+	virtual CanPlaySequence_t CanPlaySequence( bool fDisregardState, int interruptLevel );
+
+	//-----------------------------------------------------------------------------
+	
+	inline bool IsPreparingToThrow() { return m_hvStagedEnts.Count() > 0 && m_hvStagedEnts[0]; }
+
+	inline bool IsThisPropStaged( CBaseEntity *pEnt ) { return m_hvStagedEnts.HasElement( pEnt ); }
+
+	inline CBaseEntity *GetFirstStagingPosition() { return m_hvStagingPositions.Count() > 0 ? m_hvStagingPositions[0] : NULL; }
+
+	//-----------------------------------------------------------------------------
+
+	// This is ambiguous since arms are detachable and you can theoretically give them something else
+	enum AdvisorAccessory_t
+	{
+		ADVISOR_ACCESSORY_NONE,
+
+		// Arms
+		ADVISOR_ACCESSORY_ARMS,
+		ADVISOR_ACCESSORY_R_ARM,
+		ADVISOR_ACCESSORY_L_ARM,
+		ADVISOR_ACCESSORY_ARMS_STUBBED,
+	};
+
+	int GetCurrentAccessories();
+	void SetCurrentAccessories( AdvisorAccessory_t iNewAccessory );
+
+	CBaseAnimating *CreateDetachedArm( bool bLeft );
 #endif
 
 	//
 	// CAI_BaseNPC:
 	//
 	virtual float MaxYawSpeed() { return 90.0f; } //120.0f 90.0f
+	inline float MaxPitchSpeed() const { return 10.0f; }
 	
 	virtual Class_T Classify();
+
+#ifdef EZ2
+	Disposition_t	IRelationType( CBaseEntity *pTarget );
+#endif
 
 #if NPC_ADVISOR_HAS_BEHAVIOR
 	virtual int GetSoundInterests();
 	virtual int SelectSchedule();
+#ifdef MAPBASE
+	virtual void BuildScheduleTestBits();
+	virtual void PrescheduleThink();
+#endif
 	virtual void StartTask( const Task_t *pTask );
 	virtual void RunTask( const Task_t *pTask );
 	virtual void OnScheduleChange( void );
@@ -333,6 +725,8 @@ public:
 	virtual void ApplyShieldedEffects( void );
 
 	virtual int	TranslateSchedule( int scheduleType );
+
+	Activity 	NPC_TranslateActivity( Activity activity );
 
 	void StartFlying();
 	void StopFlying();
@@ -390,8 +784,11 @@ public:
 #ifdef EZ2
 	void InputStartFlying( inputdata_t &inputdata );
 	void InputStopFlying( inputdata_t &inputdata );
+	void InputSetFollowTarget( inputdata_t &inputdata );
 	void InputStartPsychicShield( inputdata_t &inputdata );
 	void InputStopPsychicShield( inputdata_t &inputdata );
+	void InputDetachRightArm( inputdata_t &inputdata );
+	void InputDetachLeftArm( inputdata_t &inputdata );
 	void InputDisablePinFailsafe( inputdata_t &inputdata ) { m_bPinFailsafeActive = false; }
 	void InputEnablePinFailsafe( inputdata_t &inputdata ) { m_bPinFailsafeActive = true; }
 
@@ -413,6 +810,11 @@ protected:
 
 	bool CanLevitateEntity( CBaseEntity *pEntity, int minMass, int maxMass );
 	void StartLevitatingObjects( void );
+
+#ifdef EZ2
+	void BeginLevitateObject( CBaseEntity *pEnt );
+	void EndLevitateObject( CBaseEntity *pEnt );
+#endif
 
 
 #if NPC_ADVISOR_HAS_BEHAVIOR
@@ -478,9 +880,37 @@ protected:
 	bool m_bAdvisorFlyer;
 	EHANDLE m_hAdvisorFlyer;
 
+	// The target entity the advisor should follow. When "flying", this is equivalent to m_hAdvisorFlyer.
+	EHANDLE m_hFollowTarget;
+
+	// 0 = right, 1 = left, 2 = both
+	int m_iThrowAnimDir;
+
 	float m_fStaggerUntilTime;
 
+	bool m_bBleeding;
+
+	bool m_bLevitatingObjects; // For save/restore
+
+	// Consider m_pEyeGlow to be m_pCameraGlow1
+	CSprite *m_pCameraGlow2;
+
 	CSoundPatch *m_pBreathSound;
+
+	Vector m_goalEyeDirection;
+
+	PoseParameter_t		m_ParameterCameraYaw;			// "camera_yaw"
+	PoseParameter_t		m_ParameterCameraPitch;			// "camera_pitch"
+	PoseParameter_t		m_ParameterFlexHorz;			// "flex_horz"
+	PoseParameter_t		m_ParameterFlexVert;			// "flex_vert"
+	PoseParameter_t		m_ParameterArmsExtent;			// "arms_extent"
+	PoseParameter_t		m_ParameterHurt;				// "hurt"
+
+	static int gm_nMouthAttachment;
+	static int gm_nLFrontTopJetAttachment;
+	static int gm_nRFrontTopJetAttachment;
+	static int gm_nLRearTopJetAttachment;
+	static int gm_nRRearTopJetAttachment;
 #endif
 
 
@@ -502,6 +932,13 @@ protected:
 #endif
 };
 
+#ifdef EZ2
+int CNPC_Advisor::gm_nMouthAttachment = -1;
+int CNPC_Advisor::gm_nLFrontTopJetAttachment = -1;
+int CNPC_Advisor::gm_nRFrontTopJetAttachment = -1;
+int CNPC_Advisor::gm_nLRearTopJetAttachment = -1;
+int CNPC_Advisor::gm_nRRearTopJetAttachment = -1;
+#endif
 
 LINK_ENTITY_TO_CLASS( npc_advisor, CNPC_Advisor );
 
@@ -527,9 +964,25 @@ BEGIN_DATADESC( CNPC_Advisor )
 	DEFINE_KEYFIELD( m_bPinFailsafeActive, FIELD_BOOLEAN, "pin_failsafe_active"),
 
 	DEFINE_FIELD( m_hAdvisorFlyer, FIELD_EHANDLE ),
+	DEFINE_FIELD( m_hFollowTarget, FIELD_EHANDLE ),
 
 	DEFINE_FIELD( m_bPsychicShieldOn, FIELD_BOOLEAN ),
 	DEFINE_FIELD( m_fStaggerUntilTime, FIELD_TIME ),
+
+	DEFINE_FIELD( m_bBleeding, FIELD_BOOLEAN ),
+
+	DEFINE_FIELD( m_bLevitatingObjects, FIELD_BOOLEAN ),
+
+	DEFINE_FIELD( m_iThrowAnimDir, FIELD_INTEGER ),
+
+	DEFINE_FIELD( m_goalEyeDirection, FIELD_VECTOR ),
+
+	DEFINE_FIELD( m_ParameterCameraYaw, FIELD_INTEGER ),
+	DEFINE_FIELD( m_ParameterCameraPitch, FIELD_INTEGER ),
+	DEFINE_FIELD( m_ParameterFlexHorz, FIELD_INTEGER ),
+	DEFINE_FIELD( m_ParameterFlexVert, FIELD_INTEGER ),
+	DEFINE_FIELD( m_ParameterArmsExtent, FIELD_INTEGER ),
+	DEFINE_FIELD( m_ParameterHurt, FIELD_INTEGER ),
 #endif
 
 	DEFINE_UTLVECTOR( m_hvStagedEnts, FIELD_EHANDLE ),
@@ -574,10 +1027,14 @@ BEGIN_DATADESC( CNPC_Advisor )
 #ifdef EZ2
 	DEFINE_INPUTFUNC( FIELD_VOID, "StartFlying", InputStartFlying ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "StopFlying", InputStopFlying ),
+	DEFINE_INPUTFUNC( FIELD_EHANDLE, "SetFollowTarget", InputSetFollowTarget ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "EnablePinFailsafe", InputEnablePinFailsafe ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "DisablePinFailsafe", InputDisablePinFailsafe ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "StartPsychicShield", InputStartPsychicShield ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "StopPsychicShield", InputStopPsychicShield ),
+
+	DEFINE_INPUTFUNC( FIELD_VOID, "DetachRightArm", InputDetachRightArm ),
+	DEFINE_INPUTFUNC( FIELD_VOID, "DetachLeftArm", InputDetachLeftArm ),
 
 	DEFINE_THINKFUNC( FlyThink )
 #endif
@@ -608,6 +1065,8 @@ void CNPC_Advisor::Spawn()
 
 	Precache();
 
+	GetAbsOrigin();
+
 	SetModel( STRING( GetModelName() ) );
 
 	m_iHealth = sk_advisor_health.GetFloat();
@@ -623,6 +1082,9 @@ void CNPC_Advisor::Spawn()
 #ifdef EZ2
 	// Advisors cannot move unassisted
 	CapabilitiesRemove( bits_CAP_MOVE_GROUND );
+
+	// Advisors are slugs with CHARACTER!
+	CapabilitiesAdd( bits_CAP_TURN_HEAD | bits_CAP_ANIMATEDFACE );
 #endif
 
 	m_flFieldOfView = VIEW_FIELD_FULL;
@@ -639,6 +1101,12 @@ void CNPC_Advisor::Spawn()
 	SetGoalEnt( NULL );
 
 	AddEFlags( EFL_NO_DISSOLVE );
+
+#ifdef EZ2
+	GetMotor()->RecalculateYawSpeed();
+
+	SetActivity( ACT_IDLE );
+#endif
 }
 
 
@@ -728,6 +1196,13 @@ void CNPC_Advisor::UpdateOnRemove()
 	if ( m_pLevitateController )
 	{
 		physenv->DestroyMotionController( m_pLevitateController );
+
+#ifdef EZ2
+		for (int i = m_physicsObjects.Count()-1; i >= 0; i--)
+		{
+			EndLevitateObject( m_physicsObjects[i] );
+		}
+#endif
 	}
 	
 	BaseClass::UpdateOnRemove();
@@ -739,10 +1214,166 @@ void CNPC_Advisor::UpdateOnRemove()
 void CNPC_Advisor::OnRestore()
 {
 	BaseClass::OnRestore();
+#ifdef EZ2
+	if (m_bLevitatingObjects)
+#endif
 	StartLevitatingObjects();
 }
 
 #ifdef EZ2
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::SetModel( const char *szModelName )
+{
+	BaseClass::SetModel( szModelName );
+
+	Init( m_ParameterCameraYaw, "camera_yaw" );
+	Init( m_ParameterCameraPitch, "camera_pitch" );
+	Init( m_ParameterFlexHorz, "flex_horz" );
+	Init( m_ParameterFlexVert, "flex_vert" );
+	Init( m_ParameterArmsExtent, "arms_extent" );
+	Init( m_ParameterHurt, "hurt" );
+
+	gm_nMouthAttachment = LookupAttachment( "attach_mouth" );
+	gm_nLFrontTopJetAttachment = LookupAttachment( "attach_l_front_top_jet" );
+	gm_nRFrontTopJetAttachment = LookupAttachment( "attach_r_front_top_jet" );
+	gm_nLRearTopJetAttachment = LookupAttachment( "attach_l_front_top_jet1" );
+	gm_nRRearTopJetAttachment = LookupAttachment( "attach_r_rear_top_jet" );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Return the pointer for a given sprite given an index
+//-----------------------------------------------------------------------------
+CSprite	*CNPC_Advisor::GetGlowSpritePtr( int index )
+{
+	switch (index)
+	{
+		case 0:
+			return m_pEyeGlow;
+		case 1:
+			return m_pCameraGlow2;
+	}
+
+	return BaseClass::GetGlowSpritePtr( index );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Sets the glow sprite at the given index
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::SetGlowSpritePtr( int index, CSprite *sprite )
+{
+	switch (index)
+	{
+		case 0:
+			m_pEyeGlow = sprite;
+			break;
+		case 1:
+			m_pCameraGlow2 = sprite;
+			break;
+	}
+
+	BaseClass::SetGlowSpritePtr( index, sprite );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Return the glow attributes for a given index
+//-----------------------------------------------------------------------------
+EyeGlow_t *CNPC_Advisor::GetEyeGlowData( int index )
+{
+	EyeGlow_t * eyeGlow = new EyeGlow_t();
+
+	switch (index){
+	case 0:
+		eyeGlow->spriteName = MAKE_STRING( "sprites/light_glow02.vmt" );
+		eyeGlow->attachment = MAKE_STRING( "camera_bottom_lens" );
+
+		eyeGlow->alpha = 255;
+		eyeGlow->brightness = 224;
+
+		eyeGlow->red = 0;
+		eyeGlow->green = 255;
+		eyeGlow->blue = 255;
+
+		eyeGlow->renderMode = kRenderWorldGlow;
+		eyeGlow->scale = 0.1f;
+		eyeGlow->proxyScale = 2.0f;
+
+		return eyeGlow;
+	case 1:
+		eyeGlow->spriteName = MAKE_STRING( "sprites/light_glow02.vmt" );
+		eyeGlow->attachment = MAKE_STRING( "camera_top_lens" );
+
+		eyeGlow->alpha = 255;
+		eyeGlow->brightness = 224;
+
+		eyeGlow->red = 0;
+		eyeGlow->green = 255;
+		eyeGlow->blue = 255;
+
+		eyeGlow->renderMode = kRenderWorldGlow;
+		eyeGlow->scale = 0.1f;
+		eyeGlow->proxyScale = 2.0f;
+
+		return eyeGlow;
+	}
+
+	return BaseClass::GetEyeGlowData(index);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::SetEyeState( AdvisorEyeState_t state )
+{
+	if (!m_pEyeGlow || !m_pCameraGlow2)
+		return;
+
+	switch (state)
+	{
+		case ADVISOR_EYE_NORMAL:
+			{
+				if (IsShieldOn())
+				{
+					m_pEyeGlow->SetRenderColor( 255, 255, 255 );
+					m_pCameraGlow2->SetRenderColor( 255, 255, 255 );
+
+					m_pEyeGlow->SetScale( 0.25 );
+					m_pCameraGlow2->SetScale( 0.25 );
+				}
+				else
+				{
+					m_pEyeGlow->SetRenderColor( 0, 255, 255 );
+					m_pCameraGlow2->SetRenderColor( 0, 255, 255 );
+
+					m_pEyeGlow->SetScale( 0.1 );
+					m_pCameraGlow2->SetScale( 0.1 );
+				}
+			} break;
+			
+		case ADVISOR_EYE_CHARGE:
+			{
+				// Turn yellow
+				m_pEyeGlow->SetRenderColor( 255, 255, 0 );
+				m_pCameraGlow2->SetRenderColor( 255, 255, 0 );
+			} break;
+			
+		case ADVISOR_EYE_DAMAGED:
+			{
+				// Start flashing
+				m_pEyeGlow->m_nRenderFX = kRenderFxFlickerSlow;
+				m_pCameraGlow2->m_nRenderFX = kRenderFxFlickerSlow;
+			} break;
+			
+		case ADVISOR_EYE_UNDAMAGED:
+			{
+				// Stop flashing
+				m_pEyeGlow->m_nRenderFX = kRenderFxNone;
+				m_pCameraGlow2->m_nRenderFX = kRenderFxNone;
+			} break;
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Parameters for scene event AI_GameText
 //-----------------------------------------------------------------------------
@@ -759,6 +1390,143 @@ bool CNPC_Advisor::GetGameTextSpeechParams( hudtextparms_t &params )
 
 	return true;
 }
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+float CNPC_Advisor::GetHeadDebounce( void )
+{
+	return advisor_head_debounce.GetFloat();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Maintain eye, head, body postures, etc.
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::MaintainLookTargets( float flInterval )
+{
+	BaseClass::MaintainLookTargets( flInterval );
+
+	// Turn our eye
+	if (HasCondition(COND_IN_PVS))
+	{
+		// Determine eye target position
+		Vector vecEyeTarget = EyePosition() + (EyeDirection3D() * 100.0f);
+		if (GetEnemy() && m_flThrowPhysicsTime + advisor_throw_warn_time.GetFloat() >= gpGlobals->curtime)
+		{
+			vecEyeTarget = GetEnemy()->EyePosition();
+		}
+		else if (GetLooktarget())
+		{
+			vecEyeTarget = GetLooktarget()->EyePosition();
+		}
+
+		// calc current animation head bias, movement needs to clamp accumulated with this
+		QAngle angBias;
+		QAngle vTargetAngles;
+
+		int iCamera = LookupAttachment( "camera" );
+		int iForward = LookupAttachment( "forward" );
+
+		matrix3x4_t eyesToWorld;
+		matrix3x4_t forwardToWorld, worldToForward;
+
+		GetAttachment( iCamera, eyesToWorld );
+
+		GetAttachment( iForward, forwardToWorld );
+		MatrixInvert( forwardToWorld, worldToForward );
+
+		MatrixInvert( forwardToWorld, worldToForward );
+
+		matrix3x4_t targetXform;
+		targetXform = forwardToWorld;
+		Vector vTargetDir = vecEyeTarget - EyePosition();
+
+		Studio_AlignIKMatrix( targetXform, vTargetDir );
+
+		matrix3x4_t headXform;
+		ConcatTransforms( worldToForward, targetXform, headXform );
+		MatrixAngles( headXform, vTargetAngles );
+
+		// partially debounce head goal
+		float s0 = 1.0 - advisor_camera_influence.GetFloat() + advisor_camera_debounce.GetFloat() * advisor_camera_influence.GetFloat();
+		float s1 = (1.0 - s0);
+		// limit velocity of head turns
+		m_goalEyeDirection.x = UTIL_Approach( m_goalEyeDirection.x * s0 + vTargetAngles.x * s1, m_goalEyeDirection.x, 10.0 );
+		m_goalEyeDirection.y = UTIL_Approach( m_goalEyeDirection.y * s0 + vTargetAngles.y * s1, m_goalEyeDirection.y, 30.0 );
+		//m_goalEyeDirection.z = UTIL_Approach( m_goalEyeDirection.z * s0 + vTargetAngles.z * s1, m_goalEyeDirection.z, 10.0 );
+
+		/*
+		if ( (m_debugOverlays & OVERLAY_NPC_SELECTED_BIT) )
+		{
+			// Msg( "yaw %.1f (%f) pitch %.1f (%.1f)\n", m_goalEyeDirection.y, vTargetAngles.y, vTargetAngles.x, m_goalEyeDirection.x );
+			// Msg( "yaw %.2f (goal %.2f) (influence %.2f) (flex %.2f)\n", flLimit, m_goalEyeDirection.y, flHeadInfluence, Get( m_FlexweightHeadRightLeft ) );
+		}
+		*/
+
+		float flTarget;
+
+		flTarget = ClampWithBias( m_ParameterCameraYaw, m_goalEyeDirection.y, angBias.y );
+		if ( (m_debugOverlays & OVERLAY_NPC_SELECTED_BIT) )
+		{
+			Msg( "yaw  %5.1f : (%5.1f : 0.0) %5.1f (%5.1f)\n", flTarget, m_goalEyeDirection.y/*, Get( m_FlexweightHeadRightLeft )*/, angBias.y, Get( m_ParameterCameraYaw ) );
+		}
+		Set( m_ParameterCameraYaw, flTarget );
+
+		flTarget = ClampWithBias( m_ParameterCameraPitch, m_goalEyeDirection.x, angBias.x );
+		if ( (m_debugOverlays & OVERLAY_NPC_SELECTED_BIT) )
+		{
+			Msg( "pitch %5.1f : (%5.1f : 0.0) %5.1f (%5.1f)\n", flTarget, m_goalEyeDirection.x/*, Get( m_FlexweightHeadUpDown )*/, angBias.x, Get( m_ParameterCameraPitch ) );
+		}
+		Set( m_ParameterCameraPitch, flTarget );
+	}
+}
+
+//---------------------------------------------------------
+// Pass a direction to get how far an NPC would see if facing
+// that direction. Pass nothing to get the length of the NPC's
+// current line of sight.
+//---------------------------------------------------------
+float CNPC_Advisor::LineOfSightDist( const Vector &vecDir, float zEye )
+{
+	Vector testDir;
+	if( vecDir == vec3_invalid )
+	{
+		testDir = EyeDirection3D();
+		testDir.x = 0;
+	}
+	else
+	{
+		testDir = vecDir;
+	}
+
+	if ( zEye == FLT_MAX ) 
+		zEye = EyePosition().z;
+
+	CTraceFilterLOS traceFilter( this, COLLISION_GROUP_NONE, m_hAdvisorFlyer );
+	trace_t tr;
+
+	// Need to center trace so don't get erratic results based on orientation
+	Vector testPos( GetAbsOrigin().x, GetAbsOrigin().y, zEye ); 
+	AI_TraceLOS( testPos, testPos + testDir * MAX_COORD_RANGE, this, &tr, &traceFilter );
+	return (tr.startpos - tr.endpos ).Length();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+CanPlaySequence_t CNPC_Advisor::CanPlaySequence( bool fDisregardNPCState, int interruptLevel )
+{
+	CanPlaySequence_t eReturn = BaseClass::CanPlaySequence( fDisregardNPCState, interruptLevel );
+
+	// Allows the advisor to play scripted sequences while dying.
+	// Mainly for death animations.
+	if ( eReturn == CANNOT_PLAY && !IsAlive() && !m_hCine )
+	{
+		eReturn = CAN_PLAY_NOW;
+	}
+
+	return eReturn;
+}
 #endif
 
 //-----------------------------------------------------------------------------
@@ -768,6 +1536,23 @@ Class_T	CNPC_Advisor::Classify()
 {
 	return CLASS_COMBINE;
 }
+
+
+#ifdef EZ2
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+Disposition_t CNPC_Advisor::IRelationType( CBaseEntity * pTarget )
+{
+	// Don't attack entities we're about to throw
+	if ( m_hvStagedEnts.HasElement(pTarget) )
+	{
+		return D_NU;
+	}
+
+	return BaseClass::IRelationType( pTarget );
+}
+#endif
 
 
 //-----------------------------------------------------------------------------
@@ -804,14 +1589,25 @@ void CNPC_Advisor::StartLevitatingObjects()
 		{
 			m_pLevitateController->AttachObject( pPhys, false );
 			pPhys->Wake();
+
+#ifdef EZ2
+			BeginLevitateObject( pEnt );
+#endif
 		}
 	}
+
+	m_bLevitatingObjects = true;
 }
 
 // This function is used by both version of the entity finder below 
 bool CNPC_Advisor::CanLevitateEntity( CBaseEntity *pEntity, int minMass, int maxMass )
 {
+#ifdef EZ2
+	// Allowed to pick up physics NPCs which aren't our flyer
+	if (!pEntity || pEntity == m_hAdvisorFlyer)
+#else
 	if (!pEntity || pEntity->IsNPC()) 
+#endif
 		return false;
 
 	IPhysicsObject *pPhys = pEntity->VPhysicsGetObject();
@@ -826,6 +1622,36 @@ bool CNPC_Advisor::CanLevitateEntity( CBaseEntity *pEntity, int minMass, int max
 			 pPhys->IsMoveable() /* &&
 			!DidThrow(pEntity) */ );
 }
+
+#ifdef EZ2
+void CNPC_Advisor::BeginLevitateObject( CBaseEntity *pEnt )
+{
+	if (pEnt && pEnt->IsNPC())
+	{
+		// Important for stopping turrets from being annoying and strange while under no gravity
+		ITippableTurret *pTippable = dynamic_cast<ITippableTurret*>(pEnt);
+		if (pTippable)
+		{
+			//Msg( "Setting low gravity on %s\n", pEnt->GetDebugName() );
+			pTippable->SetLowGravity( true );
+		}
+	}
+}
+
+void CNPC_Advisor::EndLevitateObject( CBaseEntity *pEnt )
+{
+	if (pEnt && pEnt->IsNPC())
+	{
+		// Important for stopping turrets from being annoying and strange while under no gravity
+		ITippableTurret *pTippable = dynamic_cast<ITippableTurret*>(pEnt);
+		if (pTippable)
+		{
+			//Msg( "Deactivating low gravity on %s\n", pEnt->GetDebugName() );
+			pTippable->SetLowGravity( false );
+		}
+	}
+}
+#endif
 
 #if NPC_ADVISOR_HAS_BEHAVIOR
 // find an object to throw at the player and start the warning on it. Return object's 
@@ -870,6 +1696,11 @@ CBaseEntity *CNPC_Advisor::ThrowObjectPrepare()
 		// play the sound, attach the light, fire the trigger
 		EmitSound( "NPC_Advisor.ObjectChargeUp" );
 
+#ifdef EZ2
+		// TODO: Show an effect on the throwable object
+		//DispatchParticleEffect( "Advisor_Throw_Obj_Charge", PATTACH_ABSORIGIN_FOLLOW, pThrowable );
+#endif
+
 		m_OnThrowWarn.FireOutput(pThrowable,this); 
 		m_flThrowPhysicsTime = gpGlobals->curtime + advisor_throw_warn_time.GetFloat();
 
@@ -912,8 +1743,16 @@ void CNPC_Advisor::StartTask( const Task_t *pTask )
 			touchlink_t *touchroot = ( touchlink_t * )pVolume->GetDataObject( TOUCHLINK );
 			if ( touchroot )
 			{
+#ifdef EZ2
+				for (int i = m_physicsObjects.Count()-1; i >= 0; i--)
+				{
+					EndLevitateObject( m_physicsObjects[i] );
 
+					m_physicsObjects.FastRemove( i );
+				}
+#else
 				m_physicsObjects.RemoveAll();
+#endif
 
 				for ( touchlink_t *link = touchroot->nextLink; link != touchroot; link = link->nextLink )
 				{
@@ -924,6 +1763,10 @@ void CNPC_Advisor::StartTask( const Task_t *pTask )
 						{
 							//Msg( "   %d added %s\n", m_physicsObjects.Count(), STRING( list[i]->GetModelName() ) );
 							m_physicsObjects.AddToTail( pTouch );
+
+#ifdef EZ2
+							BeginLevitateObject( pTouch );
+#endif
 						}
 					}
 				}
@@ -1051,6 +1894,7 @@ void CNPC_Advisor::StartTask( const Task_t *pTask )
 		}
 #ifdef EZ2
 		case TASK_ADVISOR_STAGGER:
+		case TASK_ADVISOR_WAIT_FOR_ACTIVITY:
 			break;
 #endif
 		default:
@@ -1176,6 +2020,10 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 					DispatchParticleEffect( "advisor_object_charge", PATTACH_ABSORIGIN_FOLLOW, 
 							pThrowable, 0, 
 							false  );
+
+#ifdef EZ2
+					SetEyeState( ADVISOR_EYE_CHARGE );
+#endif
 				}
 			}
 
@@ -1227,6 +2075,10 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 				Write_AllBeamsOff();
 				m_hvStagedEnts.RemoveAll();
 
+#ifdef EZ2
+				SetEyeState( ADVISOR_EYE_NORMAL );
+#endif
+
 				TaskFail( "Lost enemy" );
 				return;
 			}
@@ -1277,6 +2129,14 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 
 				EmitSound( "NPC_Advisor.Blast" );
 
+#ifdef EZ2
+				// Throw animation
+				Activity actThrows[]	{ ACT_ADVISOR_OBJECT_R_THROW,	ACT_ADVISOR_OBJECT_L_THROW,	ACT_ADVISOR_OBJECT_BOTH_THROW };
+				SetIdealActivity( actThrows[m_iThrowAnimDir] );
+
+				SetEyeState( ADVISOR_EYE_NORMAL );
+#endif
+
 				Write_BeamOff(m_hvStagedEnts[0]);
 				m_hvStagedEnts.Remove(0);
 				if (!ThrowObjectPrepare())
@@ -1289,6 +2149,57 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 			{	
 				// wait, bide time
 				// PullObjectToStaging(pThrowable, m_hvStagingPositions[ii]->GetAbsOrigin());
+
+#ifdef EZ2
+				// Telegraph our progress in animation
+				Activity actHolds[]	{ ACT_ADVISOR_OBJECT_R_HOLD,	ACT_ADVISOR_OBJECT_L_HOLD,	ACT_ADVISOR_OBJECT_BOTH_HOLD };
+
+				// Determine where our object is
+				m_iThrowAnimDir = 2;
+				//if (pThrowable->GetMass() < 5000.0f)
+				{
+					//Vector vecForward;
+					//GetVectors( &vecForward, NULL, NULL );
+
+					Vector2D vec2DDelta = (pThrowable->GetAbsOrigin().AsVector2D() - GetAbsOrigin().AsVector2D());
+					Vector2DNormalize( vec2DDelta );
+
+					QAngle angAngles;
+					VectorAngles( Vector(vec2DDelta.x, vec2DDelta.y, 0), angAngles );
+
+					float flObjectAngle = AngleNormalizePositive( AngleDistance( angAngles.y, GetAbsAngles().y ) );
+					//if (flObjectAngle <= 160.0f || flObjectAngle >= 200.0f)
+					{
+						if (flObjectAngle > 180.0f)
+							m_iThrowAnimDir = 0; // right
+						else
+							m_iThrowAnimDir = 1; // left
+					}
+					Msg( "flObjectAngle = %f\n", flObjectAngle );
+
+					//float flDot = DotProduct2D( vec2DDelta, vecForward.AsVector2D() );
+					//if (abs(flDot) < 0.75f)
+					//{
+					//	if (flDot < 0)
+					//		m_iThrowAnimDir = 0; // right
+					//	else
+					//		m_iThrowAnimDir = 1; // left
+					//}
+					//Msg( "Dot: %f\n", flDot );
+				}
+
+				SetIdealActivity( actHolds[m_iThrowAnimDir] );
+
+				//if (GetActivity() == actStarts[m_iThrowAnimDir])
+				//{
+				//	if (IsActivityFinished())
+				//		SetActivity( actHolds[m_iThrowAnimDir] );
+				//}
+				//else if (GetActivity() != actHolds[m_iThrowAnimDir])
+				//{
+				//	SetActivity( actStarts[m_iThrowAnimDir] );
+				//}
+#endif
 			}
 		
 			break;
@@ -1311,6 +2222,9 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 				pEnemy->SetMoveType( MOVETYPE_WALK );
 				Write_BeamOff(GetEnemy());
 				beamonce = 1;
+#ifdef EZ2
+				if (GetTask() == pTask)
+#endif
 				TaskComplete();
 				break;
 			}
@@ -1323,6 +2237,9 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 				Write_BeamOff(GetEnemy());
 				beamonce = 1;
 				Warning( "Advisor did not leave PIN PLAYER mode. Aborting due to ten second failsafe!\n" );
+#ifdef EZ2
+				if (GetTask() == pTask)
+#endif
 				TaskFail("Advisor did not leave PIN PLAYER mode. Aborting due to ten second failsafe!\n");
 				break;
 			}
@@ -1371,6 +2288,33 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 			OnTakeDamage( info );
 			TaskComplete();
 			break;
+
+		case TASK_ADVISOR_WAIT_FOR_ACTIVITY:
+			if (GetIdealActivity() != ACT_IDLE && IsActivityFinished())
+			{
+				SetIdealActivity( ACT_IDLE );
+				TaskComplete();
+				return;
+			}
+			break;
+			
+		// HACKHACK: If we're running a script, make sure we still pin the player
+		case TASK_PRE_SCRIPT:
+		case TASK_ENABLE_SCRIPT:
+		case TASK_WAIT_FOR_SCRIPT:
+		case TASK_FACE_SCRIPT:
+		case TASK_PLAY_SCRIPT:
+		case TASK_PLAY_SCRIPT_POST_IDLE:
+		{
+			if (m_hPlayerPinPos)
+			{
+				m_playerPinFailsafeTime = gpGlobals->curtime + 10.0f;
+				ChainRunTask( TASK_ADVISOR_PIN_PLAYER );
+			}
+
+			BaseClass::RunTask( pTask );
+			break;
+		}
 #endif
 		default:
 		{
@@ -1418,16 +2362,18 @@ bool CNPC_Advisor::IsShieldOn( void )
 void CNPC_Advisor::ApplyShieldedEffects(  )
 {
 	// Modulus with the skin allows multiple sets of shielded / unshielded skins
-	if ( IsShieldOn() && m_nSkin % 2 == ADVISOR_SKIN_NOSHIELD )
+	if ( IsAlive() && IsShieldOn() && m_nSkin % 2 == ADVISOR_SKIN_NOSHIELD )
 	{
 		EmitSound( "NPC_Advisor.shieldup" );
 		SetBloodColor( DONT_BLEED );
+		SetEyeState( ADVISOR_EYE_NORMAL ); // Refresh eye state
 		m_nSkin++;
 	}
 	else if ( !IsShieldOn() && m_nSkin % 2 == ADVISOR_SKIN_SHIELD)
 	{
 		EmitSound( "NPC_Advisor.shielddown" );
 		SetBloodColor( BLOOD_COLOR_GREEN );
+		SetEyeState( ADVISOR_EYE_NORMAL ); // Refresh eye state
 		m_nSkin--;
 	}
 }
@@ -1442,9 +2388,141 @@ int CNPC_Advisor::TranslateSchedule( int scheduleType )
 		return SCHED_ADVISOR_IDLE_STAND;
 		break;
 	}
+
+	case SCHED_MELEE_ATTACK1:
+	{
+		return SCHED_ADVISOR_MELEE_ATTACK1;
+		break;
+	}
+
+	case SCHED_CHASE_ENEMY:
+	{
+		return SCHED_STANDOFF;
+		break;
+	}
+
 	}
 
 	return BaseClass::TranslateSchedule( scheduleType );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+Activity CNPC_Advisor::NPC_TranslateActivity( Activity activity )
+{
+	if (activity == ACT_MELEE_ATTACK1)
+	{
+		// Determine activity based on arm type
+		switch (GetCurrentAccessories())
+		{
+			case ADVISOR_ACCESSORY_ARMS_STUBBED: // Try to attack fruitlessly
+			case ADVISOR_ACCESSORY_ARMS:
+				{
+					// Alternate between left, right, and both
+					switch (RandomInt( 0, 2 ))
+					{
+						case 0: break;
+						case 1: activity = ACT_MELEE_ATTACK2; break;
+						case 2: activity = ACT_MELEE_ATTACK_SWING; break;
+					}
+				}
+				break;
+			case ADVISOR_ACCESSORY_R_ARM:
+				// Maintain ACT_MELEE_ATTACK1
+				break;
+			case ADVISOR_ACCESSORY_L_ARM:
+				activity = ACT_MELEE_ATTACK2;
+				break;
+		}
+	}
+
+	return BaseClass::NPC_TranslateActivity( activity );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+int CNPC_Advisor::GetCurrentAccessories()
+{
+	// For now, try to identify from the bodygroup
+	int iArms = FindBodygroupByName( "arms" );
+	if (iArms == -1)
+		return ADVISOR_ACCESSORY_NONE;
+
+	int iBody = GetBodygroup( iArms );
+
+	// The advisor model starts with arms as the first and no arms as the second.
+	// Beyond that, just use the value directly.
+	if (iBody == 0)
+		return ADVISOR_ACCESSORY_ARMS;
+	else if (iBody == 1)
+		return ADVISOR_ACCESSORY_NONE;
+
+	return iBody;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::SetCurrentAccessories( AdvisorAccessory_t iNewAccessory )
+{
+	// For now, try to identify from the bodygroup
+	int iArms = FindBodygroupByName( "arms" );
+	if (iArms == -1)
+		return;
+
+	// The advisor model starts with arms as the first and no arms as the second.
+	// Beyond that, just use the value directly.
+	if (iNewAccessory == ADVISOR_ACCESSORY_NONE)
+		iNewAccessory = ADVISOR_ACCESSORY_ARMS;
+	else if (iNewAccessory == ADVISOR_ACCESSORY_ARMS)
+		iNewAccessory = ADVISOR_ACCESSORY_NONE;
+
+	SetBodygroup( iArms, iNewAccessory );
+}
+
+extern CBaseAnimating *CreateServerRagdollSubmodel( CBaseAnimating *pOwner, const char *pModelName, const Vector &position, const QAngle &angles, int collisionGroup );
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+CBaseAnimating *CNPC_Advisor::CreateDetachedArm( bool bLeft )
+{
+	const char *pszModelName = bLeft ? "models/advisor_combat_arm_l_detached.mdl" : "models/advisor_combat_arm_r_detached.mdl";
+
+	CBaseAnimating *pAnimating = CreateServerRagdollSubmodel( this, pszModelName, GetAbsOrigin(), GetAbsAngles(), COLLISION_GROUP_DEBRIS );
+	if (!pAnimating)
+		return NULL;
+
+	pAnimating->m_nSkin = m_nSkin;
+	if (IsShieldOn())
+		pAnimating->m_nSkin--; // Don't use shield skin
+
+	// For now, fade out after about 3 minutes
+	pAnimating->SUB_StartFadeOut( 180.0f, false );
+
+	Vector vecVelocity;
+	AngularImpulse vecAngVelocity;
+	GetVelocity( &vecVelocity, &vecAngVelocity );
+
+	IPhysicsObject *pList[VPHYSICS_MAX_OBJECT_LIST_COUNT];
+	int count = pAnimating->VPhysicsGetObjectList( pList, ARRAYSIZE(pList) );
+	if ( count )
+	{
+		for ( int i = 0; i < count; i++ )
+		{
+			pList[i]->SetVelocity( &vecVelocity, &vecAngVelocity );
+		}
+	}
+	else
+	{
+		// failed to create a physics object
+		UTIL_Remove( pAnimating );
+		return NULL;
+	}
+
+	return pAnimating;
 }
 
 //-----------------------------------------------------------------------------
@@ -1458,9 +2536,16 @@ void CNPC_Advisor::StartFlying()
 		m_hAdvisorFlyer->KeyValue( "SpotlightDisabled", "1" );
 		m_hAdvisorFlyer->Spawn();
 		m_hAdvisorFlyer->AcceptInput( "DisablePhotos", this, this, variant_t(), 0 );
+
+		if ( GetEnemy() )
+		{
+			m_hAdvisorFlyer->MyNPCPointer()->UpdateEnemyMemory( GetEnemy(), GetEnemyLKP() );
+		}
 	}
 
-	SetContextThink( &CNPC_Advisor::FlyThink, gpGlobals->curtime + TICK_INTERVAL, "FlyThink" );
+	m_hFollowTarget = m_hAdvisorFlyer;
+
+	SetContextThink( &CNPC_Advisor::FlyThink, gpGlobals->curtime + TICK_INTERVAL, ADVISOR_FLY_THINK );
 }
 
 //-----------------------------------------------------------------------------
@@ -1472,35 +2557,38 @@ void CNPC_Advisor::StopFlying()
 	{
 		m_hAdvisorFlyer->SUB_Remove();
 		m_hAdvisorFlyer = NULL;
-	}
 
-	SetContextThink( NULL, 0.0f, "FlyThink" );
+		m_hFollowTarget = NULL;
+
+		SetContextThink( NULL, 0.0f, ADVISOR_FLY_THINK );
+	}
 }
 
 void CNPC_Advisor::FlyThink()
 {
 	UpdateAdvisorFacing();
 
-	if ( m_hAdvisorFlyer )
+	if ( m_hFollowTarget )
 	{
 		// Something went bad! The flyer is too far, let's teleport
-		if ( m_hAdvisorFlyer->GetAbsOrigin().DistTo( GetAbsOrigin() ) > 512.0f )
+		if ( m_hFollowTarget->GetAbsOrigin().DistTo( GetAbsOrigin() ) > 512.0f )
 		{
 			// Fire a mind blast effect to blind the player while we do something janky
 			m_OnMindBlast.FireOutput( this, this, 0.0f );
 
-			Teleport( &m_hAdvisorFlyer->GetAbsOrigin(), &GetAbsAngles(), &GetAbsVelocity() );
+			DispatchParticleEffect( "tele_warp", PATTACH_ABSORIGIN_FOLLOW, this, 0, false );
+			Teleport( &m_hFollowTarget->GetAbsOrigin(), &GetAbsAngles(), &GetAbsVelocity() );
 		}
 		// Move towards the advisor flyer
 		else
 		{
 			// Gotta go fast!
-			float flAdvisorFlightSpeed = 128.0f;
-			SetAbsVelocity( ( m_hAdvisorFlyer->GetAbsOrigin() - GetAbsOrigin() ) * flAdvisorFlightSpeed );
+			float flAdvisorFlightSpeed = m_hFollowTarget == m_hAdvisorFlyer ? 128.0f : 1.0f;
+			SetAbsVelocity( ( m_hFollowTarget->GetAbsOrigin() - GetAbsOrigin() ) * flAdvisorFlightSpeed );
 		}
 	}
 
-	SetContextThink( &CNPC_Advisor::FlyThink, gpGlobals->curtime + TICK_INTERVAL, "FlyThink" );
+	SetContextThink( &CNPC_Advisor::FlyThink, gpGlobals->curtime + TICK_INTERVAL, ADVISOR_FLY_THINK );
 }
 
 //-----------------------------------------------------------------------------
@@ -1509,22 +2597,86 @@ void CNPC_Advisor::FlyThink()
 //-----------------------------------------------------------------------------
 void CNPC_Advisor::UpdateAdvisorFacing()
 {
-	switch ( GetState() )
+	/*if (m_hAdvisorFlyer)
 	{
-	case NPC_STATE_COMBAT:
-		GetMotor()->SetIdealYawToTargetAndUpdate( GetEnemyLKP(), AI_KEEP_YAW_SPEED );
-		break;
-	default:
-		if ( GetLooktarget() )
+		Vector vecDir;
+		AngleVectors( m_hAdvisorFlyer->GetAbsAngles(), &vecDir );
+		float flYaw = UTIL_VecToYaw( vecDir );
+		float flPitch = -UTIL_VecToPitch( vecDir ); // Invert flyer pitch
+		
+		GetAdvisorMotor()->SetIdealYaw( flYaw );
+		GetAdvisorMotor()->SetIdealPitch( flPitch );
+	}
+	else*/ if (advisor_use_facing_override.GetBool())
+	{
+		switch ( GetState() )
 		{
-			GetMotor()->SetIdealYawToTargetAndUpdate( GetLooktarget()->GetAbsOrigin(), AI_KEEP_YAW_SPEED );
+		case NPC_STATE_COMBAT:
+			GetAdvisorMotor()->SetIdealYawAndPitchToTarget( GetEnemyLKP()/*, AI_KEEP_YAW_SPEED*/ );
+			break;
+		case NPC_STATE_SCRIPT:
+			GetAdvisorMotor()->SetIdealPitch( 0.0f );
+			break;
+		default:
+			if ( GetLooktarget() )
+			{
+				GetAdvisorMotor()->SetIdealYawAndPitchToTarget( GetLooktarget()->GetAbsOrigin()/*, AI_KEEP_YAW_SPEED*/ );
+			}
+			else if ( HasCondition( COND_SEE_PLAYER ) )
+			{
+				CBasePlayer * pPlayer = AI_GetSinglePlayer();
+				GetAdvisorMotor()->SetIdealYawAndPitchToTarget( pPlayer->GetAbsOrigin()/*, AI_KEEP_YAW_SPEED*/ );
+			}
+			break;
 		}
-		else if ( HasCondition( COND_SEE_PLAYER ) )
+	}
+
+	if (advisor_update_yaw.GetBool())
+	{
+		//GetMotor()->SetIdealYaw( CalcReasonableFacing( true ) );
+		GetMotor()->UpdateYaw( -1 );
+	}
+
+	if (GetState() != NPC_STATE_SCRIPT)
+	{
+		if (advisor_use_flyer_poses.GetBool())
 		{
-			CBasePlayer * pPlayer = AI_GetSinglePlayer();
-			GetMotor()->SetIdealYawToTargetAndUpdate( pPlayer->GetAbsOrigin(), AI_KEEP_YAW_SPEED );
+			Vector vecForward;
+			GetVectors( &vecForward, NULL, NULL );
+			float flCurrentYaw = UTIL_VecToYaw( vecForward );
+			float flCurrentPitch = UTIL_VecToPitch( vecForward );
+
+			float flYawDiff = RemapValClamped( -AngleDistance(flCurrentYaw, GetMotor()->GetIdealYaw()), -30.0, 30.0f, -75.0f, 75.0f );
+			float flPitchDiff = RemapValClamped( -AngleDistance(flCurrentPitch, GetAdvisorMotor()->GetIdealPitch()), -30.0, 30.0f, -75.0f, 75.0f );
+
+			float yaw = GetPoseParameter( m_ParameterFlexHorz );
+			float pitch = GetPoseParameter( m_ParameterFlexVert );
+
+			SetPoseParameter( m_ParameterFlexHorz, UTIL_Approach( flYawDiff, yaw, MaxYawSpeed() ) );
+			SetPoseParameter( m_ParameterFlexVert, UTIL_Approach( flPitchDiff, pitch, MaxPitchSpeed() ) );
+
+			// Set arms extent as combination of velocity and distance to enemy
+			// (higher up = more constricted)
+			float flArmsExtent;
+			if (GetEnemy())
+			{
+				Vector vecDelta = (GetAbsOrigin() - GetEnemy()->GetAbsOrigin());
+				float flVelocityLengthSqr = GetLocalVelocity().LengthSqr() + GetLocalAngularVelocity().LengthSqr();
+				flArmsExtent = RemapVal( (flVelocityLengthSqr + vecDelta.LengthSqr()), 0, Square( 1000 ), 0.0f, 1.0f );
+			}
+			else
+			{
+				flArmsExtent = (GetAbsVelocity().Length()) * 0.005f;
+			}
+			//Msg( "flYawDiff: %f, flArmsExtent: %f (yaw: %f, ideal yaw: %f)\n", flYawDiff, flArmsExtent, flCurrentYaw, GetMotor()->GetIdealYaw() );
+			SetPoseParameter( m_ParameterArmsExtent, flArmsExtent );
 		}
-		break;
+	}
+	else
+	{
+		SetPoseParameter( m_ParameterFlexHorz, 0.0f );
+		SetPoseParameter( m_ParameterFlexVert, 0.0f );
+		SetPoseParameter( m_ParameterArmsExtent, 0.0f );
 	}
 }
 
@@ -1684,30 +2836,83 @@ void CNPC_Advisor::TraceAttack( const CTakeDamageInfo &info, const Vector &vecDi
 {
 	m_fNoDamageDecal = false;
 
+	QAngle vecAngles;
+	VectorAngles( ptr->plane.normal, vecAngles );
+
 	// Shield particle
 	if ( IsShieldOn() )
 	{
-		QAngle vecAngles;
-		VectorAngles( ptr->plane.normal, vecAngles );
-		DispatchParticleEffect( "warp_shield_impact_BMan", ptr->endpos, vecAngles );
+		DispatchParticleEffect( "warp_shield_impact_BMan", ptr->endpos, vecAngles, this );
 
 		// Make a blocked sound
 		EmitSound( "NPC_Advisor.shieldblock" );
 
 		// Do not handle trace
 		m_fNoDamageDecal = true;
+
+		// Fire a fake bullet in the normal's direction
+		//FireBulletsInfo_t bulletsInfo;
+		//bulletsInfo.m_iShots = 1;
+		//bulletsInfo.m_vecSrc = ptr->endpos;
+		//bulletsInfo.m_vecDirShooting = ptr->plane.normal;
+		//bulletsInfo.m_vecSpread = VECTOR_CONE_5DEGREES;
+		//bulletsInfo.m_flDistance = MAX_TRACE_LENGTH;
+		//bulletsInfo.m_iAmmoType = 0;
+		//bulletsInfo.m_flDamage = 0;
+		//bulletsInfo.m_iTracerFreq = 1;
+		//FireBullets( bulletsInfo );
+
+		// Make one spark fly off to represent the bullet that hit the shield
+		g_pEffects->MetalSparks( ptr->endpos, ptr->plane.normal );
+
 		return;
+	}
+	else
+	{
+		// Dispatch a bleeding particle effect
+		DispatchParticleEffect( RandomInt(0,1) ? "blood_advisor_shrapnel_spurt_1" : "blood_advisor_shrapnel_spurt_2", ptr->endpos, vecAngles, this );
+		//DispatchParticleEffect( RandomInt(0,1) ? "blood_advisor_shrapnel_spurt_1" : "blood_advisor_shrapnel_spurt_2", ptr->endpos, vecAngles, this, PATTACH_ABSORIGIN_FOLLOW );
 	}
 
 	BaseClass::TraceAttack( info, vecDir, ptr, pAccumulator );
 }
+
+//-----------------------------------------------------------------------------
+// Purpose: Custom trace filter used for advisor staging LOS traces
+//-----------------------------------------------------------------------------
+class CTraceFilterAdvisorStage : public CTraceFilterSkipTwoEntities
+{
+public:
+	CTraceFilterAdvisorStage( IHandleEntity *pHandleEntity, int collisionGroup, IHandleEntity *pHandleEntity2 = NULL )
+		: CTraceFilterSkipTwoEntities( pHandleEntity, pHandleEntity2, collisionGroup )
+	{
+		m_pAdvisor = static_cast<CNPC_Advisor *>(pHandleEntity);
+	}
+
+	bool ShouldHitEntity( IHandleEntity *pHandleEntity, int contentsMask )
+	{
+		CBaseEntity *pEntity = EntityFromEntityHandle( pHandleEntity );
+
+		if ( pEntity->GetMoveType() == MOVETYPE_VPHYSICS )
+		{
+			// Don't hit staged props
+			if ( m_pAdvisor->IsThisPropStaged( pEntity ) )
+				return false;
+		}
+
+		return CTraceFilterSimple::ShouldHitEntity( pHandleEntity, contentsMask );
+	}
+
+private:
+	CNPC_Advisor *m_pAdvisor;
+};
 #endif
 
 
 #endif
 
 // helper function for testing whether or not an avisor is allowed to grab an object
-static bool AdvisorCanPickObject(CBasePlayer *pPlayer, CBaseEntity *pEnt)
+static bool AdvisorCanPickObject( CBasePlayer *pPlayer, CBaseEntity *pEnt, CNPC_Advisor *pAdvisor = NULL )
 {
 #ifdef EZ2
 	if (pPlayer != NULL)
@@ -1741,6 +2946,26 @@ static bool AdvisorCanPickObject(CBasePlayer *pPlayer, CBaseEntity *pEnt)
 	{
 		return false;
 	}
+
+#ifdef EZ2
+	if (pAdvisor)
+	{
+		// Can the prop reach our first staging position?
+		// TODO: Check all staging positions
+		CBaseEntity *pStagingPos = pAdvisor->GetFirstStagingPosition();
+		if (pStagingPos)
+		{
+			CTraceFilterAdvisorStage traceFilter( pAdvisor, COLLISION_GROUP_NONE, pEnt );
+			trace_t tr;
+
+			Vector stagingPos = pStagingPos->GetAbsOrigin();
+			AI_TraceLine( pEnt->GetAbsOrigin(), stagingPos, MASK_SOLID, &traceFilter, &tr );
+
+			if (tr.fraction != 1.0f)
+				return false;
+		}
+	}
+#endif
 
 	return true;
 }
@@ -1798,6 +3023,11 @@ CBaseEntity *CNPC_Advisor::PickThrowable( bool bRequireInView )
 
 			if (!pThrowEnt->NameMatches(m_iszPriorityEntityGroupName)) // if this is not a priority object
 				continue;
+
+#ifdef EZ2
+			if (pThrowEnt == GetEnemy()) // Don't pick our enemy
+				continue;
+#endif
 
 			bool bCanPick = AdvisorCanPickObject( pPlayer, pThrowEnt ) && !m_hvStagedEnts.HasElement( m_physicsObjects[ii] );
 			if (!bCanPick)
@@ -2148,6 +3378,40 @@ int	CNPC_Advisor::OnTakeDamage( const CTakeDamageInfo &info )
 		m_OnHealthIsNow.Set( GetHealth(), newInfo.GetAttacker(), this);
 	}
 
+#ifdef EZ2
+	float flHealthRatio = (float)GetHealth() / (float)GetMaxHealth();
+	if ( flHealthRatio < advisor_camera_flash_health_ratio.GetFloat() )
+	{
+		SetEyeState( ADVISOR_EYE_DAMAGED );
+	}
+	else
+	{
+		SetEyeState( ADVISOR_EYE_UNDAMAGED );
+	}
+
+	// TODO: This needs an elaborate clientside implementation in order to function
+	//if ( flHealthRatio < advisor_bleed_health_ratio.GetFloat() )
+	//{
+	//	if (!m_bBleeding)
+	//	{
+	//		//DispatchParticleEffect( "blood_antlionguard_injured_heavy", PATTACH_POINT_FOLLOW, this, gm_nMouthAttachment );
+	//		//DispatchParticleEffect( "blood_drip_synth_01", PATTACH_ABSORIGIN_FOLLOW, this );
+	//		m_bBleeding = true;
+	//	}
+	//}
+	//else if (m_bBleeding)
+	//{
+	//	// HACKHACK
+	//	StopParticleEffects( this );
+	//	m_bBleeding = false;
+	//}
+
+	if (advisor_hurt_pose.GetBool())
+	{
+		SetPoseParameter( m_ParameterHurt, 1.0f - flHealthRatio );
+	}
+#endif
+
 	return retval;
 }
 
@@ -2198,7 +3462,7 @@ int CNPC_Advisor::SelectSchedule()
 
 #ifdef EZ2
 	// Don't pin the player immediately after throwing an object!
-	if ( m_hPlayerPinPos.IsValid() && gpGlobals->curtime - m_flLastThrowTime > sk_advisor_pin_throw_cooldown.GetFloat() )
+	if ( IsAlive() && m_hPlayerPinPos.IsValid() && gpGlobals->curtime - m_flLastThrowTime > sk_advisor_pin_throw_cooldown.GetFloat() )
 	{
 		ClearCondition( COND_ADVISOR_FORCE_PIN );
 		return SCHED_ADVISOR_TOSS_PLAYER;
@@ -2235,70 +3499,179 @@ int CNPC_Advisor::SelectSchedule()
 		}
 	}
 
-#ifdef EZ2
-	// Don't fall to ground!
-	ClearCondition( COND_FLOATING_OFF_GROUND );
-#endif
-
 	return BaseClass::SelectSchedule();
 }
 
+#ifdef EZ2
+//-----------------------------------------------------------------------------
+// TASK_RANGE_ATTACK1
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::BuildScheduleTestBits()
+{
+	BaseClass::BuildScheduleTestBits();
+
+	// Don't interrupt scripts. RunTask() allows pinning to occur simultaneously
+	if ( GetState() != NPC_STATE_SCRIPT )
+	{
+		SetCustomInterruptCondition( COND_ADVISOR_FORCE_PIN );
+	}
+	
+	if ( IsCurSchedule( SCHED_ADVISOR_COMBAT, false ) )
+	{
+		// Don't interrupt during barrage task
+		if (!GetTask() || GetTask()->iTask != TASK_ADVISOR_BARRAGE_OBJECTS)
+			SetCustomInterruptCondition( COND_CAN_MELEE_ATTACK1 );
+	}
+	//else if ( IsCurSchedule( SCHED_MELEE_ATTACK1, false ) )
+	//{
+	//	// Don't get stuck trying to face
+	//	if (GetTask() && GetTask()->iTask == TASK_FACE_ENEMY)
+	//		SetCustomInterruptCondition( COND_TOO_FAR_TO_ATTACK );
+	//}
+	else if ( IsCurSchedule( SCHED_STANDOFF, false ) )
+	{
+		// Interrupt when we can use our combat schedule again
+		SetCustomInterruptCondition( COND_HAVE_ENEMY_LOS );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CNPC_Advisor::PrescheduleThink()
+{
+	BaseClass::PrescheduleThink();
+
+	if ( IsPreparingToThrow() && m_iThrowAnimDir != 2 )
+	{
+		Vector vecLookOrigin = m_hvStagedEnts[0]->GetAbsOrigin();
+
+		if (m_hvStagedEnts.Count() > 1)
+		{
+			// Get a vague center
+			for (int i = 1; i < m_hvStagedEnts.Count(); i++)
+			{
+				if (m_hvStagedEnts[i])
+					vecLookOrigin += ((vecLookOrigin - m_hvStagedEnts[i]->GetAbsOrigin()) * 0.5f);
+			}
+		}
+
+		AddLookTarget( vecLookOrigin, 1.0, 0.5 );
+	}
+	else if ( IsCurSchedule( SCHED_ADVISOR_COMBAT, false ) )
+	{
+		AddLookTarget( GetEnemy(), 1.0, 0.5/*, 0.2*/ );
+	}
+}
+#endif
 
 void CNPC_Advisor::HandleAnimEvent(animevent_t *pEvent)
 {
-	switch (pEvent->event)
+	if (pEvent->type & AE_TYPE_NEWEVENTSYSTEM)
 	{
-	case ADVISOR_MELEE_LEFT:
-	{
-		CBaseEntity *pHurt = CheckTraceHullAttack(70, -Vector(128, 128, 128), Vector(128, 128, 128), sk_advisor_melee_dmg.GetFloat(), DMG_SLASH);
-		if (pHurt)
+		if ( pEvent->event == ADVISOR_AE_DETACH_R_ARM )
 		{
-			Vector forward, up;
-			AngleVectors(GetLocalAngles(), &forward, NULL, &up);
-
-			if (pHurt->GetFlags() & (FL_NPC | FL_CLIENT))
-			{
-				pHurt->ViewPunch(QAngle(5, 0, random->RandomInt(-10, 10)));
-			}
-			// Spawn some extra blood if we hit a BCC
-			CBaseCombatCharacter* pBCC = ToBaseCombatCharacter(pHurt);
-			if (pBCC)
-			{
-				SpawnBlood(pBCC->EyePosition(), g_vecAttackDir, pBCC->BloodColor(), sk_advisor_melee_dmg.GetFloat());
-			}
-			// Play a attack hit sound
-			EmitSound("NPC_Stalker.Hit");
+			InputDetachRightArm( inputdata_t() );
 		}
-		break;
-	}
-
-	case ADVISOR_MELEE_RIGHT:
-	{
-		CBaseEntity *pHurt = CheckTraceHullAttack(70, -Vector(128, 128, 128), Vector(128, 128, 128), sk_advisor_melee_dmg.GetFloat(), DMG_SLASH);
-		if (pHurt)
+		else if ( pEvent->event == ADVISOR_AE_DETACH_L_ARM )
 		{
-			Vector forward, up;
-			AngleVectors(GetLocalAngles(), &forward, NULL, &up);
-
-			if (pHurt->GetFlags() & (FL_NPC | FL_CLIENT))
-			{
-				pHurt->ViewPunch(QAngle(5, 0, random->RandomInt(-10, 10)));
-			}
-			// Spawn some extra blood if we hit a BCC
-			CBaseCombatCharacter* pBCC = ToBaseCombatCharacter(pHurt);
-			if (pBCC)
-			{
-				SpawnBlood(pBCC->EyePosition(), g_vecAttackDir, pBCC->BloodColor(), sk_advisor_melee_dmg.GetFloat());
-			}
-			// Play a attack hit sound
-			EmitSound("NPC_Stalker.Hit");
+			InputDetachLeftArm( inputdata_t() );
 		}
-		break;
+		else
+		{
+			BaseClass::HandleAnimEvent( pEvent );
+		}
 	}
+	else
+	{
+		switch (pEvent->event)
+		{
+		case ADVISOR_MELEE_LEFT:
+		{
+#ifdef EZ2
+			// If we don't have a left arm, early out
+			int iAccessory = GetCurrentAccessories();
+			if (iAccessory != ADVISOR_ACCESSORY_ARMS && iAccessory != ADVISOR_ACCESSORY_L_ARM)
+				break;
+#endif
 
-	default:
-		BaseClass::HandleAnimEvent(pEvent);
-		break;
+			CBaseEntity *pHurt = CheckTraceHullAttack(70, -Vector(128, 128, 224), Vector(128, 128, 64), sk_advisor_melee_dmg.GetFloat(), DMG_SLASH);
+			if (pHurt)
+			{
+				Vector forward, up;
+				AngleVectors(GetLocalAngles(), &forward, NULL, &up);
+
+				if (pHurt->GetFlags() & (FL_NPC | FL_CLIENT))
+				{
+					pHurt->ViewPunch(QAngle(5, 0, random->RandomInt(-10, 10)));
+				}
+				// Spawn some extra blood if we hit a BCC
+				CBaseCombatCharacter* pBCC = ToBaseCombatCharacter(pHurt);
+				if (pBCC)
+				{
+					SpawnBlood(pBCC->EyePosition(), g_vecAttackDir, pBCC->BloodColor(), sk_advisor_melee_dmg.GetFloat());
+				}
+				// Play a attack hit sound
+#ifdef EZ2
+				EmitSound("NPC_Advisor.Melee_Hit");
+#else
+				EmitSound("NPC_Stalker.Hit");
+#endif
+			}
+#ifdef EZ2
+			else
+			{
+				EmitSound( "NPC_Advisor.Melee_Miss" );
+			}
+#endif
+			break;
+		}
+
+		case ADVISOR_MELEE_RIGHT:
+		{
+#ifdef EZ2
+			// If we don't have a right arm, early out
+			int iAccessory = GetCurrentAccessories();
+			if (iAccessory != ADVISOR_ACCESSORY_ARMS && iAccessory != ADVISOR_ACCESSORY_R_ARM)
+				break;
+#endif
+
+			CBaseEntity *pHurt = CheckTraceHullAttack(70, -Vector(128, 128, 224), Vector(128, 128, 64), sk_advisor_melee_dmg.GetFloat(), DMG_SLASH);
+			if (pHurt)
+			{
+				Vector forward, up;
+				AngleVectors(GetLocalAngles(), &forward, NULL, &up);
+
+				if (pHurt->GetFlags() & (FL_NPC | FL_CLIENT))
+				{
+					pHurt->ViewPunch(QAngle(5, 0, random->RandomInt(-10, 10)));
+				}
+				// Spawn some extra blood if we hit a BCC
+				CBaseCombatCharacter* pBCC = ToBaseCombatCharacter(pHurt);
+				if (pBCC)
+				{
+					SpawnBlood(pBCC->EyePosition(), g_vecAttackDir, pBCC->BloodColor(), sk_advisor_melee_dmg.GetFloat());
+				}
+				// Play a attack hit sound
+#ifdef EZ2
+				EmitSound("NPC_Advisor.Melee_Hit");
+#else
+				EmitSound("NPC_Stalker.Hit");
+#endif
+			}
+#ifdef EZ2
+			else
+			{
+				EmitSound( "NPC_Advisor.Melee_Miss" );
+			}
+#endif
+			break;
+		}
+
+		default:
+			BaseClass::HandleAnimEvent(pEvent);
+			break;
+		}
 	}
 }
 
@@ -2341,14 +3714,28 @@ void CNPC_Advisor::Precache()
 	PrecacheScriptSound( "NPC_Advisor.shieldblock" );
 	PrecacheScriptSound( "NPC_Advisor.shieldup" );
 	PrecacheScriptSound( "NPC_Advisor.shielddown" );
+	PrecacheScriptSound( "DoSpark" );
 
 	PrecacheParticleSystem( "Advisor_Psychic_Shield_Idle" );
+	//PrecacheParticleSystem( "Advisor_Throw_Obj_Charge" );
+	PrecacheParticleSystem( "tele_warp" );
+
+	PrecacheParticleSystem( "blood_advisor_shrapnel_impact" );
+	PrecacheParticleSystem( "blood_advisor_shrapnel_spurt_1" );
+	PrecacheParticleSystem( "blood_advisor_shrapnel_spurt_2" );
+	//PrecacheParticleSystem( "blood_antlionguard_injured_heavy" );
+	//PrecacheParticleSystem( "blood_drip_synth_01" );
 #endif
 		
 	PrecacheModel( STRING( GetModelName() ) );
 
 #if NPC_ADVISOR_HAS_BEHAVIOR
 	PrecacheModel( "sprites/lgtning.vmt" );
+#endif
+
+#ifdef EZ2
+	PrecacheModel( "models/advisor_combat_arm_r_detached.mdl" );
+	PrecacheModel( "models/advisor_combat_arm_l_detached.mdl" );
 #endif
 
 	PrecacheScriptSound( "NPC_Advisor.Blast" );
@@ -2362,7 +3749,14 @@ void CNPC_Advisor::Precache()
 	PrecacheParticleSystem( "advisor_object_charge" );
 	PrecacheModel("sprites/greenglow1.vmt");
 
+#ifdef EZ2
+	PrecacheScriptSound( "NPC_Advisor.Melee_Hit" );
+	PrecacheScriptSound( "NPC_Advisor.Melee_Miss" );
+
+	PrecacheScriptSound( "NPC_Advisor.ArmDetach" );
+#else
 	PrecacheScriptSound("NPC_Stalker.Hit");
+#endif
 }
 
 
@@ -2502,6 +3896,16 @@ void CNPC_Advisor::InputStopFlying( inputdata_t & inputdata )
 	StopFlying();
 }
 
+void CNPC_Advisor::InputSetFollowTarget( inputdata_t & inputdata )
+{
+	m_hFollowTarget = inputdata.value.Entity();
+
+	if (m_hFollowTarget)
+		SetContextThink( &CNPC_Advisor::FlyThink, gpGlobals->curtime + TICK_INTERVAL, ADVISOR_FLY_THINK );
+	else
+		SetContextThink( NULL, 0.0f, ADVISOR_FLY_THINK );
+}
+
 void CNPC_Advisor::InputStartPsychicShield( inputdata_t & inputdata )
 {
 	m_bPsychicShieldOn = true;
@@ -2514,6 +3918,56 @@ void CNPC_Advisor::InputStopPsychicShield( inputdata_t & inputdata )
 	ApplyShieldedEffects();
 }
 
+void CNPC_Advisor::InputDetachRightArm( inputdata_t &inputdata )
+{
+	int iCurAccessory = GetCurrentAccessories();
+	AdvisorAccessory_t iNewBody = ADVISOR_ACCESSORY_NONE;
+
+	switch (iCurAccessory)
+	{
+		case ADVISOR_ACCESSORY_ARMS:
+			iNewBody = ADVISOR_ACCESSORY_L_ARM;
+			break;
+
+		case ADVISOR_ACCESSORY_R_ARM:
+			iNewBody = ADVISOR_ACCESSORY_ARMS_STUBBED;
+			break;
+	}
+
+	if (iNewBody != ADVISOR_ACCESSORY_NONE)
+	{
+		SetCurrentAccessories( iNewBody );
+
+		EmitSound( "NPC_Advisor.ArmDetach" );
+
+		CreateDetachedArm( false );
+	}
+}
+
+void CNPC_Advisor::InputDetachLeftArm( inputdata_t &inputdata )
+{
+	int iCurAccessory = GetCurrentAccessories();
+	AdvisorAccessory_t iNewBody = ADVISOR_ACCESSORY_NONE;
+
+	switch (iCurAccessory)
+	{
+		case ADVISOR_ACCESSORY_ARMS:
+			iNewBody = ADVISOR_ACCESSORY_R_ARM;
+			break;
+
+		case ADVISOR_ACCESSORY_L_ARM:
+			iNewBody = ADVISOR_ACCESSORY_ARMS_STUBBED;
+			break;
+	}
+
+	if (iNewBody != ADVISOR_ACCESSORY_NONE)
+	{
+		SetCurrentAccessories( iNewBody );
+
+		CreateDetachedArm( true );
+	}
+}
+
 #endif
 
 //-----------------------------------------------------------------------------
@@ -2523,6 +3977,27 @@ void CNPC_Advisor::OnScheduleChange( void )
 {
 	Write_AllBeamsOff();
 	m_hvStagedEnts.RemoveAll();
+
+#ifdef EZ2
+	if (!m_hPlayerPinPos)
+	{
+		// Make sure we're not pinning
+		CBasePlayer *pLocalPlayer = AI_GetSinglePlayer();
+		if (pLocalPlayer && pLocalPlayer->GetMoveType() == MOVETYPE_FLY)
+		{
+			StopPinPlayer( inputdata_t() );
+			pLocalPlayer->SetGravity( 1.0f );
+			pLocalPlayer->SetMoveType( MOVETYPE_WALK );
+			Write_BeamOff( pLocalPlayer );
+			beamonce = 1;
+		}
+	}
+
+	SetEyeState( ADVISOR_EYE_NORMAL );
+
+	SetIdealActivity( ACT_IDLE );
+#endif
+
 	BaseClass::OnScheduleChange();
 }
 
@@ -2574,6 +4049,9 @@ void CNPC_Advisor::GatherConditions( void )
 		}
 		ClearCondition( COND_ADVISOR_STAGGER );
 	}
+
+	// Don't fall to ground!
+	ClearCondition( COND_FLOATING_OFF_GROUND );
 #endif
 }
 
@@ -2720,6 +4198,27 @@ void CNPC_Advisor::ParticleThink()
 	}
 
 	ApplyShieldedEffects();
+	
+	float flHealthRatio = (float)GetHealth() / (float)GetMaxHealth();
+	if ( flHealthRatio < advisor_sparks_health_ratio_max.GetFloat() )
+	{
+		// Random chance of sparks coming from one of our jets, increases with lower health
+		float flChance = RandomFloat( 0, flHealthRatio );
+		if (flChance <= advisor_sparks_health_ratio_min.GetFloat())
+		{
+			Vector vecSparkPosition, vecSparkDir;
+			switch (RandomInt( 0, 3 ))
+			{
+				case 0: GetAttachment( gm_nLFrontTopJetAttachment, vecSparkPosition, &vecSparkDir ); break;
+				case 1: GetAttachment( gm_nRFrontTopJetAttachment, vecSparkPosition, &vecSparkDir ); break;
+				case 2: GetAttachment( gm_nLRearTopJetAttachment, vecSparkPosition, &vecSparkDir ); break;
+				case 3: GetAttachment( gm_nRRearTopJetAttachment, vecSparkPosition, &vecSparkDir ); break;
+			}
+
+			g_pEffects->Sparks( vecSparkPosition, (1.0f / flHealthRatio), RandomInt( 1, 4 ), &vecSparkDir );
+			EmitSound( "DoSpark" );
+		}
+	}
 
 	SetNextThink( gpGlobals->curtime + 1.0f, ADVISOR_PARTICLE_THINK );
 }
@@ -2774,6 +4273,77 @@ void CNPC_Advisor::InputElightOff( inputdata_t &inputdata )
 	WRITE_BYTE( ADVISOR_MSG_STOP_ELIGHT );
 	MessageEnd();
 }
+
+//------------------------------------------------------------------------------
+// Purpose: 
+//------------------------------------------------------------------------------
+float CNPC_AdvisorFlyer::GetGoalDistance()
+{
+	if (GetOwnerEntity())
+	{
+		CNPC_Advisor *pAdvisor = static_cast<CNPC_Advisor *>(GetOwnerEntity());
+
+		// If preparing to throw or have no defenses, get away
+		if (pAdvisor->IsPreparingToThrow() || !(pAdvisor->CapabilitiesGet() & bits_CAP_INNATE_MELEE_ATTACK1))
+		{
+			return BaseClass::GetGoalDistance() * 2.5f;
+		}
+	}
+
+	return BaseClass::GetGoalDistance();
+}
+
+//------------------------------------------------------------------------------
+// Purpose: 
+//------------------------------------------------------------------------------
+float CNPC_AdvisorFlyer::MinGroundDist()
+{
+	if (GetOwnerEntity())
+	{
+		CNPC_Advisor *pAdvisor = static_cast<CNPC_Advisor *>(GetOwnerEntity());
+
+		// If the advisor is in melee range, get closer
+		if (pAdvisor->HasCondition( COND_CAN_MELEE_ATTACK1 ))
+		{
+			return 72.0f;
+		}
+	}
+
+	return 96.0f;
+}
+
+//------------------------------------------------------------------------------
+// Purpose: 
+//------------------------------------------------------------------------------
+float CAI_AdvisorMotor::GetPitchSpeed() const
+{
+	if (GetAdvisorOuter())
+	{
+		return GetAdvisorOuter()->MaxPitchSpeed();
+	}
+
+	return 18.0f;
+}
+
+inline CNPC_Advisor *CAI_AdvisorMotor::GetAdvisorOuter()
+{
+	return static_cast<CNPC_Advisor*>(GetOuter());
+}
+
+inline const CNPC_Advisor *CAI_AdvisorMotor::GetAdvisorOuter() const
+{
+	return static_cast<const CNPC_Advisor*>(GetOuter());
+}
+
+inline CNPC_AdvisorFlyer *CAI_AdvisorMotor::GetAdvisorFlyer()
+{
+	return GetAdvisorOuter()->GetAdvisorFlyer();
+}
+
+inline const CNPC_AdvisorFlyer *CAI_AdvisorMotor::GetAdvisorFlyer() const
+{
+	return GetAdvisorOuter()->GetAdvisorFlyer();
+}
 #endif
 
 
@@ -2789,7 +4359,8 @@ CAdvisorLevitate::simresult_e	CAdvisorLevitate::Simulate( IPhysicsMotionControll
 	if ( !OldStyle() )
 	{	// independent movement of all objects
 		// if an object was recently thrown, just zero out its gravity.
-		if (pAdvisor->DidThrow(static_cast<CBaseEntity *>(pObject->GetGameData())))
+		CBaseEntity *pEnt = static_cast<CBaseEntity *>(pObject->GetGameData());
+		if (pAdvisor->DidThrow(pEnt))
 		{
 			linear = Vector( 0, 0, GetCurrentGravity() );
 			
@@ -2832,6 +4403,45 @@ CAdvisorLevitate::simresult_e	CAdvisorLevitate::Simulate( IPhysicsMotionControll
 					angular = Vector( 0, 0, 10 );
 				}
 			}
+
+#ifdef EZ2
+			// DEACTIVATED FOR NOW
+			// We could really use a solution which pushes props we aren't staging
+			/*
+			float flOurRadius = 64.0f;
+			if (pEnt)
+				flOurRadius = pEnt->BoundingRadius() * 1.5f;
+
+			Vector vecAdvisorCenter = pAdvisor->GetAbsOrigin();
+			float flAdvisorDistSqr = (vecAdvisorCenter - pos).LengthSqr() - Square( flOurRadius );
+			if (flAdvisorDistSqr <= Square(advisor_push_max_radius.GetFloat()))
+			{
+				Vector vecAdvisorVel;
+				VectorMultiply( pAdvisor->GetAbsVelocity(), advisor_push_delta.GetFloat(), vecAdvisorVel );
+			
+				float flTotalRadius = flOurRadius + pAdvisor->BoundingRadius() * 2.0f;
+				float t1, t2;
+				if ( IntersectRayWithSphere( vecAdvisorCenter, vecAdvisorVel,
+					pos, flTotalRadius, &t1, &t2 ) )
+				{
+					// Push it away from the advisor's path
+					Vector vecClosest;
+					CalcClosestPointOnLineSegment( pos, vecAdvisorCenter, vecAdvisorCenter + vecAdvisorVel, vecClosest, NULL );
+
+					Vector vecForceDir = (pos - vecClosest);
+					VectorNormalize( vecForceDir );
+					vecForceDir *= pObject->GetMass();
+
+					//angular += vecForceDir;
+
+					// The closer we are to the advisor, the more force we'll get
+					vecForceDir *= RemapVal( flAdvisorDistSqr, Square(advisor_push_max_radius.GetFloat()), 0.0f, 0.0f, advisor_push_max_force_scale.GetFloat() );
+					
+					linear += vecForceDir;
+				}
+			}
+			*/
+#endif
 			
 			return SIM_GLOBAL_ACCELERATION;
 		}
@@ -2922,6 +4532,18 @@ const impactdamagetable_t &CNPC_Advisor::GetPhysicsImpactDamageTable( void )
 //-----------------------------------------------------------------------------
 AI_BEGIN_CUSTOM_NPC( npc_advisor, CNPC_Advisor )
 
+#ifdef EZ2
+	DECLARE_ACTIVITY( ACT_ADVISOR_OBJECT_R_HOLD )
+	DECLARE_ACTIVITY( ACT_ADVISOR_OBJECT_R_THROW )
+	DECLARE_ACTIVITY( ACT_ADVISOR_OBJECT_L_HOLD )
+	DECLARE_ACTIVITY( ACT_ADVISOR_OBJECT_L_THROW )
+	DECLARE_ACTIVITY( ACT_ADVISOR_OBJECT_BOTH_HOLD )
+	DECLARE_ACTIVITY( ACT_ADVISOR_OBJECT_BOTH_THROW )
+
+	DECLARE_ANIMEVENT( ADVISOR_AE_DETACH_R_ARM )
+	DECLARE_ANIMEVENT( ADVISOR_AE_DETACH_L_ARM )
+#endif
+
 	DECLARE_TASK( TASK_ADVISOR_FIND_OBJECTS )
 	DECLARE_TASK( TASK_ADVISOR_LEVITATE_OBJECTS )
 	/*
@@ -2942,6 +4564,7 @@ AI_BEGIN_CUSTOM_NPC( npc_advisor, CNPC_Advisor )
 
 #ifdef EZ2
 	DECLARE_TASK( TASK_ADVISOR_STAGGER )
+	DECLARE_TASK( TASK_ADVISOR_WAIT_FOR_ACTIVITY )
 #endif
 	
 #ifndef EZ2
@@ -2998,14 +4621,13 @@ AI_BEGIN_CUSTOM_NPC( npc_advisor, CNPC_Advisor )
 		"		TASK_ADVISOR_FIND_OBJECTS			0"
 		"		TASK_ADVISOR_LEVITATE_OBJECTS		0"
 		"		TASK_ADVISOR_STAGE_OBJECTS			1"
-		"		TASK_FACE_ENEMY						0"
 		"		TASK_ADVISOR_BARRAGE_OBJECTS		0"
+		"		TASK_ADVISOR_WAIT_FOR_ACTIVITY		0"
 		"	"
 		"	Interrupts"
 		"		COND_ADVISOR_PHASE_INTERRUPT"
 		"		COND_ENEMY_DEAD"
-		"		COND_ADVISOR_FORCE_PIN"
-		"		COND_CAN_MELEE_ATTACK1"
+		//"		COND_CAN_MELEE_ATTACK1" // See BuildScheduleTestBits()
 		"       COND_ADVISOR_STAGGER"
 	)
 
@@ -3022,7 +4644,6 @@ AI_BEGIN_CUSTOM_NPC( npc_advisor, CNPC_Advisor )
 			"		COND_NEW_ENEMY"
 			"		COND_SEE_FEAR"
 			"		COND_ADVISOR_PHASE_INTERRUPT"
-			"		COND_ADVISOR_FORCE_PIN"
 		)
 
 		DEFINE_SCHEDULE
@@ -3030,11 +4651,10 @@ AI_BEGIN_CUSTOM_NPC( npc_advisor, CNPC_Advisor )
 			SCHED_ADVISOR_TOSS_PLAYER,
 
 			"	Tasks"
-			"		TASK_FACE_ENEMY						0"
+			//"		TASK_FACE_ENEMY						0"
 			"		TASK_ADVISOR_PIN_PLAYER				0"
 			"	"
 			"	Interrupts"
-			"       COND_ADVISOR_FORCE_PIN"
 			"       COND_ADVISOR_STAGGER"
 		)
 
@@ -3049,7 +4669,20 @@ AI_BEGIN_CUSTOM_NPC( npc_advisor, CNPC_Advisor )
 			""
 			"	Interrupts"
 			"		COND_ADVISOR_PHASE_INTERRUPT"
-			"		COND_ADVISOR_FORCE_PIN"
+		)
+
+		DEFINE_SCHEDULE
+		(
+			SCHED_ADVISOR_MELEE_ATTACK1,
+
+			"	Tasks"
+			"		TASK_MELEE_ATTACK1		0"
+			""
+			"	Interrupts"
+			"		COND_NEW_ENEMY"
+			"		COND_ENEMY_DEAD"
+			"		COND_LIGHT_DAMAGE"
+			"		COND_HEAVY_DAMAGE"
 		)
 #endif
 

--- a/sp/src/game/server/hl2/npc_attackchopper.cpp
+++ b/sp/src/game/server/hl2/npc_attackchopper.cpp
@@ -5966,6 +5966,18 @@ void CAvoidBox::ComputeAvoidanceForces( CBaseEntity *pEntity, float flEntityRadi
 }
 
 
+#ifdef EZ2
+void GetAvoidanceForcesForAdvisor( Vector &vecOutForce, CBaseEntity *pEntity, float flEntityRadius, float flAvoidTime )
+{
+	Vector vecAvoidForce;
+	CAvoidSphere::ComputeAvoidanceForces( pEntity, flEntityRadius, flAvoidTime, &vecAvoidForce );
+	vecOutForce += vecAvoidForce;
+	CAvoidBox::ComputeAvoidanceForces( pEntity, flEntityRadius, flAvoidTime, &vecAvoidForce );
+	vecOutForce += vecAvoidForce;
+}
+#endif
+
+
 //-----------------------------------------------------------------------------
 //
 // This entity is used to create little force boxes that the helicopters should avoid. 

--- a/sp/src/game/server/hl2/npc_scanner.h
+++ b/sp/src/game/server/hl2/npc_scanner.h
@@ -148,7 +148,13 @@ protected:
 
 private:
 	bool			MovingToInspectTarget( void );
+#ifdef EZ2
+protected:
 	virtual float	GetGoalDistance( void );
+private:
+#else
+	virtual float	GetGoalDistance( void );
+#endif
 
 	bool m_bIsClawScanner;	// Formerly the shield scanner.
 	bool m_bIsOpen;			// Only for claw scanner


### PR DESCRIPTION
This PR makes several major changes to the advisor NPC, primarily in regards to its animations and turning.

Some highlights of this PR:

* The advisor now uses its own unique motor which lets it smoothly turn on a full 3-dimensional axis.
* The advisor now supports head turning (i.e. looking at stuff like humans do), with its head and camera moving separately from each other.
* The advisor now uses unique activities for holding and throwing props.
* The advisor now has an eye glow which changes based on the advisor's shield state, prop-throwing task, and health.
* The advisor's arms are now capable of detaching via inputs and animation events.

---

This PR also includes a more general (but still related) change which allows NPCs who turn into ragdolls via an animation event to turn into serverside ragdolls instead. This should fix cases where, for example, hunters and citizens turned into clientside ragdolls after death animations or dynamic interactions.