### PR TITLE
Predator obstruction behavior

### DIFF
--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -26,7 +26,7 @@
 ConVar ai_debug_predator( "ai_debug_predator", "0" );
 ConVar sv_predator_heal_render_effects( "sv_predator_heal_render_effects", "1", FCVAR_NONE, "Should predators like bullsquids turn green after healing?" );
 #ifdef EZ2
-ConVar npc_predator_obstruction_behavior( "npc_predator_obstruction_behavior", "1" );
+ConVar npc_predator_obstruction_behavior( "npc_predator_obstruction_behavior", "0" );
 #endif
 
 LINK_ENTITY_TO_CLASS( npc_basepredator, CNPC_BasePredator );

--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -25,6 +25,9 @@
 
 ConVar ai_debug_predator( "ai_debug_predator", "0" );
 ConVar sv_predator_heal_render_effects( "sv_predator_heal_render_effects", "1", FCVAR_NONE, "Should predators like bullsquids turn green after healing?" );
+#ifdef EZ2
+ConVar npc_predator_obstruction_behavior( "npc_predator_obstruction_behavior", "1" );
+#endif
 
 LINK_ENTITY_TO_CLASS( npc_basepredator, CNPC_BasePredator );
 
@@ -46,6 +49,7 @@ BEGIN_DATADESC( CNPC_BasePredator )
 	DEFINE_FIELD( m_flLastHurtTime, FIELD_TIME ),
 	DEFINE_FIELD( m_flNextSpitTime, FIELD_TIME ),
 	DEFINE_FIELD( m_tBossState, FIELD_INTEGER ),
+	DEFINE_FIELD( m_hObstructor, FIELD_EHANDLE ),
 
 	DEFINE_FIELD( m_flHungryTime, FIELD_TIME ),
 	DEFINE_KEYFIELD( m_bSpawningEnabled, FIELD_BOOLEAN, "SpawningEnabled" ),
@@ -392,6 +396,12 @@ void CNPC_BasePredator::BuildScheduleTestBits()
 		SetCustomInterruptCondition( COND_CAN_MELEE_ATTACK1 );
 	}
 
