### PR TITLE
Stasis grenade weapon

### DIFF
--- a/sp/src/game/client/hl2/c_weapon__stubs_hl2.cpp
+++ b/sp/src/game/client/hl2/c_weapon__stubs_hl2.cpp
@@ -58,6 +58,7 @@ STUB_WEAPON_CLASS( weapon_endgame, WeaponEndGame, C_BaseHLCombatWeapon );
 STUB_WEAPON_CLASS( weapon_arbeit_clipboard, WeaponArbeitClipboard, C_WeaponCitizenPackage );
 
 STUB_WEAPON_CLASS( weapon_flechette_shotgun, WeaponFlechetteShotgun, C_BaseHLCombatWeapon );
+STUB_WEAPON_CLASS( weapon_stasis_grenade, WeaponStasisGrenade, C_BaseHLCombatWeapon );
 #endif
 
 

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2775,6 +2775,7 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 void CStasisVortexController::PullThink( void )
 {
 	float flStrength = m_flStrength;
+	CRagdollProp *pRagdoll = NULL;
 
 	// Pull any players close enough to us
 	FreezePlayersInRange();
@@ -2830,6 +2831,9 @@ void CStasisVortexController::PullThink( void )
 			continue;
 		}
 
+		// Reset ragdoll
+		pRagdoll = NULL;
+
 		// Freeze NPCs by stopping their think function
 		if (pEnts[i]->MyCombatCharacterPointer())
 		{
@@ -2854,6 +2858,18 @@ void CStasisVortexController::PullThink( void )
 			pEnts[i]->SetNextThink( TICK_NEVER_THINK );
 			DevMsg( "NPC '%s' caught in stasis field! Thinking stopped\n", pEnts[i]->GetDebugName() );
 
+			continue;
+		}
+
+		if (FClassnameIs( pEnts[i], "prop_ragdoll" ))
+		{
+			pRagdoll = dynamic_cast< CRagdollProp* >(this);
+		}
+
+		if (pRagdoll)
+		{
+			pRagdoll->DisableMotion();
+			pRagdoll->SetContextThink( &CStasisVortexController::UnfreezePhysicsObjectThink, m_flEndTime, "StasisGrenadeUnfreeze" );
 			continue;
 		}
 
