### PR TITLE
Drivable APC resets Think time on Activate()

### DIFF
--- a/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
+++ b/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
@@ -629,6 +629,9 @@ void CPropDrivableAPC::Activate()
 		angularVelocity *= 0.5f;
 		VPhysicsGetObject()->SetVelocityInstantaneous( &velocity, &angularVelocity );
 	}
+
+	// Reset the next think time on Activate()
+	SetNextThink( gpGlobals->curtime );
 #endif
 }
 
@@ -1810,15 +1813,6 @@ void CPropDrivableAPC::OnRestore( void )
 		// Restore the passenger information we're holding on to
 		pServerVehicle->RestorePassengerInfo();
 	}
-
-#ifdef EZ2
-	// HACKHACK - On restore, the attachment point doesn't seem to work.
-	// Brute force workaround by calling Spawn() again
-	else if (GetDriver() == NULL)
-	{
-		Spawn();
-	}
-#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When loading a save, Wilson can no longer be attached to the APC. This is because the APC think function does not get called. When the player enters the APC, it calls SetNextThink() again and re-enables the think function, which enables Wilson to be attached. This PR will call SetNextThink() from Activate() so that upon loading a save, Wilson will be attachable.