### PR TITLE
Pulse pistol shows charge as reserve value on HUD

### DIFF
--- a/sp/src/game/client/client_ez2.vpc
+++ b/sp/src/game/client/client_ez2.vpc
@@ -38,6 +38,7 @@ $Project "Client (Entropy Zero 2)"
 			$File	"ez2\c_ez2_player.h"
 			$File	"ez2\c_npc_wilson.cpp"
 			$File	"ez2\c_npc_wilson.h"
+			$File	"ez2\c_weapon_pulse_pistol.cpp"
 			$File	"ez2\zombiegooproxy.cpp"
 			$File	"ez2\hud_slamstatus.cpp"
 		}

--- a/sp/src/game/client/ez2/c_weapon_pulse_pistol.cpp
+++ b/sp/src/game/client/ez2/c_weapon_pulse_pistol.cpp
@@ -1,0 +1,118 @@
+//=============================================================================//
+//
+// Purpose: Pulse pistol clientside effects.
+// 
+// Author: Blixibon
+//
+//=============================================================================//
+
+#include "cbase.h"
+#include "c_basehlcombatweapon.h"
+#include "proxyentity.h"
+#include "materialsystem/imaterial.h"
+#include "materialsystem/imaterialvar.h"
+#include "baseviewmodel_shared.h"
+
+class C_WeaponPulsePistol : public C_BaseHLCombatWeapon
+{
+public:
+	DECLARE_CLASS( C_WeaponPulsePistol, C_BaseHLCombatWeapon );
+	DECLARE_CLIENTCLASS();
+	DECLARE_PREDICTABLE();
+
+	C_WeaponPulsePistol();
+	~C_WeaponPulsePistol();
+
+	// Don't show the reserve vlaue in the HUD
+	//bool ShouldDisplaySecondaryValue( void ) const { return false; }
+};
+
+LINK_ENTITY_TO_CLASS( weapon_pulsepistol, C_WeaponPulsePistol );
+
+IMPLEMENT_CLIENTCLASS_DT( C_WeaponPulsePistol, DT_WeaponPulsePistol, CWeaponPulsePistol )
+END_RECV_TABLE()
+
+BEGIN_PREDICTION_DATA( C_WeaponPulsePistol )
+END_PREDICTION_DATA()
+
+C_WeaponPulsePistol::C_WeaponPulsePistol()
+{
+}
+
+C_WeaponPulsePistol::~C_WeaponPulsePistol()
+{
+}
+
+//-----------------------------------------------------------------------------
+// Apply effects when the pulse pistol is charging
+//-----------------------------------------------------------------------------
+class CPulsePistolMaterialProxy : public CEntityMaterialProxy
+{
+public:
+	CPulsePistolMaterialProxy() { m_ChargeVar = NULL; }
+	virtual ~CPulsePistolMaterialProxy() {}
+	virtual bool Init( IMaterial *pMaterial, KeyValues *pKeyValues );
+	virtual void OnBind( C_BaseEntity *pEntity );
+	virtual IMaterial *GetMaterial();
+
+private:
+	IMaterialVar *m_ChargeVar;
+	//IMaterialVar *m_FullyChargedVar;
+};
+
+bool CPulsePistolMaterialProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
+{
+	bool foundAnyVar = false;
+	bool foundVar;
+
+	const char *pszChargeVar = pKeyValues->GetString( "outputCharge" );
+	m_ChargeVar = pMaterial->FindVar( pszChargeVar, &foundVar, true );
+	if (foundVar)
+		foundAnyVar = true;
+
+	//const char *pszFullyChargedVar = pKeyValues->GetString( "outputFullyCharged" );
+	//m_FullyChargedVar = pMaterial->FindVar( pszFullyChargedVar, &foundVar, true );
+	//if (foundVar)
+	//	foundAnyVar = true;
+
+	return foundAnyVar;
+}
+
+void CPulsePistolMaterialProxy::OnBind( C_BaseEntity *pEnt )
+{
+	if (!m_ChargeVar)
+		return;
+
+	C_WeaponPulsePistol *pPistol = NULL;
+	if ( pEnt->IsBaseCombatWeapon() )
+		pPistol = assert_cast<C_WeaponPulsePistol*>( pEnt );
+	else
+	{
+		C_BaseViewModel *pVM = dynamic_cast<C_BaseViewModel*>( pEnt );
+		if (pVM)
+			pPistol = assert_cast<C_WeaponPulsePistol*>( pVM->GetOwningWeapon() );
+	}
+
+	if ( pPistol )
+	{
+		// Keep synced with the max in weapon_pistol.cpp
+		const float flMaxCharge = 40.0f;
+		m_ChargeVar->SetFloatValue( ((float)pPistol->m_iClip2) / flMaxCharge );
+
+		//m_FullyChargedVar->SetFloatValue( pPistol->m_iClip2 == flMaxCharge ? 1.0f : 0.0f );
+	}
+	else
+	{
+		m_ChargeVar->SetFloatValue( 0.0f );
+	}
+}
+
+IMaterial *CPulsePistolMaterialProxy::GetMaterial()
+{
+	if ( !m_ChargeVar )
+		return NULL;
+
+	return m_ChargeVar->GetOwningMaterial();
+}
+
+EXPOSE_INTERFACE( CPulsePistolMaterialProxy, IMaterialProxy, "PulsePistolCharge" IMATERIAL_PROXY_INTERFACE_VERSION );

--- a/sp/src/game/client/hl2/c_weapon__stubs_hl2.cpp
+++ b/sp/src/game/client/hl2/c_weapon__stubs_hl2.cpp
@@ -51,7 +51,7 @@ STUB_WEAPON_CLASS( weapon_oldmanharpoon, WeaponOldManHarpoon, C_WeaponCitizenPac
 #endif
 
 #ifdef EZ2
-STUB_WEAPON_CLASS( weapon_pulsepistol, WeaponPulsePistol, C_BaseHLCombatWeapon );
+//STUB_WEAPON_CLASS( weapon_pulsepistol, WeaponPulsePistol, C_BaseHLCombatWeapon );
 STUB_WEAPON_CLASS( weapon_displacer_pistol, DisplacerPistol, C_BaseHLCombatWeapon );
 STUB_WEAPON_CLASS( weapon_ar2_proto, WeaponAR2Proto, C_BaseHLCombatWeapon );
 STUB_WEAPON_CLASS( weapon_endgame, WeaponEndGame, C_BaseHLCombatWeapon );

--- a/sp/src/game/client/hl2/hud_ammo.cpp
+++ b/sp/src/game/client/hl2/hud_ammo.cpp
@@ -153,6 +153,12 @@ void CHudAmmo::UpdatePlayerAmmo( C_BasePlayer *player )
 	{
 		// we use clip ammo, so the second ammo is the total ammo
 		ammo2 = player->GetAmmoCount(wpn->GetPrimaryAmmoType());
+
+#ifdef EZ
+		// Use the second clip when ammo isn't used (for pulse pistol)
+		if (ammo2 <= 0 && wpn->Clip2() > 0)
+			ammo2 = wpn->Clip2();
+#endif
 	}
 
 	hudlcd->SetGlobalStat( "(ammo_primary)", VarArgs( "%d", ammo1 ) );


### PR DESCRIPTION
This is a draft because this isn't a feature which has been approved or discussed by the team.

Also contains a clientside class which implements a new material proxy, which was done while experimenting with other charge communication methods and isn't currently used, but may be useful in the future.