@@ -2929,6 +2945,21 @@ void CStasisVortexController::UnfreezeNPCThink( void )
 //-----------------------------------------------------------------------------
 void CStasisVortexController::UnfreezePhysicsObjectThink( void )
 {
+	CRagdollProp *pRagdoll = NULL;
+
+	SetContextThink( NULL, TICK_NEVER_THINK, "StasisGrenadeUnfreeze" );
+
+	if (FClassnameIs( this, "prop_ragdoll" ))
+	{
+		pRagdoll = dynamic_cast< CRagdollProp* >(this);
+	}
+
+	if (pRagdoll)
+	{
+		pRagdoll->InputEnableMotion( inputdata_t() );
+		return;
+	}
+
 	IPhysicsObject *pPhysObject = VPhysicsGetObject();
 	if (pPhysObject == NULL)
 	{
@@ -2938,7 +2969,6 @@ void CStasisVortexController::UnfreezePhysicsObjectThink( void )
 	pPhysObject->EnableMotion( true );
 	pPhysObject->EnableGravity( true );
 	pPhysObject->Wake();
-	SetContextThink( NULL, TICK_NEVER_THINK, "StasisGrenadeUnfreeze" );
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2126,7 +2126,7 @@ CGravityVortexController *CGravityVortexController::Create( const Vector &origin
 #endif
 {
 	// Create an instance of the vortex
-	CStasisVortexController *pVortex = (CStasisVortexController *) CreateEntityByName( "stasis_controller" );
+	CGravityVortexController *pVortex = (CGravityVortexController *)CreateEntityByName( "vortex_controller" );
 	if ( pVortex == NULL )
 		return NULL;
 
@@ -2711,6 +2711,14 @@ void CGrenadeHopwire::Detonate( void )
 
 	// Get the time until the apex of the hop
 	float apexTime = sqrt( hopHeight / GetCurrentGravity() );
+
+	// If this is a stasis grenade, use the stasis grenade think function to detonate
+	if (FClassnameIs(this, "npc_grenade_stasis"))
+	{
+		SetThink( &CGrenadeStasis::CombatThink );
+		SetNextThink( gpGlobals->curtime + apexTime );
+		return;
+	}
 #else
 	EmitSound("NPC_Strider.Shoot"); // Sound to emit before detonating
 	SetModel( szWorldModelOpen );
@@ -2734,7 +2742,7 @@ void CGrenadeHopwire::Detonate( void )
 #endif
 
 	// Explode at the apex
-	SetThink( &CGrenadeStasis::CombatThink );
+	SetThink( &CGrenadeHopwire::CombatThink );
 	SetNextThink( gpGlobals->curtime + apexTime);
 }
 
@@ -2750,7 +2758,7 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 	if (modelOpen == NULL)
 		modelOpen = szHopwireModel;
 
-	CGrenadeStasis *pGrenade = (CGrenadeStasis *) CBaseEntity::CreateNoSpawn( "npc_grenade_stasis", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
+	CGrenadeHopwire *pGrenade = (CGrenadeHopwire *)CBaseEntity::CreateNoSpawn( "npc_grenade_hopwire", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
 	pGrenade->SetWorldModelClosed(modelClosed);
 	pGrenade->SetWorldModelOpen(modelOpen);
 
@@ -2769,6 +2777,61 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 }
 
 #ifdef EZ2
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+CBaseGrenade *StasisGrenade_Create( const Vector &position, const QAngle &angles, const Vector &velocity, const AngularImpulse &angVelocity, CBaseEntity *pOwner, float timer, const char * modelClosed, const char * modelOpen )
+{
+	// Fall back to a default model if none specified
+	static const char *szHopwireModel = "models/weapons/w_xengrenade.mdl";
+	if (modelClosed == NULL)
+		modelClosed = szHopwireModel;
+	if (modelOpen == NULL)
+		modelOpen = szHopwireModel;
+
+	CGrenadeStasis *pGrenade = (CGrenadeStasis *)CBaseEntity::CreateNoSpawn( "npc_grenade_stasis", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
+	pGrenade->SetWorldModelClosed( modelClosed );
+	pGrenade->SetWorldModelOpen( modelOpen );
+
+	DispatchSpawn( pGrenade );
+
+	// Only set ourselves to detonate on a timer if we're not a trap hopwire
+	if (hopwire_trap.GetBool() == false)
+	{
+		pGrenade->SetTimer( timer );
+	}
+
+	pGrenade->SetVelocity( velocity, angVelocity );
+	pGrenade->SetThrower( ToBaseCombatCharacter( pOwner ) );
+
+	return pGrenade;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Creation utility
+//-----------------------------------------------------------------------------
+CStasisVortexController *CStasisVortexController::Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade )
+{
+	// Create an instance of the vortex
+	CStasisVortexController *pVortex = (CStasisVortexController *)CreateEntityByName( "stasis_controller" );
+	if (pVortex == NULL)
+		return NULL;
+
+	pVortex->SetOwnerEntity( pGrenade );
+	if (pGrenade)
+		pVortex->SetThrower( static_cast<CGrenadeHopwire*>(pGrenade)->GetThrower() );
+
+	pVortex->SetNodeRadius( hopwire_spawn_node_radius.GetFloat() );
+	pVortex->SetConsumeRadius( hopwire_conusme_radius.GetFloat() );
+
+	// Start the vortex working
+	pVortex->StartPull( origin, radius, strength, duration );
+
+	return pVortex;
+}
+
+
 //-----------------------------------------------------------------------------
 // Purpose: Holds everything in a stasis field
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2848,7 +2848,7 @@ void CStasisVortexController::PullThink( void )
 			pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezeNPCThink, m_flEndTime, "StasisGrenadeUnfreeze" );
 
 			// Don't cancel the think function until the NPC picks up SCHED_NPC_FREEZE
-			if (pEnts[i]->MyNPCPointer() && !(pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE)))
+			if (pEnts[i]->MyNPCPointer() && !(pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false)))
 				continue;
 
 			pEnts[i]->SetNextThink( TICK_NEVER_THINK );

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2713,7 +2713,7 @@ void CGrenadeHopwire::Detonate( void )
 	float apexTime = sqrt( hopHeight / GetCurrentGravity() );
 
 	// If this is a stasis grenade, use the stasis grenade think function to detonate
-	if (FClassnameIs(this, "npc_grenade_stasis"))
+	if (GetHopwireStyle() == HOPWIRE_STASIS)
 	{
 		SetThink( &CGrenadeStasis::CombatThink );
 		SetNextThink( gpGlobals->curtime + apexTime );

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2194,6 +2194,9 @@ END_DATADESC()
 LINK_ENTITY_TO_CLASS( vortex_controller, CGravityVortexController );
 
 #ifdef EZ2
+
+LINK_ENTITY_TO_CLASS( stasis_controller, CStasisVortexController );
+
 #define GRENADE_MODEL_CLOSED	"models/weapons/w_XenGrenade.mdl" // was roller.mdl
 #define GRENADE_MODEL_OPEN		"models/weapons/w_XenGrenade.mdl" // was roller_spikes.mdl
 
@@ -2228,6 +2231,10 @@ BEGIN_DATADESC( CGrenadeHopwire )
 END_DATADESC()
 
 LINK_ENTITY_TO_CLASS( npc_grenade_hopwire, CGrenadeHopwire );
+
+#ifdef EZ2
+LINK_ENTITY_TO_CLASS( npc_grenade_stasis, CGrenadeStasis );
+#endif
 
 IMPLEMENT_SERVERCLASS_ST( CGrenadeHopwire, DT_GrenadeHopwire )
 END_SEND_TABLE()
@@ -2727,7 +2734,7 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 	if (modelOpen == NULL)
 		modelOpen = szHopwireModel;
 
-	CGrenadeHopwire *pGrenade = (CGrenadeHopwire *) CBaseEntity::CreateNoSpawn( "npc_grenade_hopwire", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
+	CGrenadeHopwire *pGrenade = (CGrenadeHopwire *) CBaseEntity::CreateNoSpawn( "npc_grenade_stasis", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
 	pGrenade->SetWorldModelClosed(modelClosed);
 	pGrenade->SetWorldModelOpen(modelOpen);
 
@@ -2744,3 +2751,242 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 
 	return pGrenade;
 }
+
+#ifdef EZ2
+//-----------------------------------------------------------------------------
+// Purpose: Holds everything in a stasis field
+//-----------------------------------------------------------------------------
+void CStasisVortexController::PullThink( void )
+{
+	float flStrength = m_flStrength;
+
+	// Pull any players close enough to us
+	PullPlayersInRange();
+
+	// Draw debug information
+	if (g_debug_hopwire.GetInt() >= 2)
+	{
+		NDebugOverlay::Sphere( GetAbsOrigin(), m_flRadius, 0, 255, 0, 16, 4.0f );
+	}
+
+	CBaseEntity *pEnts[128];
+	int numEnts = 0;
+
+	// Next, loop through all entities within the pull radius
+	numEnts = UTIL_EntitiesInSphere( pEnts, 128, GetAbsOrigin(), m_flRadius, 0 );
+
+	if (!m_bPVSCreated)
+	{
+		// Create a PVS for this entity
+		engine->GetPVSForCluster( engine->GetClusterForOrigin( GetAbsOrigin() ), sizeof( m_PVS ), m_PVS );
+	}
+
+	if (m_flPullFadeTime > 0.0f)
+	{
+		flStrength *= ((gpGlobals->curtime - m_flStartTime) / m_flPullFadeTime);
+	}
+
+	for (int i = 0; i < numEnts; i++)
+	{
+		if (pEnts[i]->IsPlayer())
+			continue;
+
+		IPhysicsObject *pPhysObject = NULL;
+
+		// Don't consume entities already in the process of being removed.
+		// NPCs which generate ragdolls might not be removed in time, so check for EF_NODRAW as well.
+		if (pEnts[i]->IsMarkedForDeletion() || pEnts[i]->IsEffectActive( EF_NODRAW ))
+			continue;
+
+		// Don't pull objects that are protected
+		if (pEnts[i]->IsDisplacementImpossible())
+			continue;
+
+		const Vector& vecEntCenter = pEnts[i]->WorldSpaceCenter();
+
+		// We do a PVS check here to make sure the entity isn't on another floor or behind a thick wall.
+		if (!engine->CheckOriginInPVS( vecEntCenter, m_PVS, sizeof( m_PVS ) ))
+			continue;
+
+		Vector	vecForce = GetAbsOrigin() - vecEntCenter;
+		Vector	vecForce2D = vecForce;
+		vecForce2D[2] = 0.0f;
+		float	dist2D = VectorNormalize( vecForce2D );
+		float	dist = VectorNormalize( vecForce );
+
+		// First, pull npcs outside of the ragdoll radius towards the vortex
+		if (abs( dist ) > hopwire_ragdoll_radius.GetFloat())
+		{
+			CAI_BaseNPC * pNPC = pEnts[i]->MyNPCPointer();
+			if (pEnts[i]->IsNPC() && pNPC != NULL && pNPC->CanBecomeRagdoll())
+			{
+				// Find the pull force
+				// Minimum pull force is 10% of strength here
+				vecForce *= MAX( 1.0f - (abs( dist2D ) / m_flRadius), 0.1f ) * flStrength;
+
+				// Physics damage info
+				CTakeDamageInfo info( this, this, vecForce, GetAbsOrigin(), flStrength, DMG_BLAST );
+
+				// Dispatch interaction. Skip pulling if it returns true
+				if (pEnts[i]->DispatchInteraction( g_interactionXenGrenadePull, &info, GetThrower() ))
+				{
+					continue;
+				}
+
+				// Pull
+				pNPC->ApplyAbsVelocityImpulse( vecForce );
+
+				// We already handled this NPC, move on
+				continue;
+			}
+		}
+		if (KillNPCInRange( pEnts[i], &pPhysObject ))
+		{
+			DevMsg( "Xen grenade turned NPC '%s' into a ragdoll! \n", pEnts[i]->GetDebugName() );
+		}
+		else
+		{
+			// If we didn't have a valid victim, see if we can just get the vphysics object
+			pPhysObject = pEnts[i]->VPhysicsGetObject();
+			if (pPhysObject == NULL)
+			{
+				continue;
+			}
+		}
+
+		float mass = 0.0f;
+
+		CRagdollProp * pRagdoll = dynamic_cast< CRagdollProp* >(pEnts[i]);
+		ragdoll_t * pRagdollPhys = NULL;
+		if (pRagdoll != NULL)
+		{
+			pRagdollPhys = pRagdoll->GetRagdoll();
+		}
+
+		if (pRagdollPhys != NULL)
+		{
+			// Find the aggregate mass of the whole ragdoll
+			for (int j = 0; j < pRagdollPhys->listCount; ++j)
+			{
+				mass += pRagdollPhys->list[j].pObject->GetMass();
+			}
+		}
+		else if (pPhysObject != NULL)
+		{
+			mass = pPhysObject->GetMass();
+		}
+
+
+		// Find the pull force
+		// Minimum pull force is 10% of strength here
+		vecForce *= MAX( 1.0f - (abs( dist2D ) / m_flRadius), 0.1f ) * flStrength * mass;
+
+
+		CTakeDamageInfo info( this, this, vecForce, GetAbsOrigin(), flStrength, DMG_BLAST );
+		if (!pEnts[i]->DispatchInteraction( g_interactionXenGrenadePull, &info, GetThrower() ) && pPhysObject != NULL)
+		{
+			// Pull the object in if there was no special handling
+			pEnts[i]->VPhysicsTakeDamage( info );
+		}
+	}
+
+	// Keep going if need-be
+	if (m_flEndTime > gpGlobals->curtime)
+	{
+		SetThink( &CStasisVortexController::PullThink );
+		SetNextThink( gpGlobals->curtime + 0.1f );
+	}
+	else
+	{
+		// Fire game event for player xen grenades
+		IGameEvent *event = gameeventmanager->CreateEvent( "stasis_grenade" );
+		if (event)
+		{
+			if (GetThrower())
+			{
+				event->SetInt( "entindex_attacker", GetThrower()->entindex() );
+			}
+
+			// event->SetFloat( "mass", m_flMass );
+			gameeventmanager->FireEvent( event );
+		}
+
+		m_OnPullFinished.FireOutput( this, this );
+
+		if (!HasSpawnFlags( SF_VORTEX_CONTROLLER_DONT_REMOVE ))
+		{
+			// Remove at the maximum possible time of when we would be finished spawning entities
+			SetThink( &CBaseEntity::SUB_Remove );
+			SetNextThink( gpGlobals->curtime + (m_SpawnList.Count() * hopwire_spawn_interval_max.GetFloat() + 1.0f) );
+			XenGrenadeDebugMsg( "REMOVE TIME: Count %i * interval %f + 1.0 = %f\n", m_SpawnList.Count(), hopwire_spawn_interval_max.GetFloat(), (m_SpawnList.Count() * hopwire_spawn_interval_max.GetFloat() + 1.0f) );
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Starts the vortex working
+//-----------------------------------------------------------------------------
+void CStasisVortexController::StartPull( const Vector &origin, float radius, float strength, float duration )
+{
+	SetAbsOrigin( origin );
+	m_flEndTime	= gpGlobals->curtime + duration;
+	m_flRadius	= radius;
+	m_flStrength= strength;
+
+	// Play a danger sound throughout the duration of the vortex so that NPCs run away
+	CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), radius, duration, this );
+
+	SetDefLessFunc( m_SpawnList );
+	m_SpawnList.EnsureCapacity( 16 );
+
+	m_flStartTime = gpGlobals->curtime;
+
+	SetThink( &CStasisVortexController::PullThink );
+	SetNextThink( gpGlobals->curtime + 0.1f );
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CGrenadeStasis::EndThink( void )
+{
+	EntityMessageBegin( this, true );
+	WRITE_BYTE( 1 );
+	MessageEnd();
+
+	SetThink( &CBaseEntity::SUB_Remove );
+	SetNextThink( gpGlobals->curtime + 1.0f );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CGrenadeStasis::CombatThink( void )
+{
+	if (VPhysicsGetObject() && VPhysicsGetObject()->GetGameFlags() & FVPHYSICS_PLAYER_HELD)
+	{
+		// Players must stop holding us here
+		CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+		pPlayer->ForceDropOfCarriedPhysObjects( this );
+	}
+
+	// Stop the grenade from moving
+	AddEFlags( EF_NODRAW );
+	AddFlag( FSOLID_NOT_SOLID );
+	VPhysicsDestroyObject();
+	SetAbsVelocity( vec3_origin );
+	SetMoveType( MOVETYPE_NONE );
+
+	m_hVortexController = CStasisVortexController::Create( GetAbsOrigin(), hopwire_radius.GetFloat(), hopwire_strength.GetFloat(), hopwire_duration.GetFloat(), this );
+
+	// Start our client-side effect
+	EntityMessageBegin( this, true );
+	WRITE_BYTE( 0 );
+	MessageEnd();
+
+	// Begin to stop in two seconds
+	SetThink( &CGrenadeStasis::EndThink );
+	SetNextThink( gpGlobals->curtime + 2.0f );
+}
+#endif

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -97,6 +97,8 @@ int	g_interactionXenGrenadeRelease		= 0;
 int g_interactionXenGrenadeCreate		= 0;
 int g_interactionXenGrenadeHop			= 0;
 int g_interactionXenGrenadeRagdoll      = 0;
+
+int	g_interactionStasisGrenadeFreeze	= 0;
 #endif
 
 #ifdef EZ2
@@ -2124,7 +2126,7 @@ CGravityVortexController *CGravityVortexController::Create( const Vector &origin
 #endif
 {
 	// Create an instance of the vortex
-	CGravityVortexController *pVortex = (CGravityVortexController *) CreateEntityByName( "vortex_controller" );
+	CStasisVortexController *pVortex = (CStasisVortexController *) CreateEntityByName( "stasis_controller" );
 	if ( pVortex == NULL )
 		return NULL;
 
@@ -2194,9 +2196,6 @@ END_DATADESC()
 LINK_ENTITY_TO_CLASS( vortex_controller, CGravityVortexController );
 
 #ifdef EZ2
-
-LINK_ENTITY_TO_CLASS( stasis_controller, CStasisVortexController );
-
 #define GRENADE_MODEL_CLOSED	"models/weapons/w_XenGrenade.mdl" // was roller.mdl
 #define GRENADE_MODEL_OPEN		"models/weapons/w_XenGrenade.mdl" // was roller_spikes.mdl
 
@@ -2232,12 +2231,27 @@ END_DATADESC()
 
 LINK_ENTITY_TO_CLASS( npc_grenade_hopwire, CGrenadeHopwire );
 
-#ifdef EZ2
-LINK_ENTITY_TO_CLASS( npc_grenade_stasis, CGrenadeStasis );
-#endif
-
 IMPLEMENT_SERVERCLASS_ST( CGrenadeHopwire, DT_GrenadeHopwire )
 END_SEND_TABLE()
+
+#ifdef EZ2
+BEGIN_DATADESC( CStasisVortexController )
+
+DEFINE_THINKFUNC( PullThink ),
+DEFINE_THINKFUNC( UnfreezePhysicsObjectThink ),
+DEFINE_THINKFUNC( UnfreezeNPCThink )
+
+END_DATADESC()
+
+LINK_ENTITY_TO_CLASS( stasis_controller, CStasisVortexController );
+
+BEGIN_DATADESC( CGrenadeStasis )
+DEFINE_THINKFUNC( EndThink ),
+DEFINE_THINKFUNC( CombatThink ),
+END_DATADESC()
+
+LINK_ENTITY_TO_CLASS( npc_grenade_stasis, CGrenadeStasis );
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: 
@@ -2314,6 +2328,8 @@ void CGrenadeHopwire::Precache( void )
 		g_interactionXenGrenadeCreate = CBaseCombatCharacter::GetInteractionID();
 		g_interactionXenGrenadeHop = CBaseCombatCharacter::GetInteractionID();
 		g_interactionXenGrenadeRagdoll = CBaseCombatCharacter::GetInteractionID();
+
+		g_interactionStasisGrenadeFreeze = CBaseCombatCharacter::GetInteractionID();
 	}
 
 	VerifyXenRecipeManager( GetClassname() );
@@ -2718,7 +2734,7 @@ void CGrenadeHopwire::Detonate( void )
 #endif
 
 	// Explode at the apex
-	SetThink( &CGrenadeHopwire::CombatThink );
+	SetThink( &CGrenadeStasis::CombatThink );
 	SetNextThink( gpGlobals->curtime + apexTime);
 }
 
@@ -2734,7 +2750,7 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 	if (modelOpen == NULL)
 		modelOpen = szHopwireModel;
 
-	CGrenadeHopwire *pGrenade = (CGrenadeHopwire *) CBaseEntity::CreateNoSpawn( "npc_grenade_stasis", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
+	CGrenadeStasis *pGrenade = (CGrenadeStasis *) CBaseEntity::CreateNoSpawn( "npc_grenade_stasis", position, angles, pOwner ); // Don't spawn the hopwire until models are set!
 	pGrenade->SetWorldModelClosed(modelClosed);
 	pGrenade->SetWorldModelOpen(modelOpen);
 
@@ -2761,7 +2777,7 @@ void CStasisVortexController::PullThink( void )
 	float flStrength = m_flStrength;
 
 	// Pull any players close enough to us
-	PullPlayersInRange();
+	FreezePlayersInRange();
 
 	// Draw debug information
 	if (g_debug_hopwire.GetInt() >= 2)
@@ -2808,86 +2824,56 @@ void CStasisVortexController::PullThink( void )
 		if (!engine->CheckOriginInPVS( vecEntCenter, m_PVS, sizeof( m_PVS ) ))
 			continue;
 
-		Vector	vecForce = GetAbsOrigin() - vecEntCenter;
-		Vector	vecForce2D = vecForce;
-		vecForce2D[2] = 0.0f;
-		float	dist2D = VectorNormalize( vecForce2D );
-		float	dist = VectorNormalize( vecForce );
-
-		// First, pull npcs outside of the ragdoll radius towards the vortex
-		if (abs( dist ) > hopwire_ragdoll_radius.GetFloat())
+		// Dispatch interaction. Skip freezing if it returns true
+		if (pEnts[i]->DispatchInteraction( g_interactionStasisGrenadeFreeze, NULL, GetThrower() ))
 		{
-			CAI_BaseNPC * pNPC = pEnts[i]->MyNPCPointer();
-			if (pEnts[i]->IsNPC() && pNPC != NULL && pNPC->CanBecomeRagdoll())
-			{
-				// Find the pull force
-				// Minimum pull force is 10% of strength here
-				vecForce *= MAX( 1.0f - (abs( dist2D ) / m_flRadius), 0.1f ) * flStrength;
-
-				// Physics damage info
-				CTakeDamageInfo info( this, this, vecForce, GetAbsOrigin(), flStrength, DMG_BLAST );
-
-				// Dispatch interaction. Skip pulling if it returns true
-				if (pEnts[i]->DispatchInteraction( g_interactionXenGrenadePull, &info, GetThrower() ))
-				{
-					continue;
-				}
-
-				// Pull
-				pNPC->ApplyAbsVelocityImpulse( vecForce );
-
-				// We already handled this NPC, move on
-				continue;
-			}
+			continue;
 		}
-		if (KillNPCInRange( pEnts[i], &pPhysObject ))
+
+		// Freeze NPCs by stopping their think function
+		if (pEnts[i]->MyCombatCharacterPointer())
 		{
-			DevMsg( "Xen grenade turned NPC '%s' into a ragdoll! \n", pEnts[i]->GetDebugName() );
-		}
-		else
-		{
-			// If we didn't have a valid victim, see if we can just get the vphysics object
-			pPhysObject = pEnts[i]->VPhysicsGetObject();
-			if (pPhysObject == NULL)
+			// If this NPC has already been frozen, don't refreeze
+			if (pEnts[i]->GetNextThink() == TICK_NEVER_THINK)
 			{
 				continue;
 			}
-		}
 
-		float mass = 0.0f;
-
-		CRagdollProp * pRagdoll = dynamic_cast< CRagdollProp* >(pEnts[i]);
-		ragdoll_t * pRagdollPhys = NULL;
-		if (pRagdoll != NULL)
-		{
-			pRagdollPhys = pRagdoll->GetRagdoll();
-		}
-
-		if (pRagdollPhys != NULL)
-		{
-			// Find the aggregate mass of the whole ragdoll
-			for (int j = 0; j < pRagdollPhys->listCount; ++j)
-			{
-				mass += pRagdollPhys->list[j].pObject->GetMass();
+			if (pEnts[i]->MyNPCPointer())
+			{			
+				pEnts[i]->MyNPCPointer()->SetCondition( COND_NPC_FREEZE );
+				pEnts[i]->MyNPCPointer()->TaskInterrupt();
 			}
+
+			pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezeNPCThink, m_flEndTime, "StasisGrenadeUnfreeze" );
+
+			// Don't cancel the think function until the NPC picks up SCHED_NPC_FREEZE
+			if (pEnts[i]->MyNPCPointer() && !(pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE)))
+				continue;
+
+			pEnts[i]->SetNextThink( TICK_NEVER_THINK );
+			DevMsg( "NPC '%s' caught in stasis field! Thinking stopped\n", pEnts[i]->GetDebugName() );
+
+			continue;
 		}
-		else if (pPhysObject != NULL)
+
+		// If this is not an NPC, get the physics object
+		pPhysObject = pEnts[i]->VPhysicsGetObject();
+		if (pPhysObject == NULL)
 		{
-			mass = pPhysObject->GetMass();
+			continue;
 		}
 
+		if (!pPhysObject->IsMotionEnabled())
+			continue;
 
-		// Find the pull force
-		// Minimum pull force is 10% of strength here
-		vecForce *= MAX( 1.0f - (abs( dist2D ) / m_flRadius), 0.1f ) * flStrength * mass;
+		// TODO - we should consider separating contexts for gravity and motion so that they can be toggled independently
+		if (!pPhysObject->IsGravityEnabled())
+			continue;
 
-
-		CTakeDamageInfo info( this, this, vecForce, GetAbsOrigin(), flStrength, DMG_BLAST );
-		if (!pEnts[i]->DispatchInteraction( g_interactionXenGrenadePull, &info, GetThrower() ) && pPhysObject != NULL)
-		{
-			// Pull the object in if there was no special handling
-			pEnts[i]->VPhysicsTakeDamage( info );
-		}
+		pPhysObject->EnableMotion(false);
+		pPhysObject->EnableGravity( false );
+		pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezePhysicsObjectThink, m_flEndTime, "StasisGrenadeUnfreeze" );
 	}
 
 	// Keep going if need-be
@@ -2924,6 +2910,38 @@ void CStasisVortexController::PullThink( void )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Think function to unfreeze an efntity
+//-----------------------------------------------------------------------------
+void CStasisVortexController::UnfreezeNPCThink( void )
+{
+	if (MyNPCPointer() == NULL)
+		return;
+
+	MyNPCPointer()->TaskInterrupt();
+	MyNPCPointer()->ClearCondition( COND_NPC_FREEZE );
+	MyNPCPointer()->SetCondition( COND_NPC_UNFREEZE );
+	MyNPCPointer()->Think();
+	SetNextThink( gpGlobals->curtime );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Think function to unfreeze an efntity
+//-----------------------------------------------------------------------------
+void CStasisVortexController::UnfreezePhysicsObjectThink( void )
+{
+	IPhysicsObject *pPhysObject = VPhysicsGetObject();
+	if (pPhysObject == NULL)
+	{
+		return;
+	}
+
+	pPhysObject->EnableMotion( true );
+	pPhysObject->EnableGravity( true );
+	pPhysObject->Wake();
+	SetContextThink( NULL, TICK_NEVER_THINK, "StasisGrenadeUnfreeze" );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Starts the vortex working
 //-----------------------------------------------------------------------------
 void CStasisVortexController::StartPull( const Vector &origin, float radius, float strength, float duration )
@@ -2943,6 +2961,69 @@ void CStasisVortexController::StartPull( const Vector &origin, float radius, flo
 
 	SetThink( &CStasisVortexController::PullThink );
 	SetNextThink( gpGlobals->curtime + 0.1f );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Causes players within the radius to be frozen
+//-----------------------------------------------------------------------------
+void CStasisVortexController::FreezePlayersInRange( void )
+{
+	CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+	if (!pPlayer || !pPlayer->VPhysicsGetObject())
+		return;
+
+	Vector	vecForce = GetAbsOrigin() - pPlayer->WorldSpaceCenter();
+	float	dist = VectorNormalize( vecForce );
+
+	// FIXME: Need a more deterministic method here
+	if (dist < 128.0f)
+	{
+		// Kill the player (with falling death sound and effects)
+		CTakeDamageInfo deathInfo( this, this, GetAbsOrigin(), GetAbsOrigin(), 5, DMG_FALL );
+
+		pPlayer->TakeDamage( deathInfo );
+
+		if (pPlayer->IsAlive() == false)
+		{
+			color32 blue ={ 0, 150, 252, 255 };
+			UTIL_ScreenFade( pPlayer, blue, 0.1f, 0.0f, (FFADE_OUT|FFADE_STAYOUT) );
+			return;
+		}
+	}
+
+	// Must be within the radius
+	if (dist > m_flRadius)
+		return;
+
+	// Don't pull unless convar set
+	if (!hopwire_pull_player.GetBool())
+		return;
+
+	// Don't pull noclipping players
+	if (pPlayer->GetMoveType() == MOVETYPE_NOCLIP)
+		return;
+
+	float mass = pPlayer->VPhysicsGetObject()->GetMass();
+	float playerForce = m_flStrength * 0.05f;
+
+	if (m_flPullFadeTime > 0.0f)
+	{
+		playerForce *= ((gpGlobals->curtime - m_flStartTime) / m_flPullFadeTime);
+	}
+
+	// Find the pull force
+	// NOTE: We might want to make this non-linear to give more of a "grace distance"
+	vecForce *= (1.0f - (dist / m_flRadius)) * playerForce * mass;
+	vecForce[2] *= 0.025f;
+
+	pPlayer->SetBaseVelocity( vecForce );
+	pPlayer->AddFlag( FL_BASEVELOCITY );
+
+	// Make sure the player moves
+	if (vecForce.z > 0 && (pPlayer->GetFlags() & FL_ONGROUND))
+	{
+		pPlayer->SetGroundEntity( NULL );
+	}
 }
 
 

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -152,6 +152,49 @@ public:
 #endif
 };
 
+#ifdef EZ2
+class CStasisVortexController : public CGravityVortexController
+{
+	DECLARE_CLASS( CStasisVortexController, CGravityVortexController );
+	DECLARE_DATADESC();
+
+public:
+
+	CStasisVortexController( void ) : m_flEndTime( 0.0f ), m_flRadius( 256 ), m_flStrength( 256 ) {}
+
+	static CStasisVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
+
+	void	SetThrower( CBaseCombatCharacter *pBCC ) { m_hThrower.Set( pBCC ); }
+	CBaseCombatCharacter *GetThrower() { return m_hThrower.Get(); }
+
+	bool	CanConsumeEntity( CBaseEntity *pEnt );
+
+	void	InputDetonate( inputdata_t &inputdata ) { StartPull( GetAbsOrigin(), m_flRadius, m_flStrength, m_flEndTime ); }
+
+private:
+	void	PullPlayersInRange( void );
+	bool	KillNPCInRange( CBaseEntity *pVictim, IPhysicsObject **pPhysObj );
+
+	void	PullThink( void );
+	void	StartPull( const Vector &origin, float radius, float strength, float duration );
+
+	float	m_flEndTime;	// Time when the vortex will stop functioning
+	float	m_flRadius;		// Area of effect for the vortex
+	float	m_flStrength;	// Pulling strength of the vortex
+
+	float	m_flStartTime;		// When the vortex opened
+	float	m_flPullFadeTime;	// How long the pull fade should last
+
+	CHandle<CBaseCombatCharacter>	m_hThrower;
+
+	// PVS for PullThink()
+	byte		m_PVS[MAX_MAP_CLUSTERS/8];
+	bool		m_bPVSCreated;
+
+	COutputEvent		m_OnPullFinished;
+};
+#endif
+
 class CGrenadeHopwire : public CBaseGrenade
 {
 	DECLARE_CLASS( CGrenadeHopwire, CBaseGrenade );
@@ -174,10 +217,14 @@ public:
 	void	CreateEffects( void );
 
 	void	InputSetTimer( inputdata_t &inputdata );
-#endif
-	
+
+	virtual void	EndThink( void );		// Last think before going away
+	virtual void	CombatThink( void );	// Makes the main explosion go off
+
+#else	
 	void	EndThink( void );		// Last think before going away
 	void	CombatThink( void );	// Makes the main explosion go off
+#endif
 
 	void SetWorldModelClosed(const char * modelName) { Q_strncpy(szWorldModelClosed, modelName, MAX_WEAPON_STRING); }
 	void SetWorldModelOpen(const char * modelName) { Q_strncpy(szWorldModelOpen, modelName, MAX_WEAPON_STRING); }
@@ -202,6 +249,22 @@ CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, cons
 
 #ifdef EZ2
 void VerifyXenRecipeManager( const char *pszActivator );
+
+
+
+
+class CGrenadeStasis : public CGrenadeHopwire
+{
+	DECLARE_CLASS( CGrenadeStasis, CGrenadeHopwire );
+	DECLARE_DATADESC();
+
+public:
+	virtual void	EndThink( void );		// Last think before going away
+	virtual void	CombatThink( void );	// Makes the main explosion go off
+
+};
+
+
 #endif
 
 #endif // GRENADE_HOPWIRE_H

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -159,10 +159,9 @@ class CStasisVortexController : public CGravityVortexController
 	DECLARE_DATADESC();
 
 public:
-
 	CStasisVortexController( void ) : m_flEndTime( 0.0f ), m_flRadius( 256 ), m_flStrength( 256 ) {}
 
-	// static CStasisVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
+	static CStasisVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
 
 	void	SetThrower( CBaseCombatCharacter *pBCC ) { m_hThrower.Set( pBCC ); }
 	CBaseCombatCharacter *GetThrower() { return m_hThrower.Get(); }
@@ -250,6 +249,8 @@ protected:
 CBaseGrenade *HopWire_Create( const Vector &position, const QAngle &angles, const Vector &velocity, const AngularImpulse &angVelocity, CBaseEntity *pOwner, float timer, const char * modelClosed = NULL, const char * modelOpen = NULL );
 
 #ifdef EZ2
+CBaseGrenade *StasisGrenade_Create( const Vector &position, const QAngle &angles, const Vector &velocity, const AngularImpulse &angVelocity, CBaseEntity *pOwner, float timer, const char * modelClosed = NULL, const char * modelOpen = NULL );
+
 void VerifyXenRecipeManager( const char *pszActivator );
 
 

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -162,21 +162,23 @@ public:
 
 	CStasisVortexController( void ) : m_flEndTime( 0.0f ), m_flRadius( 256 ), m_flStrength( 256 ) {}
 
-	static CStasisVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
+	// static CStasisVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
 
 	void	SetThrower( CBaseCombatCharacter *pBCC ) { m_hThrower.Set( pBCC ); }
 	CBaseCombatCharacter *GetThrower() { return m_hThrower.Get(); }
 
-	bool	CanConsumeEntity( CBaseEntity *pEnt );
+	//bool	CanConsumeEntity( CBaseEntity *pEnt );
 
 	void	InputDetonate( inputdata_t &inputdata ) { StartPull( GetAbsOrigin(), m_flRadius, m_flStrength, m_flEndTime ); }
 
-private:
-	void	PullPlayersInRange( void );
-	bool	KillNPCInRange( CBaseEntity *pVictim, IPhysicsObject **pPhysObj );
-
 	void	PullThink( void );
 	void	StartPull( const Vector &origin, float radius, float strength, float duration );
+
+private:
+	void	FreezePlayersInRange( void );
+	//bool	KillNPCInRange( CBaseEntity *pVictim, IPhysicsObject **pPhysObj );
+	void    UnfreezeNPCThink( void );
+	void	UnfreezePhysicsObjectThink( void );
 
 	float	m_flEndTime;	// Time when the vortex will stop functioning
 	float	m_flRadius;		// Area of effect for the vortex

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -16,6 +16,11 @@
 extern ConVar hopwire_trap;
 
 #ifdef EZ2
+enum HopwireStyle {
+	HOPWIRE_XEN = 0,
+	HOPWIRE_STASIS
+};
+
 // Base class for both the Xen grenade and displacer pistol
 class CDisplacerSink
 {
@@ -61,6 +66,8 @@ public:
 
 #ifdef EZ2
 	static CGravityVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
+
+	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_XEN; }
 
 	int AddNodesToHullMap( const Vector vecSearchOrigin );
 
@@ -110,6 +117,10 @@ private:
 	void	PullThink( void );
 	void	StartPull( const Vector &origin, float radius, float strength, float duration );
 
+#ifdef EZ2
+protected:
+#endif
+
 	float	m_flMass;		// Mass consumed by the vortex
 	float	m_flEndTime;	// Time when the vortex will stop functioning
 	float	m_flRadius;		// Area of effect for the vortex
@@ -127,6 +138,9 @@ private:
 
 							// If this points to an entity, the Xen grenade will always call g_interactionXenGrenadeRelease on it instead of spawning Xen life.
 							// This is so Will-E pops back out of Xen grenades.
+
+private:
+
 	EHANDLE	m_hReleaseEntity;
 
 	CHandle<CBaseCombatCharacter>	m_hThrower;
@@ -136,6 +150,7 @@ private:
 	CUtlMap<string_t, float, short> m_ClassMass;
 	CUtlMap<Vector, int, short> m_HullMap;
 
+protected:
 	// PVS for PullThink()
 	byte		m_PVS[ MAX_MAP_CLUSTERS/8 ];
 	bool		m_bPVSCreated;
@@ -159,40 +174,17 @@ class CStasisVortexController : public CGravityVortexController
 	DECLARE_DATADESC();
 
 public:
-	CStasisVortexController( void ) : m_flEndTime( 0.0f ), m_flRadius( 256 ), m_flStrength( 256 ) {}
-
 	static CStasisVortexController *Create( const Vector &origin, float radius, float strength, float duration, CBaseEntity *pGrenade = NULL );
 
-	void	SetThrower( CBaseCombatCharacter *pBCC ) { m_hThrower.Set( pBCC ); }
-	CBaseCombatCharacter *GetThrower() { return m_hThrower.Get(); }
-
-	//bool	CanConsumeEntity( CBaseEntity *pEnt );
-
-	void	InputDetonate( inputdata_t &inputdata ) { StartPull( GetAbsOrigin(), m_flRadius, m_flStrength, m_flEndTime ); }
+	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_STASIS; }
 
 	void	PullThink( void );
 	void	StartPull( const Vector &origin, float radius, float strength, float duration );
 
 private:
 	void	FreezePlayersInRange( void );
-	//bool	KillNPCInRange( CBaseEntity *pVictim, IPhysicsObject **pPhysObj );
 	void    UnfreezeNPCThink( void );
 	void	UnfreezePhysicsObjectThink( void );
-
-	float	m_flEndTime;	// Time when the vortex will stop functioning
-	float	m_flRadius;		// Area of effect for the vortex
-	float	m_flStrength;	// Pulling strength of the vortex
-
-	float	m_flStartTime;		// When the vortex opened
-	float	m_flPullFadeTime;	// How long the pull fade should last
-
-	CHandle<CBaseCombatCharacter>	m_hThrower;
-
-	// PVS for PullThink()
-	byte		m_PVS[MAX_MAP_CLUSTERS/8];
-	bool		m_bPVSCreated;
-
-	COutputEvent		m_OnPullFinished;
 };
 #endif
 
@@ -211,6 +203,8 @@ public:
 	void	Detonate( void );
 
 #ifdef EZ2
+	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_XEN; }
+
 	void	DelayThink();
 	void	SpriteOff();
 	void	BlipSound() { EmitSound( "WeaponXenGrenade.Blip" ); }
@@ -262,6 +256,8 @@ class CGrenadeStasis : public CGrenadeHopwire
 	DECLARE_DATADESC();
 
 public:
+	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_STASIS; }
+
 	virtual void	EndThink( void );		// Last think before going away
 	virtual void	CombatThink( void );	// Makes the main explosion go off
 

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -31,12 +31,6 @@
 
 #define GRENADE_RADIUS	4.0f	// inches
 
-
-enum HopwireStyle {
-	HOPWIRE_XEN = 0,
-	HOPWIRE_STASIS
-};
-
 //-----------------------------------------------------------------------------
 // Fragmentation grenades
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -468,7 +468,7 @@ void CWeaponHopwire::ThrowGrenade( CBasePlayer *pPlayer )
 	Vector vecThrow;
 	pPlayer->GetVelocity( &vecThrow, NULL );
 	vecThrow += vForward * 1200;
-	m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse(600,random->RandomInt(-1200,1200),0), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel()));
+	m_hActiveHopWire = static_cast<CGrenadeStasis *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse(600,random->RandomInt(-1200,1200),0), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel()));
 
 	m_bRedraw = true;
 

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -31,6 +31,12 @@
 
 #define GRENADE_RADIUS	4.0f	// inches
 
