### PR TITLE
Surplus pulse pistols can be picked up as armor batteries

### DIFF
--- a/sp/src/game/server/hl2/hl2_player.cpp
+++ b/sp/src/game/server/hl2/hl2_player.cpp
@@ -143,6 +143,8 @@ ConVar sv_flashlight_cc_maxweight( "sv_flashlight_cc_maxweight", "100", FCVAR_RE
 ConVar sv_flashlight_cc_filename( "sv_flashlight_cc_filename", "ez2_nvg.raw", FCVAR_REPLICATED );
 ConVar sv_player_hands_modelname( "sv_player_hands_modelname", "models/weapons/ez2/v_hands.mdl", FCVAR_REPLICATED, "Filename of model to use for suit inspect animation" );
 ConVar sv_player_kick_default_modelname( "sv_player_kick_default_modelname", "models/weapons/ez2/v_kick.mdl", FCVAR_REPLICATED, "Default filename of model to use for kick animation - can be overridden in map" );
+ConVar sv_pulsepistol_battery_pickup( "sv_pulsepistol_battery_pickup", "1", FCVAR_REPLICATED, "Picks up extra pulse pistols as armor batteries" );
+ConVar sv_pulsepistol_battery_pickup_amount( "sv_pulsepistol_battery_pickup_amount", "0.4", FCVAR_REPLICATED, "What percentage of sk_battery should be provided by extra pulse pistols" );
 #else
 ConVar sv_command_viewmodel_anims("sv_command_viewmodel_anims", "0", FCVAR_REPLICATED);
 ConVar sv_disallow_zoom_fire("sv_disallow_zoom_fire", "1", FCVAR_REPLICATED);
@@ -3575,6 +3577,18 @@ bool CHL2_Player::Weapon_CanUse( CBaseCombatWeapon *pWeapon )
 		return false;
 	}
 #endif
+#endif
+
+#ifdef EZ2
+	if ( pWeapon->ClassMatches( "weapon_pulsepistol" ) && sv_pulsepistol_battery_pickup.GetBool() )
+	{
+		if (Weapon_OwnsThisType( "weapon_pulsepistol" ))
+		{
+			if (ApplyBattery( sv_pulsepistol_battery_pickup_amount.GetFloat() ))
+				UTIL_Remove( pWeapon );
+			return false;
+		}
+	}
 #endif
 
 	return BaseClass::Weapon_CanUse( pWeapon );

--- a/sp/src/game/server/mapbase/ai_grenade.h
+++ b/sp/src/game/server/mapbase/ai_grenade.h
@@ -685,8 +685,17 @@ void CAI_GrenadeUser<BASE_NPC>::DropGrenadeItemsOnDeath( const CTakeDamageInfo &
 	if( IsAltFireCapable() && ShouldDropAltFire() )
 	{
 		CBaseEntity *pItem;
-		if (this->GetActiveWeapon() && FClassnameIs( this->GetActiveWeapon(), "weapon_smg1" ))
-			pItem = this->DropItem( "item_ammo_smg1_grenade", this->WorldSpaceCenter()+RandomVector(-4,4), RandomAngle(0,360) );
+		if (this->GetActiveWeapon())
+		{
+			if (FClassnameIs( this->GetActiveWeapon(), "weapon_smg1" ))
+				pItem = this->DropItem( "item_ammo_smg1_grenade", this->WorldSpaceCenter()+RandomVector(-4,4), RandomAngle(0,360) );
+#ifdef EZ2
+			else if (FClassnameIs( this->GetActiveWeapon(), "weapon_pulsepistol" ))
+				pItem = NULL; // Give nothing for now
+#endif
+			else
+				pItem = this->DropItem( "item_ammo_ar2_altfire", this->WorldSpaceCenter() + RandomVector( -4, 4 ), RandomAngle( 0, 360 ) );
+		}
 		else
 			pItem = this->DropItem( "item_ammo_ar2_altfire", this->WorldSpaceCenter() + RandomVector( -4, 4 ), RandomAngle( 0, 360 ) );
 


### PR DESCRIPTION
If the player already has a pulse pistol, then they will pick up additional pulse pistols as if they were armor batteries. This can be toggled using `sv_pulsepistol_battery_pickup`. Picking up an extra pulse pistol provides `10` armor by default and can be adjusted using `sv_pulsepistol_battery_pickup_amount`. This works in a similar fashion to stunsticks in HL2.

This PR also fixes NPCs dropping inappropriate alt-fire items.