### PR TITLE
Bugbait makes hostile metrocops dance (and no longer makes friendly soldiers dance)

### DIFF
--- a/sp/src/game/server/hl2/grenade_bugbait.cpp
+++ b/sp/src/game/server/hl2/grenade_bugbait.cpp
@@ -231,7 +231,12 @@ bool CGrenadeBugBait::ActivateBugbaitTargets( CBaseEntity *pOwner, Vector vecOri
 			if ( UTIL_DistApprox( pList[i]->WorldSpaceCenter(), vecOrigin ) < bugbait_grenade_radius.GetFloat() )
 			{
 				// Must be a soldier
+#ifdef EZ
+				// or metrocop
+				if ( FClassnameIs( pList[i], "npc_combine_s" ) || FClassnameIs( pList[i], "npc_metropolice" ) )
+#else
 				if ( FClassnameIs( pList[i], "npc_combine_s") )
+#endif
 				{
 					CAI_BaseNPC *pCombine = pList[i]->MyNPCPointer();
 

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -1264,6 +1264,13 @@ void CNPC_Combine::InputAssault( inputdata_t &inputdata )
 //-----------------------------------------------------------------------------
 void CNPC_Combine::InputHitByBugbait( inputdata_t &inputdata )
 {
+#ifdef EZ
+	// Ignore if the activator likes us
+	if (inputdata.pActivator && inputdata.pActivator->IsCombatCharacter() &&
+		inputdata.pActivator->MyCombatCharacterPointer()->IRelationType( this ) == D_LI)
+		return;
+#endif
+
 	SetCondition( COND_COMBINE_HIT_BY_BUGBAIT );
 }
 

--- a/sp/src/game/server/hl2/npc_metropolice.h
+++ b/sp/src/game/server/hl2/npc_metropolice.h
@@ -228,6 +228,7 @@ private:
 #endif
 #ifdef EZ
 	void InputTriggerIdleQuestion( inputdata_t &inputdata );
+	void InputHitByBugbait( inputdata_t &inputdata );
 #endif
 
 	void NotifyDeadFriend ( CBaseEntity* pFriend );
@@ -411,6 +412,11 @@ private:
 		COND_METROPOLICE_PLAYER_TOO_CLOSE,
 		COND_METROPOLICE_CHANGE_BATON_STATE,
 		COND_METROPOLICE_PHYSOBJECT_ASSAULT,
+#ifdef EZ
+		COND_METROPOLICE_HIT_BY_BUGBAIT,
+
+		NEXT_CONDITION,
+#endif
 
 	};
 
@@ -454,6 +460,9 @@ private:
 		SCHED_METROPOLICE_MOVE_TO_FORCED_GREN_LOS,
 		SCHED_METROPOLICE_RANGE_ATTACK2,
 		SCHED_METROPOLICE_AR2_ALTFIRE,
+#endif
+#ifdef EZ
+		SCHED_METROPOLICE_BUGBAIT_DISTRACTION,
 #endif
 	};
 


### PR DESCRIPTION
Allows metrocops which the player doesn't like to be stunned when they're hit with bugbait in the same way soldiers get stunned. Also allows soldiers to ignore bugbait when it comes from a player which likes them.