### PR TITLE
Player "warning target" feature for SMG grenades

### DIFF
--- a/sp/src/game/client/ez2/c_ez2_player.cpp
+++ b/sp/src/game/client/ez2/c_ez2_player.cpp
@@ -10,6 +10,7 @@
 
 IMPLEMENT_CLIENTCLASS_DT( C_EZ2_Player, DT_EZ2_Player, CEZ2_Player )
 	RecvPropBool( RECVINFO( m_bBonusChallengeUpdate ) ),
+	RecvPropEHandle( RECVINFO( m_hWarningTarget ) ),
 END_RECV_TABLE()
 
 BEGIN_PREDICTION_DATA( C_EZ2_Player )
@@ -21,11 +22,14 @@ C_EZ2_Player::C_EZ2_Player()
 
 C_EZ2_Player::~C_EZ2_Player()
 {
+	DestroyGlowTargetEffect();
 }
 
 void C_EZ2_Player::OnDataChanged( DataUpdateType_t updateType )
 {
 	BaseClass::OnDataChanged( updateType );
+
+	UpdateGlowTargetEffect();
 
 	if ( updateType == DATA_UPDATE_DATATABLE_CHANGED && m_bBonusChallengeUpdate )
 	{
@@ -44,5 +48,41 @@ void C_EZ2_Player::OnDataChanged( DataUpdateType_t updateType )
 		BonusMapChallengeUpdate( szChallengeFileName, szChallengeMapName, szChallengeName, GetBonusProgress() );
 
 		m_bBonusChallengeUpdate = false;
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void C_EZ2_Player::UpdateGlowTargetEffect( void )
+{
+	// destroy the existing effect
+	if ( m_pGlowTargetEffect )
+	{
+		DestroyGlowTargetEffect();
+	}
+
+	if (!m_hWarningTarget)
+	{
+		return;
+	}
+
+	// create a new effect
+	//if ( !m_bGlowDisabled )
+	{
+		Vector4D vecColor( 1.0f, 0, 0, 1.0f );
+		m_pGlowTargetEffect = new CGlowObject( m_hWarningTarget, vecColor.AsVector3D(), vecColor.w, true );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void C_EZ2_Player::DestroyGlowTargetEffect( void )
+{
+	if ( m_pGlowTargetEffect )
+	{
+		delete m_pGlowTargetEffect;
+		m_pGlowTargetEffect = NULL;
 	}
 }

--- a/sp/src/game/client/ez2/c_ez2_player.h
+++ b/sp/src/game/client/ez2/c_ez2_player.h
@@ -18,7 +18,13 @@ public:
 
 	void OnDataChanged( DataUpdateType_t updateType );
 
+	void UpdateGlowTargetEffect( void );
+	void DestroyGlowTargetEffect( void );
+
 	bool m_bBonusChallengeUpdate;
+	
+	EHANDLE m_hWarningTarget;
+	CGlowObject *m_pGlowTargetEffect;
 };
 
 

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -195,6 +195,8 @@ public:
 
 	bool			HidingBonusProgressHUD();
 
+	void			SetWarningTarget( CBaseEntity *pTarget ) { m_hWarningTarget = pTarget; }
+
 	void			FireBullets( const FireBulletsInfo_t &info );
 
 	// Blixibon - StartScripting for gag replacement
@@ -304,6 +306,8 @@ private:
 	// These don't need to be saved
 	CNetworkVar( bool, m_bBonusChallengeUpdate );
 	bool m_bMaskInterrupt;
+
+	CNetworkHandle( CBaseEntity, m_hWarningTarget );
 };
 
 //-----------------------------------------------------------------------------
@@ -434,7 +438,7 @@ struct SightEvent_t
 {
 	//DECLARE_SIMPLE_DATADESC();
 
-	SightEvent_t( const char *_pName, float _flCooldown, SIGHTEVENTPTR _pTestFunc, SIGHTEVENTPTR _pMainFunc )
+	SightEvent_t( const char *_pName, float _flCooldown, SIGHTEVENTPTR _pTestFunc, SIGHTEVENTPTR _pMainFunc, float _flFailedCooldown = 2.0f )
 	{
 		pName = _pName;
 		flCooldown = _flCooldown;
@@ -442,6 +446,7 @@ struct SightEvent_t
 		pMainFunc = _pMainFunc;
 		flNextHintTime = 0.0f;
 		flLastHintTime = 0.0f;
+		flFailedCooldown = _flFailedCooldown;
 	}
 
 	bool Test( CEZ2_Player *pPlayer, CBaseEntity *pActivator ) { return (*pTestFunc)(pPlayer, pActivator); }
@@ -453,6 +458,7 @@ struct SightEvent_t
 	float	flLastHintTime;
 
 	float	flCooldown;
+	float	flFailedCooldown; // When to check again when test fails
 
 private:
 

--- a/sp/src/game/server/hl2/grenade_ar2.cpp
+++ b/sp/src/game/server/hl2/grenade_ar2.cpp
@@ -67,6 +67,11 @@ void CGrenadeAR2::Spawn( void )
 	UTIL_SetSize(this, Vector(-3, -3, -3), Vector(3, 3, 3));
 //	UTIL_SetSize(this, Vector(0, 0, 0), Vector(0, 0, 0));
 
+#ifdef EZ2
+	// For player sight event
+	AddFlag( FL_OBJECT );
+#endif
+
 	SetUse( &CGrenadeAR2::DetonateUse );
 	SetTouch( &CGrenadeAR2::GrenadeAR2Touch );
 	SetThink( &CGrenadeAR2::GrenadeAR2Think );


### PR DESCRIPTION
This feature adds support for a "warning target" on the E:Z2 player which involves two indicators on a specific target:

1. A red glow outline effect.
2. An instructor hint with an "INCOMING" caption which follows the target.

At the moment, this is only used for incoming SMG grenades and is intended to make them more visible to players in `c4_4` and `c5_2`.