### PR TITLE
Predator NPCs check hit entity before applying physics

### DIFF
--- a/sp/src/game/server/ez2/npc_bullsquid.cpp
+++ b/sp/src/game/server/ez2/npc_bullsquid.cpp
@@ -457,13 +457,15 @@ void CNPC_Bullsquid::HandleAnimEvent( animevent_t *pEvent )
 			if ( pHurt ) 
 			{
 				// TODO - This should ALWAYS create a server ragdoll regardless of the convar setting
-				Vector right, up;
-				AngleVectors( GetAbsAngles(), NULL, &right, &up );
-
 				if ( pHurt->GetFlags() & ( FL_NPC | FL_CLIENT ) )
 					 pHurt->ViewPunch( QAngle( 20, 0, -20 ) );
 			
-				pHurt->ApplyAbsVelocityImpulse( 100 * (up+2*right) * GetModelScale() * ( m_bIsBaby ? 0.5f : 1.0f ) );
+				if ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS )
+				{
+					Vector right, up;
+					AngleVectors( GetAbsAngles(), NULL, &right, &up );
+					pHurt->ApplyAbsVelocityImpulse( 100 * (up+2*right) * GetModelScale() * (m_bIsBaby ? 0.5f : 1.0f) );
+				}
 			}
 		}
 		break;
@@ -553,7 +555,7 @@ CBaseEntity * CNPC_Bullsquid::BiteAttack( float flDist, const Vector & mins, con
 			m_flHungryTime = gpGlobals->curtime + 10.0f; // Headcrabs only satiate the squid for 10 seconds
 		}
 		// I don't want that!
-		else
+		else if( pVictim || pHurt->GetMoveType() == MOVETYPE_FLY )
 		{
 			Vector forward, up;
 			AngleVectors( GetAbsAngles(), &forward, NULL, &up );

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -334,7 +334,11 @@ void CNPC_PitDrone::HandleAnimEvent( animevent_t *pEvent )
 			if (pHurt)
 			{
 				BiteSound(); // Only play the bite sound if we have a target
+			}
 
+			// Apply a velocity to hit entity if it is a character or if it has a physics movetype
+			if ( pHurt && ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS ) )
+			{
 				Vector forward, up;
 				AngleVectors( GetAbsAngles(), &forward, NULL, &up );
 				pHurt->ApplyAbsVelocityImpulse( 100 * (up-forward) * GetModelScale() );
@@ -354,13 +358,16 @@ void CNPC_PitDrone::HandleAnimEvent( animevent_t *pEvent )
 			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetWhipDamage(), DMG_SLASH | DMG_ALWAYSGIB );
 			if (pHurt)
 			{
-				Vector right, up;
-				AngleVectors( GetAbsAngles(), NULL, &right, &up );
-
 				if (pHurt->GetFlags() & (FL_NPC | FL_CLIENT))
 					pHurt->ViewPunch( QAngle( 20, 0, -20 ) );
 
-				pHurt->ApplyAbsVelocityImpulse( 100 * (up+2*right) * GetModelScale() );
+				if ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS )
+				{
+					Vector right, up;
+					AngleVectors( GetAbsAngles(), NULL, &right, &up );
+
+					pHurt->ApplyAbsVelocityImpulse( 100 * (up+2*right) * GetModelScale() );
+				}
 			}
 		}
 		break;

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -850,15 +850,23 @@ void CNPC_Gonome::HandleAnimEvent( animevent_t *pEvent )
 			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector(-16,-16,-16), Vector(16,16,16), sk_zombie_assassin_dmg_bite.GetFloat(), DMG_SLASH );
 			if ( pHurt )
 			{
+				EmitSound( filter, entindex(), "Zombie.AttackHit" );
+			}
+			else // Play a random attack miss sound
+			{
+				EmitSound( filter, entindex(), "Zombie.AttackMiss" );
+			}
+
+			// Apply a velocity to hit entity if it is a character or if it has a physics movetype
+			if ( pHurt && ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS ) )
+			{
 				Vector forward, up;
 				AngleVectors( GetAbsAngles(), &forward, NULL, &up );
 				pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() - (forward * 100) );
 				pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (up * 100) );
 				pHurt->SetGroundEntity( NULL );
-				EmitSound( filter, entindex(), "Zombie.AttackHit" );
 			}
-			else // Play a random attack miss sound
-			EmitSound( filter, entindex(), "Zombie.AttackMiss" );
+
 		}
 		break;
 
@@ -869,14 +877,18 @@ void CNPC_Gonome::HandleAnimEvent( animevent_t *pEvent )
 			if ( pHurt ) 
 			{
 				EmitSound( filter, entindex(), "Gonome.Bite" );
-				Vector right, up;
-				AngleVectors( GetAbsAngles(), NULL, &right, &up );
 
 				if ( pHurt->GetFlags() & ( FL_NPC | FL_CLIENT ) )
-					 pHurt->ViewPunch( QAngle( 20, 0, -20 ) );
-			
-				pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (right * 200) );
-				pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (up * 100) );
+					pHurt->ViewPunch( QAngle( 20, 0, -20 ) );
+
+				if ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS )
+				{
+					Vector right, up;
+					AngleVectors( GetAbsAngles(), NULL, &right, &up );
+
+					pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (right * 200) );
+					pHurt->SetAbsVelocity( pHurt->GetAbsVelocity() + (up * 100) );
+				}
 
 				// If we were trying to spawn and hit something by accident, defer spawning for a while
 				if (m_bReadyToSpawn)


### PR DESCRIPTION
Sometimes the melee attacks from predator NPCs can cause unintended behavior on dynamic entities like rotating doors. It really is only meant to apply physics to objects with vphysics or to NPCs. This PR adds a check for those two cases to avoid applying physics force to other entities.