### PR TITLE
Soldier gibbing (disabled by default)

### DIFF
--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -1114,6 +1114,40 @@ bool CNPC_Combine::CanOrderSurrender()
 
 	return m_iCanOrderSurrender == TRS_TRUE;
 }
+
+ConVar npc_combine_gib( "npc_combine_gib", "0" );
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+// Input  : &info - 
+// Output : Returns true on success, false on failure.
+//-----------------------------------------------------------------------------
+bool CNPC_Combine::ShouldGib( const CTakeDamageInfo &info )
+{
+	if ( !npc_combine_gib.GetBool() )
+		return false;
+
+	// If the damage type is "always gib", we better gib!
+	if ( info.GetDamageType() & DMG_ALWAYSGIB )
+		return true;
+
+	if ( info.GetDamageType() & ( DMG_NEVERGIB | DMG_DISSOLVE ) )
+		return false;
+
+	if ( ( info.GetDamageType() & ( DMG_BLAST | DMG_ACID | DMG_POISON | DMG_CRUSH ) ) && ( GetAbsOrigin() - info.GetDamagePosition() ).LengthSqr() <= 32.0f )
+		return true;
+
+	return false;
+}
+
+//------------------------------------------------------------------------------
+// Purpose: Override to do rebel specific gibs
+// Output :
+//------------------------------------------------------------------------------
+bool CNPC_Combine::CorpseGib( const CTakeDamageInfo &info )
+{
+	return BaseClass::CorpseGib( info );
+}
 #endif
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -1126,6 +1126,10 @@ bool CNPC_Combine::ShouldGib( const CTakeDamageInfo &info )
 {
 	if ( !npc_combine_gib.GetBool() )
 		return false;
+	
+	// Don't gib if we're temporal
+	if (m_tEzVariant == EZ_VARIANT_TEMPORAL)
+		return false;
 
 	// If the damage type is "always gib", we better gib!
 	if ( info.GetDamageType() & DMG_ALWAYSGIB )

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -188,6 +188,9 @@ public:
 
 	virtual bool	CanOrderSurrender();
 
+	virtual bool	ShouldGib( const CTakeDamageInfo &info );
+	virtual bool	CorpseGib( const CTakeDamageInfo &info );
+
 	// Blixibon - Elites in ball attacks should aim while moving, even if they can't shoot
 	bool			HasAttackSlot() { return BaseClass::HasAttackSlot() || HasStrategySlot( SQUAD_SLOT_SPECIAL_ATTACK ); }
 


### PR DESCRIPTION
Optional feature. It's always felt weird to me personally how soldiers don't gib like citizens do, especially since their ragdolls can.

One problem that could arise from this feature is `c2_4`'s soldiers gibbing instead of ragdolling, which is part of why it's disabled by default.