### PR TITLE
Two misc. soldier fixes

### DIFF
--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -4836,7 +4836,12 @@ int CNPC_Combine::MeleeAttack1Conditions ( float flDot, float flDist )
 	if ( GetEnemy() && fabs(GetEnemy()->GetAbsOrigin().z - GetAbsOrigin().z) > 64 )
 		return COND_NONE;
 
+#ifdef EZ
+	// Soldiers are incapable of kicking the babies
+	if ( GetEnemy() && GetEnemy()->IsNPC() && GetEnemy()->MyNPCPointer()->GetHullType() == HULL_TINY )
+#else
 	if ( dynamic_cast<CBaseHeadcrab *>(GetEnemy()) != NULL )
+#endif
 	{
 		return COND_NONE;
 	}

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -2801,7 +2801,8 @@ void CNPC_Combine::AnnounceAssault(void)
 	if ( FVisible( pBCC ) )
 	{
 #ifdef EZ2
-		AddGesture( ACT_GESTURE_SIGNAL_ADVANCE );
+		if (GetSquad() && GetSquad()->NumMembers() > 1)
+			AddGesture( ACT_GESTURE_SIGNAL_ADVANCE );
 #endif
 #ifdef COMBINE_SOLDIER_USES_RESPONSE_SYSTEM
 		SpeakIfAllowed( TLK_CMB_ASSAULT );


### PR DESCRIPTION
These are two minor Combine soldier fixes I made a while ago which I recently rediscovered.

1. Soldiers will no longer use an advance gesture when there's nobody else in their squad.
2. Soldiers will no longer attempt to melee any NPC with a tiny hull, as their trace wouldn't reach them. This was previously exclusive to headcrabs, but it needed to be broadened in this case due to baby predator NPCs.