### PR TITLE
Player can give assassins dual weapons + Vantage point edge case fix

### DIFF
--- a/sp/src/game/server/ez2/npc_assassin.h
+++ b/sp/src/game/server/ez2/npc_assassin.h
@@ -72,9 +72,11 @@ public:
 	void		Event_Killed( const CTakeDamageInfo &info );
 	bool		IsLightDamage( const CTakeDamageInfo &info );
 	bool		IsHeavyDamage( const CTakeDamageInfo &info );
+	void		AddLeftHandGun( CBaseCombatWeapon *pWeapon );
 	void		Weapon_HandleEquip( CBaseCombatWeapon *pWeapon );
 	void		Weapon_EquipHolstered( CBaseCombatWeapon *pWeapon );
 	void		Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecTarget = NULL, const Vector *pVelocity = NULL );
+	void		Weapon_Equip( CBaseCombatWeapon *pWeapon );
 	Vector		GetAttackSpread( CBaseCombatWeapon *pWeapon, CBaseEntity *pTarget = NULL );
 	float		GetSpreadBias( CBaseCombatWeapon *pWeapon, CBaseEntity *pTarget );
 


### PR DESCRIPTION
Allows players to give Combine Assassins dual weapons in-game by giving another weapon of the same type as the weapon they are already holding. Restrictions on which weapons can be dual wielded (Pistols, Pulse Pistols, and 357s) remain, and assassins cannot dual wield two different types of weapons.

Also fixes a bug in which assassins shoot at nothing when failing to reach a vantage point hint.