+
+enum HopwireStyle {
+	HOPWIRE_XEN = 0,
+	HOPWIRE_STASIS
+};
+
 //-----------------------------------------------------------------------------
 // Fragmentation grenades
 //-----------------------------------------------------------------------------
@@ -58,6 +64,9 @@ public:
 	bool	Reload( void );
 
 	bool	ShouldDisplayHUDHint() { return true; }
+
+
+	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_XEN; }
 
 protected:
 	virtual void	ThrowGrenade( CBasePlayer *pPlayer );
@@ -99,6 +108,23 @@ IMPLEMENT_SERVERCLASS_ST(CWeaponHopwire, DT_WeaponHopwire)
 END_SEND_TABLE()
 
 LINK_ENTITY_TO_CLASS( weapon_hopwire, CWeaponHopwire );
+
+#ifdef EZ2
+class CWeaponStasisGrenade : public CWeaponHopwire
+{
+	DECLARE_CLASS( CWeaponHopwire, CWeaponHopwire );
+public:
+
+	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_STASIS; }
+
+	DECLARE_SERVERCLASS();
+};
+
+IMPLEMENT_SERVERCLASS_ST( CWeaponStasisGrenade, DT_WeaponStasisGrenade )
+END_SEND_TABLE()
+
+LINK_ENTITY_TO_CLASS( weapon_stasis_grenade, CWeaponStasisGrenade );
+#endif
 
 // In E:Z2, the hopwire's Xen spawning feature precaches a massive number of assets which shouldn't be used on levels which don't have Xen grenades.
 // As a result, the hopwire is precached in the same way as any other entity. (i.e. not precached at all times like other weapons are)
