### PR TITLE
Entropy : Zero Uprising Episode 2 Health Vial Backpack

### DIFF
--- a/sp/src/game/client/client_ez2.vpc
+++ b/sp/src/game/client/client_ez2.vpc
@@ -44,6 +44,7 @@ $Project "Client (Entropy Zero 2)"
 			$File	"ez2\c_weapon_pulse_pistol.cpp"
 			$File	"ez2\zombiegooproxy.cpp"
 			$File	"ez2\hud_slamstatus.cpp"
+			$File	"ezu\hud_healthvialstatus.cpp"
 
 			$File	"workshop_publish.cpp" [!$NO_STEAM]
 		}

--- a/sp/src/game/client/ezu/hud_healthvialstatus.cpp
+++ b/sp/src/game/client/ezu/hud_healthvialstatus.cpp
@@ -1,0 +1,335 @@
+//=============================================================================//
+//
+// Purpose: A HUD element which displays active HealthVials.
+//  This is a feature for Entropy : Zero Uprising Episode 2
+//	Copied from Blixibon's SLAM status HUD element (hud_slamstatus.cpp)
+// 
+// Author: 1upD
+//
+//=============================================================================//
+
+#include "cbase.h"
+#include "hud.h"
+#include "hudelement.h"
+#include "hud_macros.h"
+#include "iclientmode.h"
+#include "c_basehlplayer.h"
+#include "vgui_controls/Panel.h"
+#include "vgui_controls/AnimationController.h"
+#include "vgui/ISurface.h"
+#include <vgui/ILocalize.h>
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Shows the sprint power bar
+//-----------------------------------------------------------------------------
+class CHudHealthVialStatus : public CHudElement, public vgui::Panel
+{
+	DECLARE_CLASS_SIMPLE( CHudHealthVialStatus, vgui::Panel );
+
+public:
+	CHudHealthVialStatus( const char *pElementName );
+	~CHudHealthVialStatus();
+	virtual void Init( void );
+	virtual void Reset( void );
+	virtual void OnThink( void );
+	bool ShouldDraw();
+
+	void MsgFunc_HealthVialConsumed( bf_read &msg );
+
+protected:
+	virtual void Paint();
+
+private:
+	CPanelAnimationVar( vgui::HFont, m_hIconFont, "IconFont", "HudNumbers" );
+	CPanelAnimationVarAliasType( float, m_flIconInsetX, "IconInsetX", "8", "proportional_float" );
+	CPanelAnimationVarAliasType( float, m_flIconInsetY, "IconInsetY", "8", "proportional_float" );
+	CPanelAnimationVarAliasType( float, m_flIconGap, "IconGap", "20", "proportional_float" );
+
+	CPanelAnimationVar( Color, m_HealthVialIconColor, "HealthVialIconColor", "255 220 0 160" );
+	CPanelAnimationVar( Color, m_LastHealthVialColor, "LastHealthVialColor", "255 220 0 0" );
+	
+	int m_iNumHealthVials;
+	bool m_bHealthVialAdded;
+	bool m_bHealthVialConsumed;
+
+	int m_iNumHealthVialsDiff;
+
+	CPanelAnimationVarAliasType( int, m_iDefaultX, "xpos_default", "r120", "proportional_int" );
+	CPanelAnimationVarAliasType( int, m_iDefaultWide, "wide_default", "104", "proportional_int" );
+};	
+
+
+DECLARE_HUDELEMENT( CHudHealthVialStatus );
+DECLARE_HUD_MESSAGE( CHudHealthVialStatus, HealthVialConsumed );
+
+using namespace vgui;
+
+//-----------------------------------------------------------------------------
+// Purpose: Constructor
+//-----------------------------------------------------------------------------
+CHudHealthVialStatus::CHudHealthVialStatus( const char *pElementName ) : CHudElement( pElementName ), BaseClass( NULL, "HudHealthVialStatus" )
+{
+	vgui::Panel *pParent = g_pClientMode->GetViewport();
+	SetParent( pParent );
+
+	SetHiddenBits( HIDEHUD_HEALTH | HIDEHUD_PLAYERDEAD | HIDEHUD_NEEDSUIT );
+}
+
+CHudHealthVialStatus::~CHudHealthVialStatus()
+{
+	/*
+	if (vgui::surface())
+	{
+		if (m_textureID_HealthVial != -1)
+		{
+			vgui::surface()->DestroyTextureID( m_textureID_HealthVial );
+			m_textureID_HealthVial = -1;
+		}
+	}
+	*/
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CHudHealthVialStatus::Init( void )
+{
+	HOOK_HUD_MESSAGE( CHudHealthVialStatus, HealthVialConsumed );
+	m_iNumHealthVials = 0;
+	m_bHealthVialConsumed = false;
+	SetAlpha( 0 );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CHudHealthVialStatus::Reset( void )
+{
+	Init();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Save CPU cycles by letting the HUD system early cull
+// costly traversal.  Called per frame, return true if thinking and 
+// painting need to occur.
+//-----------------------------------------------------------------------------
+bool CHudHealthVialStatus::ShouldDraw( void )
+{
+	bool bNeedsDraw = false;
+
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	if ( !pPlayer )
+		return false;
+
+	bNeedsDraw = ( pPlayer->GetAmmoCount("item_healthvial") > 0 ||
+					 pPlayer->GetAmmoCount("item_healthvial") != m_iNumHealthVials || 
+					m_iNumHealthVials > 0 ||
+					m_LastHealthVialColor[3] > 0 );
+		
+	return ( bNeedsDraw && CHudElement::ShouldDraw() );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: updates hud icons
+//-----------------------------------------------------------------------------
+void CHudHealthVialStatus::OnThink( void )
+{
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	if ( !pPlayer )
+		return;
+
+	int HealthVials = pPlayer->GetAmmoCount("item_healthvial");
+
+	// Only update if we've changed vars
+	if ( HealthVials == m_iNumHealthVials )
+		return;
+
+	// update status display
+	if ( HealthVials > 0 )
+	{
+		// we have HealthVials, show the display
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialStatusShow" );
+	}
+	else if (m_LastHealthVialColor[3] <= 0)
+	{
+		// no HealthVials, hide the display
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialStatusHide" );
+	}
+
+	if ( HealthVials > m_iNumHealthVials )
+	{
+		//Msg( "HealthVial status thinking (Player's: %i/%i) (Ours: %i/%i)\n",
+		//	HealthVials, tripmines,
+		//	m_iNumHealthVials, m_iNumTripmines );
+
+		// someone is added
+		// reset the last icon color and animate
+		m_LastHealthVialColor = m_HealthVialIconColor;
+		m_LastHealthVialColor[3] = 0;
+		m_bHealthVialAdded = true;
+		m_iNumHealthVialsDiff = (m_iNumHealthVials - HealthVials);
+		DevMsg( "Sequence: HealthVialAdded\n" );
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialAdded" ); 
+	}
+	else if (HealthVials < m_iNumHealthVials)
+	{
+		//Msg( "HealthVial status thinking (Player's: %i/%i) (Ours: %i/%i)\n",
+		//	HealthVials, tripmines,
+		//	m_iNumHealthVials, m_iNumTripmines );
+
+		// someone has left
+		// reset the last icon color and animate
+		m_LastHealthVialColor = m_HealthVialIconColor;
+		m_bHealthVialAdded = false;
+		m_iNumHealthVialsDiff = (m_iNumHealthVials - HealthVials);
+
+		if (m_bHealthVialConsumed)
+		{
+			DevMsg( "Sequence: HealthVialConsumed\n" );
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialConsumed" );
+
+			m_bHealthVialConsumed = false;
+		}
+		else
+		{
+			DevMsg( "Sequence: HealthVialLeft\n" );
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialLeft" ); 
+		}
+	}
+	else
+	{
+		m_iNumHealthVialsDiff = 0;
+	}
+
+	m_iNumHealthVials = HealthVials;
+
+	if (m_bHealthVialAdded || m_LastHealthVialColor[3] <= 0)
+	{
+		// Expand the menu
+		switch (m_iNumHealthVials)
+		{
+			case 0:
+			case 1:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeOne" );
+				break;
+
+			case 2:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeTwo" );
+				break;
+
+			case 3:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeThree" );
+				break;
+
+			case 4:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeFour" );
+				break;
+
+			case 5:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeFive" );
+				break;
+
+			case 6:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeSix" );
+				break;
+
+			case 7:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeSeven" );
+				break;
+
+			default:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeMax" );
+			case 8:
+				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "HealthVialElementSizeEight" );
+				break;
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Notification of squad member being killed
+//-----------------------------------------------------------------------------
+void CHudHealthVialStatus::MsgFunc_HealthVialConsumed( bf_read &msg )
+{
+	//Msg( "HealthVial exploded\n" );
+	m_bHealthVialConsumed = true;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: draws the power bar
+//-----------------------------------------------------------------------------
+void CHudHealthVialStatus::Paint()
+{
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	if ( !pPlayer )
+		return;
+
+	/*
+	if ( m_textureID_HealthVial == -1 )
+	{
+		m_textureID_HealthVial = vgui::surface()->CreateNewTextureID();
+		vgui::surface()->DrawSetTextureFile( m_textureID_HealthVial, "vgui/icons/HealthVial_HealthVial", true, false );
+	}
+
+	if ( m_textureID_Tripmine == -1 )
+	{
+		m_textureID_Tripmine = vgui::surface()->CreateNewTextureID();
+		vgui::surface()->DrawSetTextureFile( m_textureID_Tripmine, "vgui/icons/HealthVial_tripmine", true, false );
+	}
+	*/
+
+	// draw the suit power bar
+	//surface()->DrawSetTextColor( m_HealthVialIconColor );
+	surface()->DrawSetTextFont( m_hIconFont );
+
+	int total = m_iNumHealthVials;
+
+	if (m_bHealthVialAdded)
+	{
+		if (m_iNumHealthVialsDiff < 0)
+			m_iNumHealthVialsDiff = -m_iNumHealthVialsDiff;
+	}
+	else if (m_LastHealthVialColor[3])
+	{
+		// Add to the total to represent our lost HealthVials
+		total += (m_iNumHealthVialsDiff);
+	}
+
+	bool bShowHighlight = (m_bHealthVialAdded || m_LastHealthVialColor[3]);
+	int iHealthVialHighlight = (total - m_iNumHealthVialsDiff);
+
+	//Msg( "HealthVial Paint: %s - (%i/%i), (%i/%i)\n", bShowHighlight ? "Showing highlight" : "Not showing highlight",
+	//	m_iNumHealthVials, m_iNumHealthVialsDiff,
+	//	m_iNumTripmines, m_iNumTripminesDiff );
+
+	int xpos = m_flIconInsetX, ypos = m_flIconInsetY;
+	//int iconSize = m_flIconGap - 2;
+	for (int i = 0; i < total; i++)
+	{
+		//surface()->DrawSetColor( m_HealthVialIconColor );
+		surface()->DrawSetTextColor( m_HealthVialIconColor );
+
+		surface()->DrawSetTextPos(xpos, ypos);
+
+
+		if (bShowHighlight)
+		{
+			if (m_iNumHealthVialsDiff != 0 && i >= iHealthVialHighlight)
+			{
+				//surface()->DrawSetColor( m_LastHealthVialColor );
+				surface()->DrawSetTextColor( m_LastHealthVialColor );
+			}
+		}
+
+		surface()->DrawUnicodeChar('S');
+		//surface()->DrawSetTexture( m_textureID_HealthVial );
+		//surface()->DrawTexturedRect( xpos, ypos, xpos + iconSize, ypos + iconSize );
+
+		xpos += m_flIconGap;
+	}
+}
+
+

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -160,6 +160,7 @@ public:
 	// Override impulse commands for new detonation command
 	virtual void		CheatImpulseCommands( int iImpulse );
 	virtual void		DetonateExplosives();
+	virtual void		UseHealthVial();
 
 	// For more accurate representations of whether the player actually sees something
 	// (3D dot calculations instead of 2D dot calculations)

--- a/sp/src/game/shared/hl2/hl2_gamerules.cpp
+++ b/sp/src/game/shared/hl2/hl2_gamerules.cpp
@@ -2978,6 +2978,11 @@ CAmmoDef *GetAmmoDef()
 		def.AddAmmoType("762mm",			DMG_BULLET,					TRACER_LINE_AND_WHIZ,	"sk_plr_dmg_762mm",		"sk_npc_dmg_762mm",		"sk_max_762mm",		BULLET_IMPULSE(200, 1225), 0 );
 #endif
 
+		// Uprising
+#ifdef EZ
+		def.AddAmmoType("item_healthvial", DMG_GENERIC, TRACER_NONE, "sk_healthvial", "sk_healthvial", "sk_healthvial_max", 0, 0);
+#endif
+
 	}
 
 	return &def;

--- a/sp/src/game/shared/hl2/hl2_usermessages.cpp
+++ b/sp/src/game/shared/hl2/hl2_usermessages.cpp
@@ -56,6 +56,10 @@ void RegisterUserMessages( void )
 	usermessages->Register( "SLAMExploded", 1 );
 #endif
 
+#ifdef EZ
+	usermessages->Register("HealthVialConsumed", 1);
+#endif
+
 #ifndef _X360
 	// NVNT register haptic user messages
 	RegisterHapticMessages();

--- a/sp/src/game/shared/shareddefs.h
+++ b/sp/src/game/shared/shareddefs.h
@@ -123,8 +123,8 @@ public:
 
 #ifdef EZ
 // E:Z needs a higher limit
-#define	MAX_AMMO_TYPES	36
-#define MAX_AMMO_SLOTS  36		// not really slots
+#define	MAX_AMMO_TYPES	64
+#define MAX_AMMO_SLOTS  64		// not really slots
 #else
 #define	MAX_AMMO_TYPES	32		// ???
 #define MAX_AMMO_SLOTS  32		// not really slots


### PR DESCRIPTION
This is a feature intended for Entropy : Zero Uprising Episode 2. This pull request for Entropy : Zero 2 is a placeholder until such a time as we decide we want to implement this feature for workshop content or for other Entropy : Zero mods.

## Description

The health vial backpack is a feature that allows the player to store health vials they find. With the backpack enabled, contacting a health vial will add it as an ammo type instead of doing the normal interaction. The number of health vials currently in your inventory will be displayed on a new HUD element. 

Pressing a key bound to the command "impulse 28" will consume one health vial from the inventory and restore the normal number of hitpoints.

## How to use

To use the health vial backpack, you must set the ConVars and make a few configuration changes to display the backpack on the HUD.

### ConVars

This pull request adds two ConVars.
```
sk_healthvial_backpack 0
sk_healthvial_max 0
````

To use the health vial backpack, set sk_healthvial_backpack to 1. The player may hold health vials up to ``sk_healthvial_max``. Please note that the HUD is only set up to handle a maximum of 8 healthvials. 

### Key binding to consume health vial

Bind the command "impulse 28" to a key in order to use the "consume health vial" function. Please look at how "impulse 36" is handled in Entropy : Zero 2's configuration files to figure out the best way to set up a binding in the menu. For debug purposes, you can also type ``bind b "impulse 28"`` to bind impulse 28 to the B key.

### HUD config files

[healthvial_backpack_scripts.zip](https://github.com/entropy-zero/source-sdk-2013/files/12876825/healthvial_backpack_scripts.zip)

**hudlayout.res**

Add the following configurations:
```
HudHealthVialStatus	[!$DECK]
{
  "fieldName"	"HudHealthVialStatus"
  "visible"	"1"
  "enabled" "1"
  "xpos"	"16"
  "ypos"	"394"
  "wide"	"104"
  "tall"	"32"
  "xpos_default"	"120"
  "wide_default"	"104"
  "HealthVialIconColor"	"255 244 244 160"
  "LastHealthVialColor"	"255 244 244 160"
  "IconInsetX"	"8"
  "IconInsetY"	"4"
  "IconGap"		"24"
  "IconFont"		"HudNumbersSmall"
  
  "PaintBackgroundType"	"2"
}

HudHealthVialStatus	[$DECK]
{
  "fieldName"	"HudHealthVialStatus"
  "visible"	"1"
  "enabled" "1"
  "xpos"	"16"
  "ypos"	"386"
  "wide"	"104"
  "tall"	"32"
  "xpos_default"	"120"
  "wide_default"	"104"
  "HealthVialIconColor"	"255 244 244 160"
  "LastHealthVialColor"	"255 244 244 160"
  "IconInsetX"	"8"
  "IconInsetY"	"4"
  "IconGap"		"24"
  "IconFont"		"HudNumbersSmall_Deck"
  
  "PaintBackgroundType"	"2"
}
```

hudanimations_ezu.txt

In a hudanimations file, add these events. (You could create new file hudanimations_ezu.txt and add it to the hudanimations_manifest.txt file)

```
event HealthVialStatusShow
{
	Animate HudHealthVialStatus Alpha	"255" Linear 0.0 0.4
	Animate HudHealthVialStatus		FgColor		"BrightFg"		Linear	0.4		0.1
	Animate HudHealthVialStatus		FgColor		"FgColor"		Linear	0.5		1.6
}

event HealthVialStatusHide
{
	Animate HudHealthVialStatus Alpha	"0" Linear 0.0 0.4
}

event HealthVialAdded
{
	StopEvent	HealthVialConsumed		0.0
	StopEvent	HealthVialDied		0.0
	StopEvent	HealthVialLeft		0.0

	// add in the squad member, brighter then normal color
	Animate HudHealthVialStatus LastHealthVialColor	"255 255 255 255" Linear 0.0 0.1
	Animate HudHealthVialStatus LastHealthVialColor	"255 244 244 160" Linear 0.3 0.3
}

event HealthVialLeft
{
	StopEvent	HealthVialConsumed		0.0
	StopEvent	HealthVialDied		0.0
	StopEvent	HealthVialAdded	0.0

	// fade out the icon
	Animate HudHealthVialStatus LastHealthVialColor	"255 244 244 0"	Linear 0.0 0.5
}

event HealthVialConsumed
{
	StopEvent	HealthVialDied		0.0
	StopEvent	HealthVialAdded	0.0
	StopEvent	HealthVialLeft	0.0

	// Flash orange while fading out the icon
	Animate HudHealthVialStatus	LastHealthVialColor	"255 192 0 255"	Linear 0.0 0.15
	Animate HudHealthVialStatus	LastHealthVialColor	"255 192 0 0"	Linear 0.3 0.15
}

event HealthVialDied
{
	StopEvent	HealthVialAdded	0.0
	StopEvent	HealthVialConsumed		0.0
	StopEvent	HealthVialLeft		0.0

	// flash red, hold, then disappear
	Animate HudHealthVialStatus	LastHealthVialColor	"255 0 0 255"	Linear 0.0 0.5
	Animate HudHealthVialStatus	LastHealthVialColor	"255 0 0 0"		Linear 1.0 1.0
}

// Blixibon couldn't figure out how to do this in code. 1upD never even tried :(
event HealthVialElementSizeOne
{
	Animate HudHealthVialStatus		Wide	"29"	Deaccel	0.0		0.3
}

event HealthVialElementSizeTwo
{
	Animate HudHealthVialStatus		Wide	"53"	Deaccel	0.0		0.3
}

event HealthVialElementSizeThree
{
	Animate HudHealthVialStatus		Wide	"77"	Deaccel	0.0		0.3
}

event HealthVialElementSizeFour
{
	Animate HudHealthVialStatus		Wide	"101"	Deaccel	0.0		0.3
}

event HealthVialElementSizeFive
{
	Animate HudHealthVialStatus		Wide	"125"	Deaccel	0.0		0.3
}

event HealthVialElementSizeSix
{
	Animate HudHealthVialStatus		Wide	"149"	Deaccel	0.0		0.3
}

event HealthVialElementSizeSeven
{
	Animate HudHealthVialStatus		Wide	"173"	Deaccel	0.0		0.3
}

event HealthVialElementSizeEight
{
	Animate HudHealthVialStatus		Wide	"197"	Deaccel	0.0		0.3
}

event HealthVialElementSizeMax
{
	Animate HudHealthVialStatus		FgColor		"255 0 0 128"		Linear	0.0		0.5
	Animate HudHealthVialStatus		FgColor		"FgColor"		Linear	0.5		1.6
}
```
