### PR TITLE
Fixed dropships not dropping APCs correctly on Linux

### DIFF
--- a/sp/src/game/server/mapentities.cpp
+++ b/sp/src/game/server/mapentities.cpp
@@ -185,6 +185,12 @@ static void SortSpawnListByHierarchy( int nEntities, HierarchicalSpawn_t *pSpawn
 
 	g_pClassnameSpawnPriority->AddString( "prop_physics", 7 );
 	g_pClassnameSpawnPriority->AddString( "prop_ragdoll", 7 );
+
+#if defined(EZ2) && defined(LINUX)
+	// HACKHACK: Fixes dropships spawning before APCs and picking them up improperly on Linux
+	g_pClassnameSpawnPriority->AddString( "prop_vehicle_drivable_apc", 7 );
+#endif
+
 	// Sort the entities (other than the world) by hierarchy depth, in order to spawn them in
 	// that order. This insures that each entity's parent spawns before it does so that
 	// it can properly set up anything that relies on hierarchy.


### PR DESCRIPTION
On Linux, when dropships drop APCs in `ez2_c4_1` and `ez2_c4_2`, they get stuck where the dropships released them and don't fall to the ground.

This is because for some reason, the dropship and the APC spawn in a different order on Windows compared to Linux. On Windows, the APC spawns before the dropship. On Linux, the dropship spawns before the APC. The behavior on Linux is technically more accurate to the the order of the templates in the VMF, but the maps were designed around the behavior present on Windows and break otherwise.

This could be a symptom of a larger issue with template spawn order, so I would recommend keeping an eye out for any other special dependencies between entities in `point_template`s for similar problems. There's already a system in place to spawn parent entities before their children, so maybe that could be expanded to encompass other keyvalues (e.g. the dropship's target APC) as well.