+	// If we're an absolute beast, allow our chase schedule to be interrupted by obstructions
+	if ( ShouldImmediatelyAttackObstructions() && IsCurSchedule( SCHED_CHASE_ENEMY ) )
+	{
+		SetCustomInterruptCondition( COND_PREDATOR_OBSTRUCTED );
+	}
+
 	// Like zombies, ignore damage if we're attacking.
 	switch (GetActivity())
 	{
@@ -402,6 +412,62 @@ void CNPC_BasePredator::BuildScheduleTestBits()
 		ClearCustomInterruptCondition( COND_HEAVY_DAMAGE );
 		break;
 	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CNPC_BasePredator::OnObstructionPreSteer( AILocalMoveGoal_t *pMoveGoal, float distClear, AIMoveResult_t *pResult )
+{
+	if ( pMoveGoal->directTrace.pObstruction && !pMoveGoal->directTrace.pObstruction->IsWorld() && GetGroundEntity() != pMoveGoal->directTrace.pObstruction )
+	{
+		if ( ShouldAttackObstruction( pMoveGoal->directTrace.pObstruction ) )
+		{
+			m_hObstructor = pMoveGoal->directTrace.pObstruction;
+			SetCondition( COND_PREDATOR_OBSTRUCTED );
+		}
+	}
+
+	return BaseClass::OnObstructionPreSteer( pMoveGoal, distClear, pResult );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CNPC_BasePredator::ShouldAttackObstruction( CBaseEntity *pEntity )
+{
+	if (!npc_predator_obstruction_behavior.GetBool())
+		return false;
+
+	// Don't attack obstructions if we can't melee attack
+	if ((CapabilitiesGet() & bits_CAP_INNATE_MELEE_ATTACK1) == 0)
+		return false;
+
+	// Only attack combat characters and physics props
+	if ( !pEntity->MyCombatCharacterPointer() && pEntity->GetMoveType() != MOVETYPE_VPHYSICS )
+		return false;
+
+	// Don't attack props which don't have motion enabled
+	if ( pEntity->VPhysicsGetObject() && !pEntity->VPhysicsGetObject()->IsMotionEnabled() )
+		return false;
+
+	// Don't attack NPCs in the same squad
+	if (pEntity->IsNPC() && pEntity->MyNPCPointer()->GetSquad() == GetSquad() && GetSquad() != NULL)
+		return false;
+
+	return true;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: If true, NPCs will immediately attack obstructions instead of waiting for the pathfinder to find a way around
+//-----------------------------------------------------------------------------
+bool CNPC_BasePredator::ShouldImmediatelyAttackObstructions()
+{
+	// Babies are too small to throw their own weight around
+	if (IsBaby())
+		return false;
+
+	return true;
 }
 
 //=========================================================
@@ -1032,6 +1098,14 @@ int CNPC_BasePredator::SelectSchedule( void )
 		return SCHED_PREDATOR_SPAWN;
 	}
 
+	// If we immediately attack obstructions, just plow through
+	if ( ShouldImmediatelyAttackObstructions() && HasCondition( COND_PREDATOR_OBSTRUCTED ) )
+	{
+		SetTarget( m_hObstructor );
+		m_hObstructor = NULL;
+		return SCHED_PREDATOR_ATTACK_TARGET;
+	}
+
 	switch ( m_NPCState )
 	{
 	case NPC_STATE_ALERT:
@@ -1147,6 +1221,16 @@ int CNPC_BasePredator::SelectSchedule( void )
 
 int CNPC_BasePredator::SelectFailSchedule( int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode )
 {
+	// If we can swat physics objects, see if we can swat our obstructor
+	if ( IsPathTaskFailure( taskFailCode ) && 
+		 m_hObstructor != NULL && m_hObstructor->VPhysicsGetObject() )
+	{
+		SetTarget( m_hObstructor );
+		m_hObstructor = NULL;
+		return SCHED_PREDATOR_ATTACK_TARGET;
+	}
+	m_hObstructor = NULL;
+
 	// Need special case handling for when predators smell food they can't navigate too
 	switch (failedSchedule)
 	{
@@ -1448,6 +1532,7 @@ AI_BEGIN_CUSTOM_NPC( npc_predator, CNPC_BasePredator )
 	DECLARE_CONDITION( COND_NEW_BOSS_STATE )
 	DECLARE_CONDITION( COND_PREDATOR_CAN_GROW )
 	DECLARE_CONDITION( COND_PREDATOR_GROWTH_INVALID )
+	DECLARE_CONDITION( COND_PREDATOR_OBSTRUCTED )
 
 	DECLARE_SQUADSLOT( SQUAD_SLOT_FEED )
 	DECLARE_SQUADSLOT( SQUAD_SLOT_THREAT_DISPLAY )
@@ -1683,6 +1768,25 @@ AI_BEGIN_CUSTOM_NPC( npc_predator, CNPC_BasePredator )
 		"		COND_CAN_MELEE_ATTACK1"
 		"		COND_CAN_MELEE_ATTACK2"
 		"       COND_PREDATOR_GROWTH_INVALID"
+	)
+			
+	//=========================================================
+	// > SCHED_PREDATOR_ATTACK_TARGET
+	//=========================================================
+	DEFINE_SCHEDULE
+	(
+		SCHED_PREDATOR_ATTACK_TARGET,
+
+		"	Tasks"
+		"		TASK_GET_PATH_TO_TARGET		0"
+		"		TASK_MOVE_TO_TARGET_RANGE	50"
+		"		TASK_STOP_MOVING			0"
+		"		TASK_FACE_TARGET			0"
+		"		TASK_PLAY_SEQUENCE			ACTIVITY:ACT_MELEE_ATTACK1"
+		"	"
+		"	Interrupts"
+		"		COND_NEW_ENEMY"
+		"		COND_ENEMY_DEAD"
 	)
 
 AI_END_CUSTOM_NPC()

--- a/sp/src/game/server/ez2/npc_basepredator.h
+++ b/sp/src/game/server/ez2/npc_basepredator.h
@@ -65,6 +65,7 @@ enum
 	SCHED_PREDATOR_WANDER, // Similar to SCHED_PATROL_WALK, but with more interrupts for the [REDACTED]
 	SCHED_PREDATOR_SPAWN,
 	SCHED_PREDATOR_GROW,
+	SCHED_PREDATOR_ATTACK_TARGET,
 	LAST_SHARED_SCHEDULE_PREDATOR
 };
 
@@ -77,6 +78,7 @@ enum
 	COND_NEW_BOSS_STATE,
 	COND_PREDATOR_CAN_GROW,
 	COND_PREDATOR_GROWTH_INVALID,
+	COND_PREDATOR_OBSTRUCTED,
 	NEXT_CONDITION
 };
 
@@ -142,6 +144,7 @@ public:
 	float MaxYawSpeed ( void );
 
 	virtual void BuildScheduleTestBits();
+	virtual bool OnObstructionPreSteer( AILocalMoveGoal_t *pMoveGoal, float distClear, AIMoveResult_t *pResult );
 
 	virtual int RangeAttack1Conditions( float flDot, float flDist );
 	virtual int MeleeAttack1Conditions( float flDot, float flDist );
@@ -176,6 +179,9 @@ public:
 	virtual bool ShouldFindMate();
 	virtual bool CanMateWithTarget( CNPC_BasePredator * pTarget, bool receiving );
 	virtual bool ShouldEatInCombat();
+	virtual bool ShouldAttackObstruction( CBaseEntity *pEntity );
+	virtual bool ShouldImmediatelyAttackObstructions(); // If true, NPCs will immediately attack obstructions instead of waiting for the pathfinder to find a way around
+	virtual bool ShouldMeleeDamageAnyNPC() { return IsCurSchedule( SCHED_PREDATOR_ATTACK_TARGET, false ); }
 
 	virtual bool IsBaby() { return m_bIsBaby; };
 	virtual void SetIsBaby( bool bIsBaby ) { m_bIsBaby = bIsBaby; };
@@ -224,6 +230,8 @@ protected:
 	float m_flNextSpitTime;// last time the bullsquid used the spit attack.
 	float m_flHungryTime;// set this is a future time to stop the monster from eating for a while. 
 	float m_flNextSpawnTime; // Next time the bullsquid can birth offspring
+
+	EHANDLE	m_hObstructor; // Object obstructing path
 
 	float m_flStartedFearingEnemy; // Blixibon - Needed for Bad Cop's speech AI
 

--- a/sp/src/game/server/ez2/npc_bullsquid.cpp
+++ b/sp/src/game/server/ez2/npc_bullsquid.cpp
@@ -543,10 +543,14 @@ void CNPC_Bullsquid::HandleAnimEvent( animevent_t *pEvent )
 //=========================================================
 CBaseEntity * CNPC_Bullsquid::BiteAttack( float flDist, const Vector & mins, const Vector & maxs )
 {
-	CBaseEntity *pHurt = CheckTraceHullAttack( flDist, mins, maxs, GetBiteDamage(), DMG_SLASH | DMG_ALWAYSGIB );
+	CBaseEntity *pHurt = CheckTraceHullAttack( flDist, mins, maxs, GetBiteDamage(), DMG_SLASH | DMG_ALWAYSGIB, 1.0f, ShouldMeleeDamageAnyNPC() );
 	if ( pHurt )
 	{
 		BiteSound(); // Only play the bite sound if we have a target
+		
+		// If the player is holding this, make sure it's dropped
+		Pickup_ForcePlayerToDropThisObject( pHurt );
+
 		CBaseCombatCharacter *pVictim = ToBaseCombatCharacter( pHurt );
 		// Try to eat the target
 		if (pVictim && pVictim->DispatchInteraction( g_interactionBullsquidMonch, NULL, this ))

--- a/sp/src/game/server/ez2/npc_flyingpredator.h
+++ b/sp/src/game/server/ez2/npc_flyingpredator.h
@@ -61,6 +61,8 @@ public:
 	virtual void OnFed();
 	virtual bool ShouldEatInCombat() { return m_bIsBaby || BaseClass::ShouldEatInCombat(); }
 
+	virtual bool ShouldAttackObstruction( CBaseEntity *pEntity ) { return false; }
+
 	// No fly. Jump good!
 	bool IsJumpLegal( const Vector & startPos, const Vector & apex, const Vector & endPos ) const { return true; }
 

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -330,10 +330,13 @@ void CNPC_PitDrone::HandleAnimEvent( animevent_t *pEvent )
 		break;
 		case PREDATOR_AE_BITE:
 		{
-			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetBiteDamage(), DMG_SLASH | DMG_ALWAYSGIB );
+			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetBiteDamage(), DMG_SLASH | DMG_ALWAYSGIB, 1.0f, ShouldMeleeDamageAnyNPC() );
 			if (pHurt)
 			{
 				BiteSound(); // Only play the bite sound if we have a target
+
+				// If the player is holding this, make sure it's dropped
+				Pickup_ForcePlayerToDropThisObject( pHurt );
 			}
 
 			// Apply a velocity to hit entity if it is a character or if it has a physics movetype
@@ -355,9 +358,12 @@ void CNPC_PitDrone::HandleAnimEvent( animevent_t *pEvent )
 
 		case PREDATOR_AE_TAILWHIP:
 		{
-			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetWhipDamage(), DMG_SLASH | DMG_ALWAYSGIB );
+			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetWhipDamage(), DMG_SLASH | DMG_ALWAYSGIB, 1.0f, ShouldMeleeDamageAnyNPC() );
 			if (pHurt)
 			{
+				// If the player is holding this, make sure it's dropped
+				Pickup_ForcePlayerToDropThisObject( pHurt );
+
 				if (pHurt->GetFlags() & (FL_NPC | FL_CLIENT))
 					pHurt->ViewPunch( QAngle( 20, 0, -20 ) );
 

--- a/sp/src/game/server/ez2/npc_pitdrone.h
+++ b/sp/src/game/server/ez2/npc_pitdrone.h
@@ -50,6 +50,9 @@ public:
 	// On feeding
 	virtual void OnFed();
 
+	// Pit drones don't deal enough melee damage/force for this to be an effective strategy
+	virtual bool ShouldImmediatelyAttackObstructions() { return false; }
+
 	// Update bodygroups based on ammo count
 	void UpdateAmmoBodyGroups( void );
 

--- a/sp/src/game/server/ez2/npc_voltigore.cpp
+++ b/sp/src/game/server/ez2/npc_voltigore.cpp
@@ -404,10 +404,13 @@ void CNPC_Voltigore::HandleAnimEvent( animevent_t *pEvent )
 		break;
 		case PREDATOR_AE_BITE:
 		{
-			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetBiteDamage(), DMG_SLASH | DMG_ALWAYSGIB );
+			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetBiteDamage(), DMG_SLASH | DMG_ALWAYSGIB, 1.0f, ShouldMeleeDamageAnyNPC() );
 			if (pHurt)
 			{
 				BiteSound(); // Only play the bite sound if we have a target
+
+				// If the player is holding this, make sure it's dropped
+				Pickup_ForcePlayerToDropThisObject( pHurt );
 
 				Vector forward, up;
 				AngleVectors( GetAbsAngles(), &forward, NULL, &up );
@@ -425,9 +428,12 @@ void CNPC_Voltigore::HandleAnimEvent( animevent_t *pEvent )
 
 		case PREDATOR_AE_TAILWHIP:
 		{
-			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetWhipDamage(), DMG_SLASH | DMG_ALWAYSGIB );
+			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), GetWhipDamage(), DMG_SLASH | DMG_ALWAYSGIB, 1.0f, ShouldMeleeDamageAnyNPC() );
 			if (pHurt)
 			{
+				// If the player is holding this, make sure it's dropped
+				Pickup_ForcePlayerToDropThisObject( pHurt );
+
 				Vector right, up;
 				AngleVectors( GetAbsAngles(), NULL, &right, &up );
 

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -989,10 +989,13 @@ void CNPC_Gonome::HandleAnimEvent( animevent_t *pEvent )
 		{
 		// SOUND HERE!
 			CPASAttenuationFilter filter( this );
-			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector(-16,-16,-16), Vector(16,16,16), sk_zombie_assassin_dmg_bite.GetFloat(), DMG_SLASH );
+			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector(-16,-16,-16), Vector(16,16,16), sk_zombie_assassin_dmg_bite.GetFloat(), DMG_SLASH, 1.0f, ShouldMeleeDamageAnyNPC() );
 			if ( pHurt )
 			{
 				EmitSound( filter, entindex(), "Zombie.AttackHit" );
+
+				// If the player is holding this, make sure it's dropped
+				Pickup_ForcePlayerToDropThisObject( pHurt );
 			}
 			else // Play a random attack miss sound
 			{
@@ -1015,10 +1018,13 @@ void CNPC_Gonome::HandleAnimEvent( animevent_t *pEvent )
 		case GONOME_AE_TAILWHIP:
 		{
 			CPASAttenuationFilter filter( this );
-			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector(-16,-16,-16), Vector(16,16,16), sk_zombie_assassin_dmg_whip.GetFloat(), DMG_SLASH | DMG_ALWAYSGIB );
+			CBaseEntity *pHurt = CheckTraceHullAttack( 70, Vector(-16,-16,-16), Vector(16,16,16), sk_zombie_assassin_dmg_whip.GetFloat(), DMG_SLASH | DMG_ALWAYSGIB, 1.0f, ShouldMeleeDamageAnyNPC() );
 			if ( pHurt ) 
 			{
 				EmitSound( filter, entindex(), "Gonome.Bite" );
+
+				// If the player is holding this, make sure it's dropped
+				Pickup_ForcePlayerToDropThisObject( pHurt );
 
 				if ( pHurt->GetFlags() & ( FL_NPC | FL_CLIENT ) )
 					pHurt->ViewPunch( QAngle( 20, 0, -20 ) );


### PR DESCRIPTION
Predators will now attack objects obstructing their path and, if the object they hit is being carried by the player, the player will drop them. This fixes exploits in Chapter 3 involving objects the player is holding, including Wilson.

* Gonomes and adult bullsquids will immediately attack anything in their path.
* Pit drones and baby bullsquids will only attack obstructions if their schedule fails.

This behavior can be controlled with a cvar.