### PR TITLE
Assorted surrender behavior changes August 2022

### DIFF
--- a/sp/src/game/server/ez2/ai_behavior_surrender.cpp
+++ b/sp/src/game/server/ez2/ai_behavior_surrender.cpp
@@ -753,6 +753,9 @@ int CAI_SurrenderBehavior::TranslateSchedule( int scheduleType )
 
 	case SCHED_MOVE_AWAY:
 		return SCHED_SURRENDER_MOVE_AWAY;
+
+	case SCHED_INVESTIGATE_SOUND:
+		return SCHED_ALERT_FACE_BESTSOUND;
 	}
 
 	return BaseClass::TranslateSchedule( scheduleType );

--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -614,7 +614,7 @@ void CEZ2_Player::OnUseEntity( CBaseEntity *pEntity )
 	{
 		if ( bOrderSurrender )
 		{
-			pNPC->DispatchInteraction( g_interactionBadCopOrderSurrender, NULL, this );
+			OnOrderSurrender( pNPC );
 		}
 		else if ( bStealthChat )
 		{
@@ -647,7 +647,7 @@ void CEZ2_Player::OnUseEntity( CBaseEntity *pEntity )
 		if (/*GetNumSquadCommandables() <= 0 &&*/ pNPC->FInViewCone( this ) && GetActiveWeapon() && player_silent_surrender.GetBool())
 		{
 			//GetActiveWeapon()->SendWeaponAnim( ACT_VM_COMMAND_SEND );
-			pNPC->DispatchInteraction( g_interactionBadCopOrderSurrender, NULL, this );
+			OnOrderSurrender( pNPC );
 		}
 	}
 }
@@ -697,6 +697,24 @@ bool CEZ2_Player::HandleInteraction( int interactionType, void *data, CBaseComba
 	}
 
 	return BaseClass::HandleInteraction( interactionType, data, sourceEnt );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CEZ2_Player::OnOrderSurrender( CAI_BaseNPC *pNPC )
+{
+	pNPC->DispatchInteraction( g_interactionBadCopOrderSurrender, NULL, this );
+
+	// Increment the associated global
+	int iGlobal = GlobalEntity_GetIndex( GLOBAL_PLAYER_ORDER_SURRENDER );
+	if ( iGlobal < 0 )
+	{
+		iGlobal = GlobalEntity_Add( GLOBAL_PLAYER_ORDER_SURRENDER, STRING(gpGlobals->mapname), GLOBAL_ON );
+		GlobalEntity_SetCounter( iGlobal, 0 );
+	}
+
+	GlobalEntity_AddToCounter( iGlobal, 1 );
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -23,6 +23,8 @@ class CAI_PlayerNPCDummy;
 class CEZ2_Player;
 struct SightEvent_t;
 
+#define GLOBAL_PLAYER_ORDER_SURRENDER "player_ordered_surrenders"
+
 // 
 // Bad Cop-specific concepts
 // 
@@ -148,6 +150,8 @@ public:
 
 	void			OnUseEntity( CBaseEntity *pEntity );
 	bool			HandleInteraction( int interactionType, void *data, CBaseCombatCharacter* sourceEnt );
+
+	void			OnOrderSurrender( CAI_BaseNPC *pNPC );
 
 	Disposition_t	IRelationType( CBaseEntity *pTarget );
 

--- a/sp/src/game/server/ez2/npc_clonecop.cpp
+++ b/sp/src/game/server/ez2/npc_clonecop.cpp
@@ -71,11 +71,11 @@ CNPC_CloneCop::CNPC_CloneCop()
 	m_bThrowXenGrenades = true;
 	m_bLookForItems = true;
 	SetDisplacementImpossible( true );
-	m_SquadName = MAKE_STRING( IsBadCop() ? "bc_squad" : "cc_squad" );
+	m_SquadName = MAKE_STRING( "cc_squad" );
 
 	// TODO - See comment in npc_combine.cpp
 	// Clone Cop probably shouldn't order surrender by default
-	m_bCanOrderSurrender = false;
+	m_iCanOrderSurrender = TRS_FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1109,6 +1109,7 @@ LINK_ENTITY_TO_CLASS( npc_badcop, CNPC_BadCop );
 
 CNPC_BadCop::CNPC_BadCop()
 {
+	m_SquadName = MAKE_STRING( "bc_squad" );
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -325,7 +325,7 @@ DEFINE_KEYFIELD( m_bDisablePlayerUse, FIELD_BOOLEAN, "DisablePlayerUse" ),
 DEFINE_INPUTFUNC( FIELD_VOID, "EnablePlayerUse", InputEnablePlayerUse ),
 DEFINE_INPUTFUNC( FIELD_VOID, "DisablePlayerUse", InputDisablePlayerUse ),
 
-DEFINE_KEYFIELD( m_bCanOrderSurrender, FIELD_BOOLEAN, "CanOrderSurrender" ),
+DEFINE_KEYFIELD( m_iCanOrderSurrender, FIELD_INTEGER, "CanOrderSurrender" ),
 DEFINE_INPUTFUNC( FIELD_VOID, "EnableOrderSurrender", InputEnableOrderSurrender ),
 DEFINE_INPUTFUNC( FIELD_VOID, "DisableOrderSurrender", InputDisableOrderSurrender ),
 #endif
@@ -357,10 +357,7 @@ CNPC_Combine::CNPC_Combine()
 
 	m_bDontPickupWeapons = true;
 
-	// TODO - Ordering surrender is on by default. This could become an issue.
-	// Consider making it a three-state variable and using a ConVar or Global Var
-	// to track default behavior.
-	m_bCanOrderSurrender = true;
+	m_iCanOrderSurrender = TRS_NONE;
 #endif
 }
 
@@ -1104,6 +1101,19 @@ void CNPC_Combine::PickupWeapon( CBaseCombatWeapon *pWeapon )
 		m_bDontPickupWeapons = true;
 	}
 }
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+bool CNPC_Combine::CanOrderSurrender()
+{
+	if (m_iCanOrderSurrender == TRS_NONE && IsPlayerAlly())
+	{
+		// Order surrenders if the player has ordered one before
+		return GlobalEntity_GetState( GLOBAL_PLAYER_ORDER_SURRENDER ) == GLOBAL_ON;
+	}
+
+	return m_iCanOrderSurrender == TRS_TRUE;
+}
 #endif
 
 //-----------------------------------------------------------------------------
