### PR TITLE
Predator NPCs handle ignition

### DIFF
--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -721,8 +721,12 @@ void CNPC_Gonome::IdleSound( void )
 //=========================================================
 void CNPC_Gonome::PainSound( const CTakeDamageInfo &info )
 {
-	CPASAttenuationFilter filter( this );
-	EmitSound( filter, entindex(), "Gonome.Pain" );	
+	// Burning creatures shouldn't play pain sounds constantly
+	if ( !( IsOnFire() && info.GetDamageType() & DMG_BURN ) )
+	{
+		CPASAttenuationFilter filter( this );
+		EmitSound( filter, entindex(), "Gonome.Pain" );
+	}
 }
 
 //=========================================================

--- a/sp/src/game/server/ez2/npc_zassassin.h
+++ b/sp/src/game/server/ez2/npc_zassassin.h
@@ -95,6 +95,8 @@ public:
 	float	m_flBurnDamage;				// Keeps track of how much burn damage we've incurred in the last few seconds.
 	float	m_flBurnDamageResetTime;	// Time at which we reset the burn damage.
 
+	void Scorch( int rate, int floor ) {}; // The gonome model doesn't look right scorched
+
 	CAI_BeastBehavior	m_BeastBehavior;
 
 private:


### PR DESCRIPTION
Previously, predator NPCs (bullsquids, pit drones, zassassins, stukabats) would loop pain sounds when on fire. This PR adds a check to pain sound. It will also extinguish flames if a flaming predator eats food. Boss NPCs also extinguish when their health resets.