### PR TITLE
Soldier giving/backup weapon improvements and misc. fixes

### DIFF
--- a/sp/src/game/server/ez2/npc_clonecop.h
+++ b/sp/src/game/server/ez2/npc_clonecop.h
@@ -43,6 +43,9 @@ public:
 
 	void		PickupItem( CBaseEntity *pItem );
 
+	// Clone Cop/Bad Cop can pull out a 357, because they're THAT cool.
+	const char	*GetBackupWeaponClass() { return "weapon_357"; }
+
 	int			OnTakeDamage( const CTakeDamageInfo &info );
 	float		GetHitgroupDamageMultiplier( int iHitGroup, const CTakeDamageInfo &info );
 	Vector		GetShootEnemyDir( const Vector &shootOrigin, bool bNoisy = true );

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -355,7 +355,7 @@ DEFINE_KEYFIELD( m_iCanOrderSurrender, FIELD_INTEGER, "CanOrderSurrender" ),
 DEFINE_INPUTFUNC( FIELD_VOID, "EnableOrderSurrender", InputEnableOrderSurrender ),
 DEFINE_INPUTFUNC( FIELD_VOID, "DisableOrderSurrender", InputDisableOrderSurrender ),
 
-DEFINE_KEYFIELD( m_bDisablePlayerGive, FIELD_BOOLEAN, "DisablePlayerGive" ),
+DEFINE_KEYFIELD( m_iCanPlayerGive, FIELD_INTEGER, "CanPlayerGive" ),
 DEFINE_INPUTFUNC( FIELD_VOID, "EnablePlayerGive", InputEnablePlayerGive ),
 DEFINE_INPUTFUNC( FIELD_VOID, "DisablePlayerGive", InputDisablePlayerGive ),
 #endif
@@ -388,6 +388,7 @@ CNPC_Combine::CNPC_Combine()
 	m_bDontPickupWeapons = true;
 
 	m_iCanOrderSurrender = TRS_NONE;
+	m_iCanPlayerGive = TRS_NONE;
 #endif
 }
 
@@ -1502,12 +1503,12 @@ void CNPC_Combine::InputDisableOrderSurrender( inputdata_t &inputdata )
 //-----------------------------------------------------------------------------
 void CNPC_Combine::InputEnablePlayerGive( inputdata_t &inputdata )
 {
-	m_bDisablePlayerGive = false;
+	m_iCanPlayerGive = TRS_TRUE;
 }
 
 void CNPC_Combine::InputDisablePlayerGive( inputdata_t &inputdata )
 {
-	m_bDisablePlayerGive = true;
+	m_iCanPlayerGive = TRS_FALSE;
 }
 #endif
 

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -140,6 +140,8 @@ public:
 	void InputDisablePlayerUse( inputdata_t &inputdata );
 	void InputEnableOrderSurrender( inputdata_t &inputdata );
 	void InputDisableOrderSurrender( inputdata_t &inputdata );
+	void InputEnablePlayerGive( inputdata_t &inputdata );
+	void InputDisablePlayerGive( inputdata_t &inputdata );
 	COutputEHANDLE	m_OutManhack;
 
 	//-----------------------------------------------------
@@ -180,6 +182,7 @@ public:
 	void			PickupItem( CBaseEntity *pItem );
 	virtual void	Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecTarget = NULL, const Vector *pVelocity = NULL );
 	virtual void	PickupWeapon( CBaseCombatWeapon *pWeapon );
+	virtual const char *GetBackupWeaponClass();
 
 	int 			SelectSchedulePriorityAction();
 	virtual int 	SelectScheduleRetrieveItem();
@@ -189,6 +192,12 @@ public:
 	virtual bool	IsMajorCharacter() { return IsCommandable(); }
 
 	virtual bool	CanOrderSurrender();
+
+	virtual bool	ShouldAllowPlayerGive() { return IsCommandable() && !m_bDisablePlayerGive; }
+	virtual bool	IsGiveableWeapon( CBaseCombatWeapon *pWeapon ) { return true; }
+	virtual bool	IsGiveableItem( CBaseEntity *pItem );
+	virtual void	StartPlayerGive( CBasePlayer *pPlayer ) {}
+	virtual void	OnCantBeGivenObject( CBaseEntity *pItem ) {}
 
 	virtual bool	ShouldGib( const CTakeDamageInfo &info );
 	virtual bool	CorpseGib( const CTakeDamageInfo &info );
@@ -276,6 +285,7 @@ public:
 
 #ifdef EZ
 	bool			PickTacticalLookTarget( AILookTargetArgs_t *pArgs );
+	void			OnStateChange( NPC_STATE OldState, NPC_STATE NewState );
 	void			AimGun();
 #endif
 
@@ -315,6 +325,8 @@ public:
 	void			AnnounceAssault( void );
 	void			AnnounceEnemyType( CBaseEntity *pEnemy );
 	void			AnnounceEnemyKill( CBaseEntity *pEnemy );
+
+	virtual void	BashSound() { EmitSound( "NPC_Combine.WeaponBash" ); }
 
 	void			NotifyDeadFriend( CBaseEntity* pFriend );
 
@@ -365,6 +377,8 @@ protected:
 	// TRS_TRUE = Can always order surrender
 	// TRS_FALSE = Can never order surrender
 	ThreeState_t m_iCanOrderSurrender;
+
+	bool m_bDisablePlayerGive;
 #endif
 
 #ifdef EZ2

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -193,7 +193,7 @@ public:
 
 	virtual bool	CanOrderSurrender();
 
-	virtual bool	ShouldAllowPlayerGive() { return IsCommandable() && !m_bDisablePlayerGive; }
+	virtual bool	ShouldAllowPlayerGive() { return (m_iCanPlayerGive == TRS_NONE && IsCommandable()) || m_iCanPlayerGive == TRS_TRUE; }
 	virtual bool	IsGiveableWeapon( CBaseCombatWeapon *pWeapon ) { return true; }
 	virtual bool	IsGiveableItem( CBaseEntity *pItem );
 	virtual void	StartPlayerGive( CBasePlayer *pPlayer ) {}
@@ -378,7 +378,10 @@ protected:
 	// TRS_FALSE = Can never order surrender
 	ThreeState_t m_iCanOrderSurrender;
 
-	bool m_bDisablePlayerGive;
+	// TRS_NONE = Don't care, only allow give when commandable
+	// TRS_TRUE = Can always be given weapons/items
+	// TRS_FALSE = Can never be given weapons/items
+	ThreeState_t m_iCanPlayerGive;
 #endif
 
 #ifdef EZ2


### PR DESCRIPTION
This PR mainly improves and stubs out the soldier giving behavior so that it's more diverse and capable of being overridden by derived classes. It also changes the behavior of backup weapons, giving elites pulse pistols and Clone Cop/Bad Cop a 357 if they're caught without a weapon after the player tries to give them one.

Notably, this adds a new keyvalue and inputs for soldiers to toggle giving behavior. This may be useful for, say, maps with commandable soldiers who should keep their weapon, or other "soldiers" who don't want to negotiate. However, this modifies the soldiers' data description, which I thought would risk interfering with saves, but from what I can tell after testing different saves, it actually doesn't seem to affect anything. Maybe Source's save/restore is more resilient than I thought. Regardless, we have a framework for warning users about major updates when they load saves now, so players have a way of falling back if any problems arise.

This PR also includes fixes for soldiers trying to kick obstructions that are too large to kick (e.g. cars) and makes them look at their enemy more quickly after entering combat.