### PR TITLE
Fix crash bug with challenges

### DIFF
--- a/sp/src/game/client/ez2/c_ez2_player.cpp
+++ b/sp/src/game/client/ez2/c_ez2_player.cpp
@@ -34,24 +34,7 @@ void C_EZ2_Player::OnDataChanged( DataUpdateType_t updateType )
 
 	if ( updateType == DATA_UPDATE_DATATABLE_CHANGED )
 	{
-		if ( m_bBonusChallengeUpdate )
-		{
-			// Borrow the achievement manager for this
-			CAchievementMgr *pAchievementMgr = dynamic_cast<CAchievementMgr *>(engine->GetAchievementMgr());
-			if (pAchievementMgr)
-			{
-				if (pAchievementMgr->WereCheatsEverOn())
-					return;
-			}
-
-			char szChallengeFileName[128];
-			char szChallengeMapName[128];
-			char szChallengeName[128];
-			BonusMapChallengeNames( szChallengeFileName, szChallengeMapName, szChallengeName );
-			BonusMapChallengeUpdate( szChallengeFileName, szChallengeMapName, szChallengeName, GetBonusProgress() );
-
-			m_bBonusChallengeUpdate = false;
-		}
+		BonusChallengeUpdate();
 
 		if (cl_slam_glow.GetBool())
 		{
@@ -89,6 +72,28 @@ void C_EZ2_Player::OnDataChanged( DataUpdateType_t updateType )
 
 	UpdateGlowTargetEffect();
 	UpdateSLAMGlowEffect();
+}
+
+void C_EZ2_Player::BonusChallengeUpdate()
+{
+	if (m_bBonusChallengeUpdate)
+	{
+		// Borrow the achievement manager for this
+		CAchievementMgr *pAchievementMgr = dynamic_cast<CAchievementMgr *>(engine->GetAchievementMgr());
+		if (pAchievementMgr)
+		{
+			if (pAchievementMgr->WereCheatsEverOn())
+				return;
+		}
+
+		char szChallengeFileName[128];
+		char szChallengeMapName[128];
+		char szChallengeName[128];
+		BonusMapChallengeNames( szChallengeFileName, szChallengeMapName, szChallengeName );
+		BonusMapChallengeUpdate( szChallengeFileName, szChallengeMapName, szChallengeName, GetBonusProgress() );
+
+		m_bBonusChallengeUpdate = false;
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/client/ez2/c_ez2_player.h
+++ b/sp/src/game/client/ez2/c_ez2_player.h
@@ -18,6 +18,8 @@ public:
 
 	void OnDataChanged( DataUpdateType_t updateType );
 
+	void BonusChallengeUpdate( );
+
 	void UpdateGlowTargetEffect( void );
 	void DestroyGlowTargetEffect( void );
 


### PR DESCRIPTION
The SLAM glow feature broke bonus challenges because the challenge update code can case OnDataChanged to exit prematurely. This PR will fix the bug by breaking challenge updates into a separate method.