### PR TITLE
CAI_BeastBehavior only uses hint criteria bits_HINT_NODE_REPORT_FAILURES in developer>1

### DIFF
--- a/sp/src/game/server/ez2/ai_behavior_beast.cpp
+++ b/sp/src/game/server/ez2/ai_behavior_beast.cpp
@@ -20,6 +20,8 @@
 
 ConVar ez2_beast_return_time( "ez2_beast_return_time", "20.0", FCVAR_NONE, "How much time should pass after the beast becomes alert (e.g. due to investigating a sound with no enemy in sight or losing an existing enemy) before it should be slammed to idle, allowing it to return home." );
 
+extern ConVar developer;	// developer mode
+
 //---------------------------------------------------------
 // Save/Restore
 //---------------------------------------------------------
@@ -184,7 +186,14 @@ void CAI_BeastBehavior::StartTask( const Task_t *pTask )
 		{
 			CHintCriteria hintCriteria;
 			hintCriteria.SetHintType( HINT_BEAST_HOME );
-			hintCriteria.SetFlag( bits_HINT_NODE_NEAREST | bits_HINT_NODE_REPORT_FAILURES );
+
+			int iBits = bits_HINT_NODE_NEAREST;
+			if ( developer.GetInt() > 0 )
+			{
+				iBits |= bits_HINT_NODE_REPORT_FAILURES;
+			}
+
+			hintCriteria.SetFlag( iBits );
 			hintCriteria.AddIncludePosition( GetAbsOrigin(), pTask->flTaskData );
 			CAI_Hint *pHint = CAI_HintManager::FindHint( GetOuter(), hintCriteria );
 			if (pHint)


### PR DESCRIPTION
In CAI_BeastBehavior::StartTask(), when starting a task of type ``TASK_BEAST_FIND_HOME`` it adds the criteria bits ``bits_HINT_NODE_REPORT_FAILURES``. There is only one other class that uses these hint criteria bits, CAI_ActBusyBehavior. In all cases where CAI_ActBusyBehavior, it first checks the ConVar ``ai_debug_actbusy.GetInt() == 3``.

For example:
```cpp
//-----------------------------------------------------------------------------
// Purpose: Find a general purpose, suitable Hint Node for me to Act Busy.
//-----------------------------------------------------------------------------
CAI_Hint *CAI_ActBusyBehavior::FindActBusyHintNode()
{
	Assert( !IsCombatActBusy() );

	int iBits = bits_HINT_NODE_USE_GROUP;
	if ( m_bVisibleOnly )
	{
		iBits |= bits_HINT_NODE_VISIBLE;
	}

	if ( ai_debug_actbusy.GetInt() == 3 && GetOuter()->m_debugOverlays & OVERLAY_NPC_SELECTED_BIT )
	{
		iBits |= bits_HINT_NODE_REPORT_FAILURES;
	}

#ifdef EZ2
	if ( m_bUseNearestBusy || IsBeastActBusy() )
#else
	if ( m_bUseNearestBusy )
#endif
	{
		iBits |= bits_HINT_NODE_NEAREST;
	}
	else
	{
		iBits |= bits_HINT_NODE_RANDOM;
	}

	CAI_Hint *pNode = CAI_HintManager::FindHint( GetOuter(), HINT_WORLD_WORK_POSITION, iBits, m_flBusySearchRange );

	return pNode;
}
```

With this in mind, these bits should check if developer mode is enabled.

I discovered bugs related to this while working on my map Company Values.

---

#### Does this PR close any issues?
No issue has been opened for this bug.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
