### PR TITLE
EZ2 should also have the 'Manhack' ammo type

### DIFF
--- a/sp/src/game/shared/hl2/hl2_gamerules.cpp
+++ b/sp/src/game/shared/hl2/hl2_gamerules.cpp
@@ -2892,7 +2892,7 @@ CAmmoDef *GetAmmoDef()
 		def.AddAmmoType("CombineCannon",	DMG_BULLET,					TRACER_LINE,			"sk_npc_dmg_gunship_to_plr", "sk_npc_dmg_gunship", NULL, 1.5 * 750 * 12, 0 ); // hit like a 1.5kg weight at 750 ft/s
 		def.AddAmmoType("AirboatGun",		DMG_AIRBOAT,				TRACER_LINE,			"sk_plr_dmg_airboat",		"sk_npc_dmg_airboat",		NULL,					BULLET_IMPULSE(10, 600), 0 );
 			
-#ifdef EZ1
+#ifdef EZ
 		// Entropy Zero
 		def.AddAmmoType("Manhack", DMG_BURN, TRACER_NONE, 0, 0, 2, 0, 0);
 #endif


### PR DESCRIPTION
This PR changes the preprocessor block surrounding the Manhack ammo type so that it is available in both EZ games
---

#### Does this PR close any issues?
* https://github.com/entropy-zero/source-sdk-2013/issues/230

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
