### PR TITLE
weapon_pulsepistol improvements to be used by NPCs

### DIFF
--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -643,9 +643,9 @@ public:
 		if ( GetOwner() && GetOwner()->IsPlayer() )
 		{
 			return 3.0f;
-		} 
+		}
 
-		return BaseClass::GetFireRate();
+		return 1.0f;
 	}
 
 	virtual void	UpdateOnRemove( void );
@@ -836,7 +836,7 @@ void CWeaponPulsePistol::FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, 
 	WeaponSound( SINGLE_NPC );
 
 	FireBulletsInfo_t info;
-	info.m_iShots = 1;
+	info.m_iShots = 2;
 	info.m_vecSrc = vecShootOrigin;
 	info.m_vecDirShooting = vecShootDir;
 	info.m_vecSpread = VECTOR_CONE_PRECALCULATED;
@@ -847,7 +847,9 @@ void CWeaponPulsePistol::FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, 
 	pOperator->FireBullets( info );
 	pOperator->DoMuzzleFlash();
 	m_iClip1 = MAX(m_iClip1 - 10, 0);
-	DevMsg( "NPC pulse pistol clip: %i\n", m_iClip1 );
+
+	// NPCs handle recharging after every shot
+	RechargeAmmo();
 }
 
 

--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -638,7 +638,12 @@ public:
 
 	virtual float GetFireRate( void )
 	{
-		return 3.0f;
+		if ( GetOwner() && GetOwner()->IsPlayer() )
+		{
+			return 3.0f;
+		} 
+
+		return BaseClass::GetFireRate();
 	}
 
 	virtual void	UpdateOnRemove( void );

--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -63,7 +63,7 @@ public:
 	void	DryFire( void );
 	void	Operator_HandleAnimEvent( animevent_t *pEvent, CBaseCombatCharacter *pOperator );
 #ifdef MAPBASE
-	void	FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, Vector &vecShootOrigin, Vector &vecShootDir );
+	virtual void FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, Vector &vecShootOrigin, Vector &vecShootDir );
 	void	Operator_ForceNPCFire( CBaseCombatCharacter  *pOperator, bool bSecondary );
 #endif
 
@@ -611,6 +611,8 @@ public:
 
 	void	Operator_HandleAnimEvent( animevent_t *pEvent, CBaseCombatCharacter *pOperator );
 
+	void	FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, Vector &vecShootOrigin, Vector &vecShootDir );
+
 	virtual bool Reload( void ) { return false; } // The pulse pistol does not reload
 
 	virtual int GetMaxClip2( void ) const { int iBase = BaseClass::GetMaxClip2(); return iBase > 0 ? iBase : sv_pulse_pistol_max_charge.GetInt(); }
@@ -822,6 +824,30 @@ void CWeaponPulsePistol::Operator_HandleAnimEvent( animevent_t * pEvent, CBaseCo
 	}
 
 	BaseClass::Operator_HandleAnimEvent( pEvent, pOperator );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Overridden by CWeaponPulsePistol to handle unique clip sizes
+//-----------------------------------------------------------------------------
+void CWeaponPulsePistol::FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, Vector &vecShootOrigin, Vector &vecShootDir )
+{
+	CSoundEnt::InsertSound( SOUND_COMBAT|SOUND_CONTEXT_GUNFIRE, pOperator->GetAbsOrigin(), SOUNDENT_VOLUME_PISTOL, 0.2, pOperator, SOUNDENT_CHANNEL_WEAPON, pOperator->GetEnemy() );
+
+	WeaponSound( SINGLE_NPC );
+
+	FireBulletsInfo_t info;
+	info.m_iShots = 1;
+	info.m_vecSrc = vecShootOrigin;
+	info.m_vecDirShooting = vecShootDir;
+	info.m_vecSpread = VECTOR_CONE_PRECALCULATED;
+	info.m_flDistance = MAX_TRACE_LENGTH;
+	info.m_iAmmoType = m_iPrimaryAmmoType;
+	info.m_iTracerFreq = 1; // Pulse pistol ALWAYS uses tracer
+
+	pOperator->FireBullets( info );
+	pOperator->DoMuzzleFlash();
+	m_iClip1 = MAX(m_iClip1 - 10, 0);
+	DevMsg( "NPC pulse pistol clip: %i\n", m_iClip1 );
 }
 
 


### PR DESCRIPTION
This pull request is to improve the functionality of the weapon_pulsepistol when used by NPCs instead of by the player. weapon_pulsepistol should be an equippable weapon by NPCs and they should be able to use it similarly to how the player does.

* NPCs fire two bullets instead of one like the player
* Fire rate is closer to the original pistol's for NPCs only
* NPCs take 10 ammo per shot like the player
* NPCs regenerate ammo like the player

This pull request is opened in draft status for visibility. It will be taken out of draft status when it is ready to be reviewed.

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
