### PR TITLE
Fix antlion guard dynamic prop shoving/punting from stock HL2

### DIFF
--- a/sp/src/game/server/ai_senses.cpp
+++ b/sp/src/game/server/ai_senses.cpp
@@ -144,7 +144,11 @@ void CAI_Senses::Listen( void )
 
 bool CAI_Senses::ShouldSeeEntity( CBaseEntity *pSightEnt )
 {
+#ifdef EZ2
+	if ( pSightEnt == GetOuter() || (!(pSightEnt->GetFlags() & FL_OBJECT) && !pSightEnt->IsAlive()) )
+#else
 	if ( pSightEnt == GetOuter() || !pSightEnt->IsAlive() )
+#endif
 		return false;
 
 	if ( pSightEnt->IsPlayer() && ( pSightEnt->GetFlags() & FL_NOTARGET ) )


### PR DESCRIPTION
In Half-Life 2, antlion guards are supposed to be able to punt props at targets they can't reach. However, this works by making antlion guards "see" certain props when they spawn, and that isn't compatible with the AI sensing code, which requires sight targets to be alive.

This simply makes an exception in the AI sensing code for "objects" (i.e. things that wouldn't be alive) and hooks the dynamic punting behavior to cvars so that the min/max mass can be controlled, or the behavior can be disabled if needed. The upper-limit for mass has also been raised so that antlion guards can punt heavier props (e.g. Arbeit cars).

---

I mainly restored this to try to make antlion guards spawned via Xen grenades more effective (since the environment they were spawned in might not let them reach certain targets), although I had trouble spawning guards in locations where there were props around to punt, mainly since most nearby props were been consumed by the Xen grenades which spawned them.

Maybe I should put this in Mapbase instead 🥴