### PR TITLE
Assorted fixes Aug 6th (Mapbase develop branch)

### DIFF
--- a/sp/src/game/client/c_point_commentary_node.cpp
+++ b/sp/src/game/client/c_point_commentary_node.cpp
@@ -248,7 +248,7 @@ public:
 
 #ifdef MAPBASE
 			// Special commentary localization file (useful for things like text nodes or print names)
-			g_pVGuiLocalize->AddFile( "resource/commentary_%language%.txt" );
+			g_pVGuiLocalize->AddFile( "resource/commentary_%language%.txt", "MOD", true );
 #endif
 		}
 

--- a/sp/src/game/server/hl2/weapon_rpg.cpp
+++ b/sp/src/game/server/hl2/weapon_rpg.cpp
@@ -1405,9 +1405,16 @@ acttable_t	CWeaponRPG::m_acttable[] =
 	{ ACT_GESTURE_RANGE_ATTACK1,	ACT_GESTURE_RANGE_ATTACK_RPG,	false },
 #endif
 
+#ifdef MAPBASE
+	// Readiness activities should not be required
+	{ ACT_IDLE_RELAXED,				ACT_IDLE_RPG_RELAXED,			false },
+	{ ACT_IDLE_STIMULATED,			ACT_IDLE_ANGRY_RPG,				false },
+	{ ACT_IDLE_AGITATED,			ACT_IDLE_ANGRY_RPG,				false },
+#else
 	{ ACT_IDLE_RELAXED,				ACT_IDLE_RPG_RELAXED,			true },
 	{ ACT_IDLE_STIMULATED,			ACT_IDLE_ANGRY_RPG,				true },
 	{ ACT_IDLE_AGITATED,			ACT_IDLE_ANGRY_RPG,				true },
+#endif
 
 	{ ACT_IDLE,						ACT_IDLE_RPG,					true },
 	{ ACT_IDLE_ANGRY,				ACT_IDLE_ANGRY_RPG,				true },

--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -4478,6 +4478,13 @@ void CBasePropDoor::CalcDoorSounds()
 #endif
 			}
 
+#ifdef MAPBASE
+			// This would still be -1 if the hardware wasn't valid
+			if (m_flNPCOpenDistance == -1)
+				m_flNPCOpenDistance = ai_door_enable_acts.GetBool() ? 32.0 : 64.0;
+#endif
+
+
 			// If any sounds were missing, try the "defaults" block.
 			if ( ( strSoundOpen == NULL_STRING ) || ( strSoundClose == NULL_STRING ) || ( strSoundMoving == NULL_STRING ) ||
 				 ( strSoundLocked == NULL_STRING ) || ( strSoundUnlocked == NULL_STRING ) )


### PR DESCRIPTION
* Fixes RPG readiness activities marked as required; *In E:Z2, this manifested as soldiers being unable to pick up RPGs*
* Fixes NPCs being unable to open doors with undefined hardware; *In E:Z2, this manifested as a regression in `c2_4` which had to be fixed via a keyvalue override which bypasses the issue*
* Fixes commentary localization files not loading properly; *In E:Z2, this would've manifested when we do developer commentary*