### PR TITLE
Sidearms for Combine soldiers who were tricked into being unarmed

### DIFF
--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -1076,6 +1076,13 @@ void CNPC_Combine::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecTa
 		// Make sure they're allowed to re-arm themselves in case they fail to pick up this weapon.
 		m_bTemporarilyNeedWeapon = true;
 		m_bDontPickupWeapons = false;
+
+		// Check if we don't have other weapons in our inventory
+		if ( !m_hMyWeapons[1].Get() )
+		{
+			// In case we get into combat while unarmed, have a pistol on-hand
+			GiveWeaponHolstered( AllocPooledString( "weapon_pistol" ) );
+		}
 	}
 }
 

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -1076,6 +1076,7 @@ void CNPC_Combine::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecTa
 		// Make sure they're allowed to re-arm themselves in case they fail to pick up this weapon.
 		m_bTemporarilyNeedWeapon = true;
 		m_bDontPickupWeapons = false;
+		m_flNextWeaponSearchTime = gpGlobals->curtime + 1.0f;
 
 		// Check if we don't have other weapons in our inventory
 		if ( !m_hMyWeapons[1].Get() )


### PR DESCRIPTION
**This is for after the Mapbase v7.0 merge!!!**

---

At the moment, players can use the soldier weapon-swapping feature to trick squadmates into being unarmed. This feature allows those squadmates to pull out a pistol if they enter combat.