### PR TITLE
Combine soldiers being able to order surrender is default

### DIFF
--- a/sp/src/game/server/ez2/npc_clonecop.cpp
+++ b/sp/src/game/server/ez2/npc_clonecop.cpp
@@ -69,7 +69,7 @@ CNPC_CloneCop::CNPC_CloneCop()
 	m_SquadName = MAKE_STRING( IsBadCop() ? "bc_squad" : "cc_squad" );
 
 	// TODO - See comment in npc_combine.cpp
-	// Clone Cop probably sohuldn't order surrender by default
+	// Clone Cop probably shouldn't order surrender by default
 	m_bCanOrderSurrender = false;
 }
 

--- a/sp/src/game/server/ez2/npc_clonecop.cpp
+++ b/sp/src/game/server/ez2/npc_clonecop.cpp
@@ -67,6 +67,10 @@ CNPC_CloneCop::CNPC_CloneCop()
 	m_bThrowXenGrenades = true;
 	SetDisplacementImpossible( true );
 	m_SquadName = MAKE_STRING( IsBadCop() ? "bc_squad" : "cc_squad" );
+
+	// TODO - See comment in npc_combine.cpp
+	// Clone Cop probably sohuldn't order surrender by default
+	m_bCanOrderSurrender = false;
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -352,6 +352,11 @@ CNPC_Combine::CNPC_Combine()
 	m_iNumGrenades = 5;
 
 	m_bDontPickupWeapons = true;
+
+	// TODO - Ordering surrender is on by default. This could become an issue.
+	// Consider making it a three-state variable and using a ConVar or Global Var
+	// to track default behavior.
+	m_bCanOrderSurrender = true;
 #endif
 }
 


### PR DESCRIPTION
Quick change to set the key value for ordering surrender to on by default. This means all Combine soldiers will be able to order surrenders unless the key value is set to false explicitly.