@@ -468,7 +494,21 @@ void CWeaponHopwire::ThrowGrenade( CBasePlayer *pPlayer )
 	Vector vecThrow;
 	pPlayer->GetVelocity( &vecThrow, NULL );
 	vecThrow += vForward * 1200;
-	m_hActiveHopWire = static_cast<CGrenadeStasis *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse(600,random->RandomInt(-1200,1200),0), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel()));
+
+#ifndef EZ2
+	m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse(600,random->RandomInt(-1200,1200),0), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel()));
+#else
+	switch (GetHopwireStyle())
+	{
+	case HOPWIRE_STASIS:
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		break;
+	default:
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		break;
+
+	}
+#endif
 
 	m_bRedraw = true;
 
@@ -501,7 +541,21 @@ void CWeaponHopwire::LobGrenade( CBasePlayer *pPlayer )
 	Vector vecThrow;
 	pPlayer->GetVelocity( &vecThrow, NULL );
 	vecThrow += vForward * 350 + Vector( 0, 0, 50 );
-	m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse(200,random->RandomInt(-600,600),0), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel()));
+#ifndef EZ2
+	m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+#else
+	switch (GetHopwireStyle())
+	{
+	case HOPWIRE_STASIS:
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		break;
+	default:
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		break;
+
+	}
+#endif
+
 
 	WeaponSound( WPN_DOUBLE );
 

