### PR TITLE
Metrocops use model KV for eye glows

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -2057,9 +2057,17 @@ EyeGlow_t * CAI_BaseNPC::GetEyeGlowData( int i )
 				pSkin = glowskins[m_nSkin % glowskins.Count()];
 				if (pSkin)
 				{
+					Color color = pSkin->GetColor( "color" );
+
+					// 0 alpha means this skin should not use an eye glow
+					if (color.a() == 0)
+					{
+						modelKeyValues->deleteThis();
+						return NULL;
+					}
+
 					eyeGlow = new EyeGlow_t();
 
-					Color color = pSkin->GetColor( "color" );
 					eyeGlow->red = color.r();
 					eyeGlow->green = color.g();
 					eyeGlow->blue = color.b();

--- a/sp/src/game/server/hl2/npc_metropolice.cpp
+++ b/sp/src/game/server/hl2/npc_metropolice.cpp
@@ -6165,47 +6165,6 @@ void CNPC_MetroPolice::PrecriminalUse( CBaseEntity *pActivator, CBaseEntity *pCa
 	}
 }
 
-#ifdef EZ
-//-----------------------------------------------------------------------------
-// Purpose: Return the glow attributes for a given index
-//-----------------------------------------------------------------------------
-EyeGlow_t * CNPC_MetroPolice::GetEyeGlowData(int i)
-{
-	EyeGlow_t * eyeGlow = BaseClass::GetEyeGlowData( i );
-
-	if (eyeGlow != NULL)
-		return eyeGlow;
-
-	if (i != 0)
-		return NULL;
-
-	eyeGlow = new EyeGlow_t();
-
-	eyeGlow->spriteName = AllocPooledString("sprites/light_glow02.vmt");
-	eyeGlow->attachment = AllocPooledString("eyes");
-
-	eyeGlow->alpha = 100;
-	eyeGlow->red = 0;
-	eyeGlow->green = 255;
-	eyeGlow->blue = 255;
-	eyeGlow->scale = 0.3f;
-	eyeGlow->proxyScale = 3.0f;
-	eyeGlow->renderMode = kRenderGlow;
-	return eyeGlow;
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: If the metrocop has NVG on, it has 1 glow sprite
-//		Otherwise 0
-//-----------------------------------------------------------------------------
-int CNPC_MetroPolice::GetNumGlows()
-{
-	if (m_nSkin == 1)
-		return 1;
-	return 0;
-}
-#endif
-
 //-----------------------------------------------------------------------------
 //
 // Schedules

--- a/sp/src/game/server/hl2/npc_metropolice.h
+++ b/sp/src/game/server/hl2/npc_metropolice.h
@@ -360,11 +360,6 @@ private:
 	virtual bool IsWaitingToRappel( void ) { return m_RappelBehavior.IsWaitingToRappel(); }
 	void BeginRappel() { m_RappelBehavior.BeginRappel(); }
 
-#ifdef EZ
-	EyeGlow_t	* GetEyeGlowData(int i);
-	int			  GetNumGlows();
-#endif
-
 private:
 	enum
 	{


### PR DESCRIPTION
Fixes elite cop not having an eye glow. Also includes a base change which allows the first skin to have no eye glow.