### PR TITLE
Flechette shotgun improvements

### DIFF
--- a/sp/src/game/server/episodic/npc_hunter.cpp
+++ b/sp/src/game/server/episodic/npc_hunter.cpp
@@ -392,6 +392,21 @@ protected:
 
 	void FlechetteTouch( CBaseEntity *pOther );
 
+	virtual const char *GetFlechetteModel() { return HUNTER_FLECHETTE_MODEL; }
+	virtual float GetFlechetteDamage() { return sk_hunter_dmg_flechette.GetFloat(); }
+	virtual float GetFlechetteExplodeDamage() { return sk_hunter_flechette_explode_dmg.GetFloat(); }
+	virtual float GetFlechetteExplodeRadius() { return sk_hunter_flechette_explode_radius.GetFloat(); }
+
+	virtual const char *GetFlechetteSound_NearMiss() { return "NPC_Hunter.FlechetteNearmiss"; }
+	virtual const char *GetFlechetteSound_HitBody() { return "NPC_Hunter.FlechetteHitBody"; }
+	virtual const char *GetFlechetteSound_HitWorld() { return "NPC_Hunter.FlechetteHitWorld"; }
+	virtual const char *GetFlechetteSound_PreExplode() { return "NPC_Hunter.FlechettePreExplode"; }
+	virtual const char *GetFlechetteSound_Explode() { return "NPC_Hunter.FlechetteExplode"; }
+
+	virtual const char *GetFlechetteParticle_Trail_Bright() { return "hunter_flechette_trail_striderbuster"; }
+	virtual const char *GetFlechetteParticle_Trail() { return "hunter_flechette_trail"; }
+	virtual const char *GetFlechetteParticle_Explode() { return "hunter_projectile_explosion_1"; }
+
 #ifdef EZ2
 	virtual bool IsShotgunFlechette() { return false; }
 #endif
