### PR TITLE
Vortigaunts killed by zombigaunts can be converted to zombigaunts

### DIFF
--- a/sp/src/game/server/hl2/npc_vortigaunt_episodic.cpp
+++ b/sp/src/game/server/hl2/npc_vortigaunt_episodic.cpp
@@ -94,6 +94,8 @@ ConVar sk_vortigaunt_armor_charge_per_token( "sk_vortigaunt_armor_charge_per_tok
 ConVar sk_vortigaunt_npc_health_charge_per_token( "sk_vortigaunt_npc_health_charge_per_token", "50" );
 ConVar sk_vortigaunt_health_drain_per_token( "sk_vortigaunt_health_drain_per_token", "5" );
 ConVar sk_vortigaunt_health_drain_time( "sk_vortigaunt_health_drain_time", "15" );
+
+ConVar sk_vortigaunt_zombie_infection( "sk_vortigaunt_zombie_infection", "0", FCVAR_NONE, "If 1, vortigaunts killed by zombigaunts will transform into zombigaunts" );
 #endif
 
 ConVar sk_vortigaunt_health( "sk_vortigaunt_health","0");
@@ -1467,6 +1469,39 @@ void CNPC_Vortigaunt::Event_Killed( const CTakeDamageInfo &info )
 {
 	ClearBeams();
 	ClearHandGlow();
+
+	if (sk_vortigaunt_zombie_infection.GetBool() && info.GetAttacker()->MyNPCPointer() && info.GetAttacker()->ClassMatches( "npc_zombigaunt" ) && Classify() == CLASS_VORTIGAUNT )
+	{
+		CNPC_Vortigaunt *pChild = dynamic_cast< CNPC_Vortigaunt * >(CreateEntityByName( "npc_zombigaunt" ));
+		if (pChild)
+		{
+			// TODO - Play eerie scream sound when vortigaunt is converted
+
+
+			pChild->SetName( GetEntityName() );
+			pChild->m_tEzVariant = this->m_tEzVariant;
+			pChild->m_nSkin = this->m_nSkin;
+			pChild->SetModelName( GetModelName() );
+			pChild->SetAbsAngles( GetAbsAngles() );
+			pChild->SetAbsOrigin( GetAbsOrigin() );
+			pChild->AddSpawnFlags( GetSpawnFlags() );
+			pChild->Precache();
+
+			DispatchSpawn( pChild );
+
+			pChild->SetSquad( info.GetAttacker()->MyNPCPointer()->GetSquad() );
+			pChild->Activate();
+			pChild->SetActivityAndSequence( GetActivity(), GetSequence(), GetActivity(), GetActivity() );
+			pChild->SetCycle( GetCycle() );
+
+			// Deal damage to new zombigaunt
+			pChild->TakeDamage( info );
+
+			// Remove self
+			SUB_Remove();
+			return;
+		}
+	}
 
 	BaseClass::Event_Killed( info );
 }


### PR DESCRIPTION
This is just a little experiment I did for fun. The idea is that with a certain convar set, vortigaunts killed by zombigaunts turn into zombigaunts, without changing their appearance. The concept being that the Vortessence allows zombigaunts to dominate vortigaunts telepathically and convert them into a zombie-like state without actually infecting them with a headcrab.

This is just a concept. I'm opening a draft PR as a placeholder for the future.