@@ -1344,12 +1354,12 @@ void CNPC_Combine::InputEnablePlayerUse( inputdata_t &inputdata )
 //-----------------------------------------------------------------------------
 void CNPC_Combine::InputEnableOrderSurrender( inputdata_t &inputdata )
 {
-	m_bCanOrderSurrender = true;
+	m_iCanOrderSurrender = TRS_TRUE;
 }
 
 void CNPC_Combine::InputDisableOrderSurrender( inputdata_t &inputdata )
 {
-	m_bCanOrderSurrender = false;
+	m_iCanOrderSurrender = TRS_FALSE;
 }
 #endif
 

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -186,7 +186,7 @@ public:
 
 	virtual bool	IsMajorCharacter() { return IsCommandable(); }
 
-	virtual bool	CanOrderSurrender() { return m_bCanOrderSurrender; }
+	virtual bool	CanOrderSurrender();
 
 	// Blixibon - Elites in ball attacks should aim while moving, even if they can't shoot
 	bool			HasAttackSlot() { return BaseClass::HasAttackSlot() || HasStrategySlot( SQUAD_SLOT_SPECIAL_ATTACK ); }
@@ -351,7 +351,10 @@ protected:
 	// 1upD - If true, player +USE has no effect
 	bool m_bDisablePlayerUse;
 
-	bool m_bCanOrderSurrender;
+	// TRS_NONE = Don't care, modified from global state if the player orders a surrender
+	// TRS_TRUE = Can always order surrender
+	// TRS_FALSE = Can never order surrender
+	ThreeState_t m_iCanOrderSurrender;
 #endif
 
 #ifdef EZ2


### PR DESCRIPTION
- The instructor hint for making a citizen surrender now has cvars to adjust their values and also relies on when the enemy was acquired.
- By default, soldiers will no longer order surrenders on their own unless the player has made a citizen surrender before. This is done using a new global state called `player_ordered_surrenders`, which is incremented for each citizen they make surrender.
- Previously, surrendered medics provided medkits and surrendered brutes provided ammo based on their starting weapon and grenade capabilities. Regular surrendered rebels provided nothing. As of this PR, all regular rebels will now be able to resupply ammo based on their starting weapon and brutes with the right capabilities will always provide grenade or alt-fire-related ammo.
	- Each surrendered rebel's ammo reserve will now deplete by 20% each time they give the player ammo.
	- Rebels who did not have a starting weapon with a valid ammo type will provide 357 ammo instead. These rebels are very rare.