### PR TITLE
E:Z2 savegame metadata

### DIFF
--- a/sp/src/game/server/ez2/ez2_save_metadata.cpp
+++ b/sp/src/game/server/ez2/ez2_save_metadata.cpp
@@ -1,0 +1,101 @@
+//=============================================================================//
+//
+// Purpose: Creates custom metadata for each save file
+//
+//=============================================================================//
+
+#include "cbase.h"
+#include "tier3/tier3.h"
+#include "vgui/ILocalize.h"
+#include "npc_wilson.h"
+
+//=============================================================================
+//=============================================================================
+class CCustomSaveMetadata : public CAutoGameSystem
+{
+public:
+
+	void OnSave()
+	{
+		char const *pchSaveFile = engine->GetSaveFileName();
+		if (!pchSaveFile || !pchSaveFile[0])
+		{
+			Msg( "NO SAVE FILE\n" );
+			return;
+		}
+
+		char name[MAX_PATH];
+		Q_strncpy( name, pchSaveFile, sizeof( name ) );
+		Q_strlower( name );
+		Q_SetExtension( name, ".txt", sizeof( name ) );
+		Q_FixSlashes( name );
+
+		if (filesystem->FileExists( name, "MOD" ))
+		{
+			const char *pszFileName = V_GetFileName( pchSaveFile );
+			bool bAutoOrQuickSave = (V_stricmp( pszFileName, "autosave.sav" ) == 0 || V_stricmp( pszFileName, "quick.sav" ) == 0);
+
+			// autosave.txt -> autosave01.txt
+			// quick.txt -> quick01.txt
+			// (TODO: Account for save_history_count)
+			if (bAutoOrQuickSave)
+			{
+				char name2[MAX_PATH];
+				Q_StripExtension( pchSaveFile, name2, sizeof( name2 ) );
+				Q_strlower( name2 );
+				Q_FixSlashes( name );
+
+				Q_strncat( name2, "01.txt", sizeof( name2 ) );
+
+				if ( filesystem->FileExists( name2, "MOD" ) )
+					filesystem->RemoveFile( name2, "MOD" );
+
+				filesystem->RenameFile( name, name2, "MOD" );
+			}
+		}
+
+		KeyValues *pCustomSaveMetadata = new KeyValues( "CustomSaveMetadata" );
+		if (pCustomSaveMetadata)
+		{
+			// E:Z2 Version
+			pCustomSaveMetadata->SetString( "ez2_version", g_pVGuiLocalize->FindAsUTF8( "#EZ2_Version_Stamp" ) );
+
+			// Map Version
+			pCustomSaveMetadata->SetInt( "mapversion", gpGlobals->mapversion );
+
+			// UNDONE: Host Name
+			//{
+			//	char szHostName[128];
+			//	gethostname( szHostName, sizeof( szHostName ) );
+			//	pCustomSaveMetadata->SetString( "hostname", szHostName );
+			//}
+
+			// OS Platform
+			{
+#ifdef _WIN32
+				pCustomSaveMetadata->SetString( "platform", "windows" );
+#elif defined(LINUX)
+				pCustomSaveMetadata->SetString( "platform", "linux" );
+#endif
+			}
+
+			// Steam Deck
+			{
+				const char *pszSteamDeckEnv = getenv( "SteamDeck" );
+				pCustomSaveMetadata->SetBool( "is_deck", (pszSteamDeckEnv && *pszSteamDeckEnv) ); // g_pSteamInput->IsSteamRunningOnSteamDeck()
+			}
+
+			// Wilson
+			if (CNPC_Wilson *pWilson = CNPC_Wilson::GetWilson())
+			{
+				pCustomSaveMetadata->SetBool("wilson", true );
+			}
+
+			Msg( "Saving custom metadata to %s\n", name );
+
+			pCustomSaveMetadata->SaveToFile( filesystem, name, "MOD" );
+		}
+		pCustomSaveMetadata->deleteThis();
+	}
+
+} g_CustomSaveMetadata;

--- a/sp/src/game/server/server_ez2.vpc
+++ b/sp/src/game/server/server_ez2.vpc
@@ -46,6 +46,7 @@ $Project "Server (Entropy Zero 2)"
 			$File	"ez2\ai_sensorydummy.h"
 			$File	"ez2\ez2_player.h"
 			$File	"ez2\ez2_player.cpp"
+			$File	"ez2\ez2_save_metadata.cpp"
 			$File	"ez2\npc_clonecop.h" [!$EZ2_DEMO]
 			$File	"ez2\npc_clonecop.cpp" [!$EZ2_DEMO]
 			$File	"ez2\npc_baseflora.h"


### PR DESCRIPTION
Causes each save game to be accompanied by a unique `.txt` file containing E:Z2-specific metadata. This is intended to be used with Gamepad UI for save game versioning, and other potential future features.

Currently, this only keeps track of 5 variables from the saved game:

* The current version of E:Z2 (pulled directly from localization string)
* The internal version of the map
* The user's operating system (Windows or Linux)
* Whether or not the user is using a Steam Deck
* Whether or not Wilson exists in the level