### PR TITLE
Misc. surrender behavior fixes

### DIFF
--- a/sp/src/game/server/ez2/ai_behavior_surrender.h
+++ b/sp/src/game/server/ez2/ai_behavior_surrender.h
@@ -94,7 +94,7 @@ public:
 	void	ComputeAndSetRenderBounds();
 	void	ResetBounds();
 
-	bool CanSurrender() { return m_bCanSurrender; }
+	bool CanSurrender();
 	virtual void Surrender( CBaseCombatCharacter *pCaptor );
 	void StopSurrendering();
 	inline bool IsSurrendered() const { return m_bSurrendered; }


### PR DESCRIPTION
- For now, fixed citizens falling through displacements by making them unable to fall when surrendered on the ground.
- Fixed citizens in scripts invisibly surrendering.
- Added a condition for citizens to interrupt schedules when ordered to surrender in the same way they would be interrupted by, for example, player command orders.
- Added `CLASS_COMBINE_NEMESIS` to the list of Combine captor classes.