### PR TITLE
Pit Drones set projectile model before spawning projectile

### DIFF
--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -303,10 +303,10 @@ void CNPC_PitDrone::HandleAnimEvent( animevent_t *pEvent )
 				UTIL_SetOrigin( pBolt, vSpitPos );
 				pBolt->SetAbsAngles( angAiming );
 				pBolt->KeyValue( "ImpactEffect", "DroneBoltImpact" );
+				pBolt->SetModel( "models/pitdrone_projectile.mdl" );
 				pBolt->Spawn();
 				pBolt->SetOwnerEntity( this );
 				pBolt->SetDamage( GetProjectileDamge() );
-				pBolt->SetModel( "models/pitdrone_projectile.mdl" );
 
 				if ( this->GetWaterLevel() == 3 )
 				{

--- a/sp/src/game/server/hl2/weapon_crossbow.cpp
+++ b/sp/src/game/server/hl2/weapon_crossbow.cpp
@@ -215,9 +215,13 @@ bool CCrossbowBolt::CreateSprites( void )
 //-----------------------------------------------------------------------------
 void CCrossbowBolt::Spawn( void )
 {
+#ifndef EZ
 	Precache( );
 
 	SetModel( "models/crossbow_bolt.mdl" );
+#else
+	Precache();
+#endif
 	SetMoveType( MOVETYPE_FLYGRAVITY, MOVECOLLIDE_FLY_CUSTOM );
 	UTIL_SetSize( this, -Vector(0.3f,0.3f,0.3f), Vector(0.3f,0.3f,0.3f) );
 	SetSolid( SOLID_BBOX );
@@ -243,7 +247,14 @@ void CCrossbowBolt::Precache( void )
 	PrecacheModel( BOLT_MODEL );
 
 	// This is used by C_TEStickyBolt, despte being different from above!!!
+#ifndef EZ
 	PrecacheModel( "models/crossbow_bolt.mdl" );
+#else
+	if ( GetModelName() == NULL_STRING )
+		SetModel( "models/crossbow_bolt.mdl" );
+
+	PrecacheModel( STRING( GetModelName() ) );
+#endif
 
 	PrecacheModel( "sprites/light_glow02_noz.vmt" );
 }


### PR DESCRIPTION
Previously, there was a bug with Pit Drone spines where they would collide incorrectly. This seems to have something to do with their collisions re-initializing when their model is assigned after spawning.

This PR changes crossbow bolts to accept custom models and has the pit drone set the spine model on the crossbow bolt before spawning.