### PR TITLE
Wilson eye phonemes proxy

### DIFF
--- a/sp/src/game/client/c_baseflex.h
+++ b/sp/src/game/client/c_baseflex.h
@@ -273,7 +273,9 @@ protected:
 
 	Emphasized_Phoneme m_PhonemeClasses[ NUM_PHONEME_CLASSES ];
 
+#ifndef EZ2 // Wilson phoneme test
 private:
+#endif
 
 	C_BaseFlex( const C_BaseFlex & ); // not defined, not accessible
 
@@ -281,6 +283,9 @@ private:
 
 	void			ProcessVisemes( Emphasized_Phoneme *classes );
 	void			AddVisemesForSentence( Emphasized_Phoneme *classes, float emphasis_intensity, CSentence *sentence, float t, float dt, bool juststarted );
+#ifdef EZ2 // Wilson phoneme test
+	virtual
+#endif
 	void			AddViseme( Emphasized_Phoneme *classes, float emphasis_intensity, int phoneme, float scale, bool newexpression );
 	bool			SetupEmphasisBlend( Emphasized_Phoneme *classes, int phoneme );
 	void			ComputeBlendedSetting( Emphasized_Phoneme *classes, float emphasis_intensity );

--- a/sp/src/game/client/ez2/c_npc_wilson.cpp
+++ b/sp/src/game/client/ez2/c_npc_wilson.cpp
@@ -33,7 +33,6 @@ C_AI_TurretBase::~C_AI_TurretBase()
 	{
 		for (int i = 0; i < 4; i++)
 		{
-			DevMsg("Removing rope %i\n", i);
 			if (m_pRopes[i])
 				m_pRopes[i]->Remove();
 			m_pRopes[i] = NULL;
@@ -60,7 +59,6 @@ void C_AI_TurretBase::ClientThink( void )
 
 			for (int i = 0; i < 4; i++)
 			{
-				DevMsg("Creating rope %i\n", i);
 				m_pRopes[i] = CreateRope( m_iRopeStartAttachments[i], m_iRopeEndAttachments[i] );
 			}
 		}
@@ -69,7 +67,6 @@ void C_AI_TurretBase::ClientThink( void )
 	{
 		for (int i = 0; i < 4; i++)
 		{
-			DevMsg("Removing rope %i\n", i);
 			if (m_pRopes[i])
 				m_pRopes[i]->Remove();
 			m_pRopes[i] = NULL;
@@ -173,6 +170,8 @@ END_RECV_TABLE()
 
 BEGIN_PREDICTION_DATA( C_NPC_Wilson )
 END_PREDICTION_DATA()
+
+LINK_ENTITY_TO_CLASS( npc_wilson, C_NPC_Wilson )
 
 C_NPC_Wilson::C_NPC_Wilson()
 {
@@ -306,8 +305,6 @@ void C_NPC_Wilson::AddViseme( Emphasized_Phoneme *classes, float emphasis_intens
 
 			// Lerp it
 			m_flTalkGlow = FLerp( npc_wilson_talk_min.GetFloat(), npc_wilson_talk_max.GetFloat(), flPhonemes / m_flTalkGlow );
-
-			Msg( "m_flTalkGlow: %f\n", m_flTalkGlow );
 		}
 	}
 }
@@ -336,13 +333,10 @@ public:
 		C_BaseEntity *pEntity = BindArgToEntity( pC_BaseEntity );
 
 		// HACKHACK: The Wilson model may be used for dynamic props instead, so make sure it's actually him
-		if (FClassnameIs( pEntity, "class C_NPC_Wilson" ))
+		if (FClassnameIs( pEntity, "npc_wilson" ))
 		{
 			C_NPC_Wilson *pWilson = static_cast<C_NPC_Wilson*>(pEntity);
 			SetFloatResult( pWilson->m_flTalkGlow );
-
-			if (pWilson->m_flTalkGlow != 1.0f)
-				Msg( "Proxy is setting talk glow (%f)\n", pWilson->m_flTalkGlow );
 		}
 	}
 };

--- a/sp/src/game/client/ez2/c_npc_wilson.cpp
+++ b/sp/src/game/client/ez2/c_npc_wilson.cpp
@@ -323,6 +323,9 @@ public:
 		if (!CResultProxy::Init( pMaterial, pKeyValues ))
 			return false;
 
+		// Scale is optional
+		m_Scale.Init( pMaterial, pKeyValues, "scale", 1.0f );
+
 		return true;
 	}
 	virtual void OnBind( void *pC_BaseEntity )
@@ -336,9 +339,26 @@ public:
 		if (FClassnameIs( pEntity, "npc_wilson" ))
 		{
 			C_NPC_Wilson *pWilson = static_cast<C_NPC_Wilson*>(pEntity);
-			SetFloatResult( pWilson->m_flTalkGlow );
+
+			float flScale = m_Scale.GetFloat();
+			if (flScale != 1.0f)
+			{
+				// Scale distance from 1.0
+				SetFloatResult( ((pWilson->m_flTalkGlow - 1.0f) * flScale) + 1.0f );
+			}
+			else
+			{
+				SetFloatResult( pWilson->m_flTalkGlow );
+			}
+		}
+		else
+		{
+			SetFloatResult( 1.0f );
 		}
 	}
+
+private:
+	CFloatInput	m_Scale;
 };
 
 EXPOSE_INTERFACE( CWilsonEyeMaterialProxy, IMaterialProxy, "WilsonEye" IMATERIAL_PROXY_INTERFACE_VERSION );

--- a/sp/src/game/client/ez2/c_npc_wilson.h
+++ b/sp/src/game/client/ez2/c_npc_wilson.h
@@ -112,7 +112,11 @@ public:
 	void UpdateGlow( Vector &vVector, Vector &vecForward );
 	C_RopeKeyframe *CreateRope( int iStartAttach, int iEndAttach );
 
+	void AddViseme( Emphasized_Phoneme *classes, float emphasis_intensity, int phoneme, float scale, bool newexpression );
+
 	C_TurretGlowOverlay m_Glow;
+
+	float	m_flTalkGlow;
 };
 
 class C_NPC_Arbeit_FloorTurret : public C_AI_TurretBase


### PR DESCRIPTION
This was an old feature I experimented with back in August 2021. It allows Wilson's eye to light up as he speaks, similar to the cores from Portal 2. It requires each line to have "phonemes" added to them, which are normally used for lip-syncing on humanoid characters. This was unrealistic for us to use because of how many lines Wilson has and how arduous it is to add phonemes to voice lines, but I dug this back up in case anyone wants to use it in the future anyway.

It works by having this material proxy defined in the `turret_eye` VMTs:

```
		"WilsonEye"
		{
			resultVar	"$selfillumtint"
		}
```

This allows the illumination in Wilson's eye to change according to what he's saying.

Here's an old video showing it in action:

https://cdn.discordapp.com/attachments/526449481252601863/870362391110627388/2021-07-29_12-46-35.mp4

Worth mentioning this PR also removes some dev messages.