### PR TITLE
Fix stasis grenade not compiling on Linux

### DIFF
--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -3033,7 +3033,8 @@ void CStasisVortexController::UnfreezePhysicsObjectThink( void )
 
 	if (pRagdoll)
 	{
-		pRagdoll->InputEnableMotion( inputdata_t() );
+		inputdata_t dummy;
+		pRagdoll->InputEnableMotion( dummy );
 		return;
 	}
 


### PR DESCRIPTION
Fixes ```error: cannot bind non-const lvalue reference of type ‘inputdata_t&’ to an rvalue of type ‘inputdata_t’```