### PR TITLE
Fixed E:Z2 achievements not working on Linux

### DIFF
--- a/sp/src/game/shared/achievementmgr.cpp
+++ b/sp/src/game/shared/achievementmgr.cpp
@@ -370,7 +370,15 @@ void CAchievementMgr::PostInit()
 		// applies to, or truly cross-game) or, if it does have a game filter, the filter matches current game.
 		// (e.g. EP 1/2/... achievements are in shared binary but are game specific, they have a game filter for runtime check.)
 		const char *pGameDirFilter = pAchievement->m_pGameDirFilter;
+#if defined(EZ2) && defined(LINUX)
+		// HACKHACK: When we shipped E:Z2, we used the casing "EntropyZero2" for the achievements' game dir filters as well as the -game target.
+		// However, this did not match the actual folder's casing, "entropyzero2", and that causes a conflict with Linux's case sensitivty.
+		// Rather than trying to coordinate a change with the launch options on Steam and all of the achievements' game dir filters, we've just
+		// made this particular check case insensitive for now.
+		if ( !pGameDirFilter || ( 0 == Q_stricmp( pGameDir, pGameDirFilter ) ) )
+#else
 		if ( !pGameDirFilter || ( 0 == Q_strcmp( pGameDir, pGameDirFilter ) ) )
+#endif
 		{
 			m_mapAchievement.Insert( pAchievement->GetAchievementID(), pAchievement );
 			if ( pAchievement->IsMetaAchievement() )


### PR DESCRIPTION
Achievements were designed around the mod directory being named `EntropyZero2`. This is actually based on the `-game` parameter rather than the actual folder name, and Windows launches it with that casing even though the folder itself is called `entropyzero2`. Meanwhile, Linux launches it as `entropyzero2` due to its case sensitivity and therefore it fails the mod directory checks.

This is a workaround which makes the mod directory comparison case-insensitive. The alternative would be to change both the Windows launch option on Steam and all of the achievements' game directory filters in the code at once to match the folder name, which isn't really worth the risk right now.