--- a/sp/src/game/shared/hl2/hl2_gamerules.cpp
+++ b/sp/src/game/shared/hl2/hl2_gamerules.cpp
@@ -397,6 +397,8 @@ ConVar	sk_npc_dmg_gunship_to_plr	( "sk_npc_dmg_gunship_to_plr", "0", FCVAR_REPLI
 
 #ifdef EZ2
 ConVar	sv_player_death_time( "sv_player_death_time", "1.0", FCVAR_REPLICATED );
+
+ConVar	sk_max_stasis_grenade		( "sk_max_stasis_grenade", "5", FCVAR_REPLICATED );
 #endif
 
 #ifdef CSS_WEAPONS_IN_HL2
@@ -2824,6 +2826,7 @@ CAmmoDef *GetAmmoDef()
 #ifdef EZ2
 		// Entropy Zero 2
 		def.AddAmmoType("XenGrenade", DMG_BLAST, TRACER_NONE, "sk_plr_dmg_grenade", "sk_npc_dmg_grenade", "sk_max_hopwire", 0, 0); // this is the xen grenade
+		def.AddAmmoType("StasisGrenade", DMG_BLAST, TRACER_NONE, "sk_plr_dmg_grenade", "sk_npc_dmg_grenade", "sk_max_stasis_grenade", 0, 0);
 
 		// Entropy Zero 2
 		def.AddAmmoType("GaussPistol", DMG_BULLET, TRACER_LINE_AND_WHIZ, "sk_plr_dmg_gauss_pistol", "sk_npc_dmg_gauss_pistol", "sk_max_gauss_pistol", BULLET_IMPULSE(200, 1225), 0);
@@ -2901,6 +2904,7 @@ CAmmoDef *GetAmmoDef()
 		def.AddAmmoType("556mm",			DMG_BULLET,					TRACER_LINE_AND_WHIZ,	"sk_plr_dmg_556mm",		"sk_npc_dmg_556mm",		"sk_max_556mm",		BULLET_IMPULSE(200, 1225), 0 );
 		def.AddAmmoType("762mm",			DMG_BULLET,					TRACER_LINE_AND_WHIZ,	"sk_plr_dmg_762mm",		"sk_npc_dmg_762mm",		"sk_max_762mm",		BULLET_IMPULSE(200, 1225), 0 );
 #endif
+
 	}
 
 	return &def;


### PR DESCRIPTION
This PR will add a new weapon for stasis grenades. Stasis grenades work like the Xen grenades but hold props and NPCs in a stasis field.

Not included in this PR:
- Unique effects for stasis grenades (Right now they use the same visual effects as Xen grenades)
- Particles to show the boundaries of stasis fields
- Separate ConVars to control the behavior of stasis fields
These should be added in future PRs