@@ -544,11 +559,11 @@ bool CHunterFlechette::CreateSprites( bool bBright )
 {
 	if ( bBright )
 	{
-		DispatchParticleEffect( "hunter_flechette_trail_striderbuster", PATTACH_ABSORIGIN_FOLLOW, this );
+		DispatchParticleEffect( GetFlechetteParticle_Trail_Bright(), PATTACH_ABSORIGIN_FOLLOW, this);
 	}
 	else
 	{
-		DispatchParticleEffect( "hunter_flechette_trail", PATTACH_ABSORIGIN_FOLLOW, this );
+		DispatchParticleEffect( GetFlechetteParticle_Trail(), PATTACH_ABSORIGIN_FOLLOW, this);
 	}
 	
 	return true;
@@ -561,7 +576,7 @@ void CHunterFlechette::Spawn()
 {
 	Precache( );
 
-	SetModel( HUNTER_FLECHETTE_MODEL );
+	SetModel( GetFlechetteModel() );
 	SetMoveType( MOVETYPE_FLYGRAVITY, MOVECOLLIDE_FLY_CUSTOM );
 	UTIL_SetSize( this, -Vector(1,1,1), Vector(1,1,1) );
 	SetSolid( SOLID_BBOX );
@@ -603,18 +618,18 @@ void CHunterFlechette::SetupGlobalModelData()
 //-----------------------------------------------------------------------------
 void CHunterFlechette::Precache()
 {
-	PrecacheModel( HUNTER_FLECHETTE_MODEL );
+	PrecacheModel( GetFlechetteModel() );
 	PrecacheModel( "sprites/light_glow02_noz.vmt" );
 
-	PrecacheScriptSound( "NPC_Hunter.FlechetteNearmiss" );
-	PrecacheScriptSound( "NPC_Hunter.FlechetteHitBody" );
-	PrecacheScriptSound( "NPC_Hunter.FlechetteHitWorld" );
-	PrecacheScriptSound( "NPC_Hunter.FlechettePreExplode" );
-	PrecacheScriptSound( "NPC_Hunter.FlechetteExplode" );
+	PrecacheScriptSound( GetFlechetteSound_NearMiss() );
+	PrecacheScriptSound( GetFlechetteSound_HitBody() );
+	PrecacheScriptSound( GetFlechetteSound_HitWorld() );
+	PrecacheScriptSound( GetFlechetteSound_PreExplode() );
+	PrecacheScriptSound( GetFlechetteSound_Explode() );
 
-	PrecacheParticleSystem( "hunter_flechette_trail_striderbuster" );
-	PrecacheParticleSystem( "hunter_flechette_trail" );
-	PrecacheParticleSystem( "hunter_projectile_explosion_1" );
+	PrecacheParticleSystem( GetFlechetteParticle_Trail_Bright() );
+	PrecacheParticleSystem( GetFlechetteParticle_Trail() );
+	PrecacheParticleSystem( GetFlechetteParticle_Explode() );
 }
 
 
@@ -622,7 +637,7 @@ void CHunterFlechette::Precache()
 //-----------------------------------------------------------------------------
 void CHunterFlechette::StickTo( CBaseEntity *pOther, trace_t &tr )
 {
-	EmitSound( "NPC_Hunter.FlechetteHitWorld" );
+	EmitSound( GetFlechetteSound_HitWorld() );
 
 	SetMoveType( MOVETYPE_NONE );
 	
@@ -678,6 +693,21 @@ void CHunterFlechette::StickTo( CBaseEntity *pOther, trace_t &tr )
 	SetContextThink( NULL, 0, s_szHunterFlechetteSeekThink );
 
 	// Get ready to explode.
+#ifdef EZ2
+	if ( IsShotgunFlechette() )
+	{
+		extern ConVar sk_plr_flechette_shotgun_explode_delay;
+		extern ConVar sk_npc_flechette_shotgun_explode_delay;
+
+		float flExplodeDelay = sk_plr_flechette_shotgun_explode_delay.GetFloat();
+		if (GetOwnerEntity() && GetOwnerEntity()->IsNPC())
+			flExplodeDelay = sk_npc_flechette_shotgun_explode_delay.GetFloat();
+
+		SetThink( &CHunterFlechette::DangerSoundThink );
+		SetNextThink( gpGlobals->curtime + (flExplodeDelay - HUNTER_FLECHETTE_WARN_TIME) );
+	}
+	else
+#endif
 	if ( !bAttachedToBuster )
 	{
 		SetThink( &CHunterFlechette::DangerSoundThink );
@@ -717,7 +747,7 @@ void CHunterFlechette::FlechetteTouch( CBaseEntity *pOther )
 			return;
 	}
 
-	if ( FClassnameIs( pOther, "hunter_flechette" ) )
+	if ( FClassnameIs( pOther, GetClassname() ) )
 		return;
 
 	trace_t	tr;
@@ -730,7 +760,7 @@ void CHunterFlechette::FlechetteTouch( CBaseEntity *pOther )
 		ClearMultiDamage();
 		VectorNormalize( vecNormalizedVel );
 
-		float flDamage = sk_hunter_dmg_flechette.GetFloat();
+		float flDamage = GetFlechetteDamage();
 		CBreakable *pBreak = dynamic_cast <CBreakable *>(pOther);
 		if ( pBreak && ( pBreak->GetMaterialType() == matGlass ) )
 		{
@@ -751,7 +781,7 @@ void CHunterFlechette::FlechetteTouch( CBaseEntity *pOther )
 		SetAbsVelocity( Vector( 0, 0, 0 ) );
 
 		// play body "thwack" sound
-		EmitSound( "NPC_Hunter.FlechetteHitBody" );
+		EmitSound( GetFlechetteSound_HitBody() );
 
 		StopParticleEffects( this );
 
@@ -883,7 +913,7 @@ void CHunterFlechette::DopplerThink()
 
 	if ( flPlayerDot <= flMyDot )
 	{
-		EmitSound( "NPC_Hunter.FlechetteNearMiss" );
+		EmitSound( GetFlechetteSound_NearMiss() );
 		
 		// We've played the near miss sound and we're not seeking. Stop thinking.
 		SetThink( NULL );
@@ -930,11 +960,28 @@ void CHunterFlechette::Shoot( Vector &vecVelocity, bool bBrightFX )
 //-----------------------------------------------------------------------------
 void CHunterFlechette::DangerSoundThink()
 {
-	EmitSound( "NPC_Hunter.FlechettePreExplode" );
+	EmitSound( GetFlechetteSound_PreExplode() );
 
 	CSoundEnt::InsertSound( SOUND_DANGER|SOUND_CONTEXT_EXCLUDE_COMBINE, GetAbsOrigin(), 150.0f, 0.5, this );
 	SetThink( &CHunterFlechette::ExplodeThink );
-	SetNextThink( gpGlobals->curtime + HUNTER_FLECHETTE_WARN_TIME );
+
+#ifdef EZ2
+	if (IsShotgunFlechette())
+	{
+		extern ConVar sk_plr_flechette_shotgun_explode_warn_duration;
+		extern ConVar sk_npc_flechette_shotgun_explode_warn_duration;
+
+		float flWarnTime = sk_plr_flechette_shotgun_explode_warn_duration.GetFloat();
+		if (GetOwnerEntity() && GetOwnerEntity()->IsNPC())
+			flWarnTime = sk_npc_flechette_shotgun_explode_warn_duration.GetFloat();
+
+		SetNextThink( gpGlobals->curtime + flWarnTime );
+	}
+	else
+#endif
+	{
+		SetNextThink( gpGlobals->curtime + HUNTER_FLECHETTE_WARN_TIME );
+	}
 }
 
 
@@ -955,12 +1002,12 @@ void CHunterFlechette::Explode()
 	// Don't catch self in own explosion!
 	m_takedamage = DAMAGE_NO;
 
-	EmitSound( "NPC_Hunter.FlechetteExplode" );
+	EmitSound( GetFlechetteSound_Explode() );
 	
 	// Move the explosion effect to the tip to reduce intersection with the world.
 	Vector vecFuse;
 	GetAttachment( s_nFlechetteFuseAttach, vecFuse );
-	DispatchParticleEffect( "hunter_projectile_explosion_1", vecFuse, GetAbsAngles(), NULL );
+	DispatchParticleEffect( GetFlechetteParticle_Explode(), vecFuse, GetAbsAngles(), NULL);
 
 	int nDamageType = DMG_DISSOLVE;
 
@@ -975,7 +1022,7 @@ void CHunterFlechette::Explode()
 
 #ifdef EZ2
 	// Shotgun flechettes ignore their owners
-	RadiusDamage( CTakeDamageInfo( this, GetOwnerEntity(), sk_hunter_flechette_explode_dmg.GetFloat(), nDamageType ), GetAbsOrigin(), sk_hunter_flechette_explode_radius.GetFloat(), CLASS_NONE, IsShotgunFlechette() ? GetOwnerEntity() : NULL );
+	RadiusDamage( CTakeDamageInfo( this, GetOwnerEntity(), GetFlechetteExplodeDamage(), nDamageType), GetAbsOrigin(), GetFlechetteExplodeRadius(), CLASS_NONE, IsShotgunFlechette() ? GetOwnerEntity() : NULL);
 #else
 	RadiusDamage( CTakeDamageInfo( this, GetOwnerEntity(), sk_hunter_flechette_explode_dmg.GetFloat(), nDamageType ), GetAbsOrigin(), sk_hunter_flechette_explode_radius.GetFloat(), CLASS_NONE, NULL );
 #endif
@@ -7570,6 +7617,16 @@ void Hunter_StriderBusterDetached( CBaseEntity *pHunter, CBaseEntity *pAttached 
 
 
 #ifdef EZ2
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+extern ConVar	sk_plr_dmg_flechette;
+extern ConVar	sk_plr_flechette_shotgun_explode_dmg;
+extern ConVar	sk_plr_flechette_shotgun_explode_radius;
+extern ConVar	sk_npc_dmg_flechette;
+extern ConVar	sk_npc_flechette_shotgun_explode_dmg;
+extern ConVar	sk_npc_flechette_shotgun_explode_radius;
+
 class CShotgunFlechette : public CHunterFlechette
 {
 	DECLARE_CLASS( CShotgunFlechette, CHunterFlechette );
@@ -7578,6 +7635,24 @@ public:
 
 	//CShotgunFlechette();
 	//~CShotgunFlechette();
+
+	inline bool IsOwnerNPC() { return GetOwnerEntity() && GetOwnerEntity()->IsNPC(); }
+
+	float GetFlechetteDamage() { return IsOwnerNPC() ? sk_npc_dmg_flechette.GetFloat() : sk_plr_dmg_flechette.GetFloat(); }
+	float GetFlechetteExplodeDamage() { return IsOwnerNPC() ? sk_npc_flechette_shotgun_explode_dmg.GetFloat() : sk_plr_flechette_shotgun_explode_dmg.GetFloat(); }
+	float GetFlechetteExplodeRadius() { return IsOwnerNPC() ? sk_npc_flechette_shotgun_explode_radius.GetFloat() : sk_plr_flechette_shotgun_explode_radius.GetFloat(); }
+
+	const char *GetFlechetteSound_NearMiss() { return "Weapon_Flechette_Shotgun.FlechetteNearmiss"; }
+	const char *GetFlechetteSound_HitBody() { return "Weapon_Flechette_Shotgun.FlechetteHitBody"; }
+	const char *GetFlechetteSound_HitWorld() { return "Weapon_Flechette_Shotgun.FlechetteHitWorld"; }
+	const char *GetFlechetteSound_PreExplode() { return "Weapon_Flechette_Shotgun.FlechettePreExplode"; }
+	const char *GetFlechetteSound_Explode() { return "Weapon_Flechette_Shotgun.FlechetteExplode"; }
+
+	const char *GetFlechetteParticle_Trail_Bright() { return "shotgun_flechette_trail_striderbuster"; }
+	const char *GetFlechetteParticle_Trail() { return "shotgun_flechette_trail"; }
+	const char *GetFlechetteParticle_Explode() { return "shotgun_flechette_projectile_explosion_1"; }
+
+	const char *GetFlechetteModel() { return "models/weapons/shotgun_flechette.mdl"; }
 
 	bool IsShotgunFlechette() { return true; }
 

--- a/sp/src/game/server/hl2/npc_combines.cpp
+++ b/sp/src/game/server/hl2/npc_combines.cpp
@@ -448,6 +448,12 @@ bool CNPC_CombineS::IsHeavyDamage( const CTakeDamageInfo &info )
 		return true;
 	}
 
+#ifdef EZ2
+	// Heavy damage when hit directly by shotgun flechettes
+	if ( info.GetDamageType() & (DMG_DISSOLVE | DMG_NEVERGIB) && info.GetInflictor() && FClassnameIs( info.GetInflictor(), "shotgun_flechette" ) )
+		return true;
+#endif
+
 	return BaseClass::IsHeavyDamage( info );
 }
 

--- a/sp/src/game/server/hl2/npc_metropolice.cpp
+++ b/sp/src/game/server/hl2/npc_metropolice.cpp
@@ -4772,6 +4772,12 @@ bool CNPC_MetroPolice::IsHeavyDamage( const CTakeDamageInfo &info )
 	if ( info.GetDamageType() & DMG_BULLET )
 		return true;
 
+#ifdef EZ2
+	// Heavy damage when hit directly by shotgun flechettes
+	if ( info.GetDamageType() & (DMG_DISSOLVE | DMG_NEVERGIB) && info.GetInflictor() && FClassnameIs( info.GetInflictor(), "shotgun_flechette" ) )
+		return true;
+#endif
+
 	return BaseClass::IsHeavyDamage( info );
 }
 

--- a/sp/src/game/server/hl2/npc_zombie.cpp
+++ b/sp/src/game/server/hl2/npc_zombie.cpp
@@ -1205,6 +1205,15 @@ bool CZombie::IsHeavyDamage( const CTakeDamageInfo &info )
 			return true;
 	}
 
+#ifdef EZ2
+	// Heavy damage when hit directly by shotgun flechettes
+	if ( info.GetDamageType() & (DMG_DISSOLVE | DMG_NEVERGIB) && info.GetInflictor() && FClassnameIs( info.GetInflictor(), "shotgun_flechette" ) )
+	{
+		if ( !m_fIsTorso )
+			return true;
+	}
+#endif
+
 	// Randomly treat all damage as heavy
 	if ( info.GetDamageType() & (DMG_BULLET | DMG_BUCKSHOT) )
 	{

--- a/sp/src/game/server/hl2/weapon_shotgun.cpp
+++ b/sp/src/game/server/hl2/weapon_shotgun.cpp
@@ -986,12 +986,26 @@ void CWeaponShotgun::WeaponIdle( void )
 //-----------------------------------------------------------------------------
 
 ConVar	sk_plr_flechette_shotgun_num_pellets( "sk_plr_flechette_shotgun_num_pellets","6", FCVAR_REPLICATED);
-ConVar	sk_plr_flechette_shotgun_num_pellets_double( "sk_plr_flechette_shotgun_num_pellets_double","11", FCVAR_REPLICATED);
+ConVar	sk_plr_flechette_shotgun_num_pellets_double( "sk_plr_flechette_shotgun_num_pellets_double","9", FCVAR_REPLICATED);
 ConVar	sk_npc_flechette_shotgun_num_pellets( "sk_npc_flechette_shotgun_num_pellets","6", FCVAR_REPLICATED);
-ConVar	sk_plr_flechette_shotgun_speed_min( "sk_plr_flechette_shotgun_speed_min","900", FCVAR_REPLICATED);
-ConVar	sk_plr_flechette_shotgun_speed_max( "sk_plr_flechette_shotgun_speed_max","1000", FCVAR_REPLICATED);
-ConVar	sk_npc_flechette_shotgun_speed_min( "sk_npc_flechette_shotgun_speed_min","1250", FCVAR_REPLICATED);
+
+ConVar	sk_plr_flechette_shotgun_speed_min( "sk_plr_flechette_shotgun_speed_min","1750", FCVAR_REPLICATED);
+ConVar	sk_plr_flechette_shotgun_speed_max( "sk_plr_flechette_shotgun_speed_max","2100", FCVAR_REPLICATED);
+ConVar	sk_npc_flechette_shotgun_speed_min( "sk_npc_flechette_shotgun_speed_min","1000", FCVAR_REPLICATED);
 ConVar	sk_npc_flechette_shotgun_speed_max( "sk_npc_flechette_shotgun_speed_max","1250", FCVAR_REPLICATED);
+
+ConVar	sk_plr_dmg_flechette( "sk_plr_dmg_flechette", "4.0" );
+ConVar	sk_plr_flechette_shotgun_explode_dmg( "sk_plr_flechette_shotgun_explode_dmg", "13.0" );
+ConVar	sk_plr_flechette_shotgun_explode_radius( "sk_plr_flechette_shotgun_explode_radius", "128.0" );
+ConVar	sk_npc_dmg_flechette( "sk_npc_dmg_flechette", "6.0" );
+ConVar	sk_npc_flechette_shotgun_explode_dmg( "sk_npc_flechette_shotgun_explode_dmg", "11.0" );
+ConVar	sk_npc_flechette_shotgun_explode_radius( "sk_npc_flechette_shotgun_explode_radius", "128.0" );
+
+ConVar	sk_plr_flechette_shotgun_explode_delay( "sk_plr_flechette_shotgun_explode_delay", "0" );
+ConVar	sk_npc_flechette_shotgun_explode_delay( "sk_npc_flechette_shotgun_explode_delay", "0" );
+
+ConVar	sk_plr_flechette_shotgun_explode_warn_duration( "sk_plr_flechette_shotgun_explode_warn_duration", "0.25" );
+ConVar	sk_npc_flechette_shotgun_explode_warn_duration( "sk_npc_flechette_shotgun_explode_warn_duration", "0.5" );
 
 class CWeaponFlechetteShotgun : public CWeaponShotgun
 {
@@ -1006,12 +1020,11 @@ public:
 
 	virtual const Vector& GetBulletSpread( void )
 	{
-		// NPCs need to return 100% accurate here because they calculate spread differently
-		static Vector npcCone = VECTOR_CONE_1DEGREES;
+		static Vector npcCone = VECTOR_CONE_7DEGREES;
 		if ( GetOwner() && GetOwner()->IsNPC() )
 			return npcCone;
 
-		static Vector cone = VECTOR_CONE_10DEGREES;
+		static Vector cone = VECTOR_CONE_6DEGREES;
 		return cone;
 	}
 
@@ -1034,7 +1047,7 @@ LINK_ENTITY_TO_CLASS( weapon_flechette_shotgun, CWeaponFlechetteShotgun );
 void CWeaponFlechetteShotgun::Precache( void )
 {
 	BaseClass::Precache();
-	UTIL_PrecacheOther( "hunter_flechette" );
+	UTIL_PrecacheOther( "shotgun_flechette" );
 }
 
 //-----------------------------------------------------------------------------
@@ -1184,7 +1197,8 @@ void CWeaponFlechetteShotgun::SecondaryAttack( void )
 
 	for (int i = 0; i < sk_plr_flechette_shotgun_num_pellets_double.GetInt(); i++)
 	{
-		vecDir = Manipulator.ApplySpread( GetBulletSpread() );
+		// Use a wider spread for the secondary
+		vecDir = Manipulator.ApplySpread( VECTOR_CONE_10DEGREES );
 
 		FlechetteShotgun_CreateFlechette( vecSrc, vecDir * RandomFloat( sk_plr_flechette_shotgun_speed_min.GetFloat(), sk_plr_flechette_shotgun_speed_max.GetFloat() ), pPlayer);
 	}


### PR DESCRIPTION
This PR further iterates upon the flechette shotgun.

* Rather than being an explosion of steadily moving flechettes, the flechettes are now much faster and more concentrated. NPC flechettes are still slower for balancing reasons.
* The player's shotgun flechettes now explode within 1/4 of a second. NPCs' shotgun flechettes now explode within 1/2 of a second.
* The shotgun flechettes now use their own model, particles, and sounds based on the original hunter flechettes.
* Certain NPCs will now flinch when being hit by shotgun flechettes.