### PR TITLE
Creature crates spawning handles null breaker

### DIFF
--- a/sp/src/game/server/hl2/item_itemcrate.cpp
+++ b/sp/src/game/server/hl2/item_itemcrate.cpp
@@ -463,7 +463,7 @@ void CItem_ItemCrate::OnBreak( const Vector &vecVelocity, const AngularImpulse &
 
 		if ( pSpawn->IsNPC() )
 		{
-			OnSpawnNPC( pSpawn, pBreaker->MyCombatCharacterPointer() );
+			OnSpawnNPC( pSpawn, pBreaker ? pBreaker->MyCombatCharacterPointer() : NULL );
 		}
 #endif
 


### PR DESCRIPTION
Fix for a bug where maps with creature crates would crash sometimes if the crate was zapped by a vort