### PR TITLE
Fix nemesis manhacks not initializing eye properly + Add SetNemesis input

### DIFF
--- a/sp/src/game/server/hl2/npc_manhack.cpp
+++ b/sp/src/game/server/hl2/npc_manhack.cpp
@@ -209,7 +209,7 @@ BEGIN_DATADESC( CNPC_Manhack )
 #endif
 
 #ifdef EZ2
-	DEFINE_INPUTFUNC( FIELD_BOOLEAN, "SetNemesis", InputSetNemesis ),
+	DEFINE_INPUTFUNC( FIELD_BOOLEAN, "SetNemesisManhack", InputSetNemesisManhack ),
 #endif
 
 	DEFINE_ENTITYFUNC( CrashTouch ),

--- a/sp/src/game/server/hl2/npc_manhack.cpp
+++ b/sp/src/game/server/hl2/npc_manhack.cpp
@@ -208,6 +208,10 @@ BEGIN_DATADESC( CNPC_Manhack )
 	DEFINE_INPUTFUNC( FIELD_VOID, "DisableSprites", InputDisableSprites ),
 #endif
 
+#ifdef EZ2
+	DEFINE_INPUTFUNC( FIELD_BOOLEAN, "SetNemesis", InputSetNemesis ),
+#endif
+
 	DEFINE_ENTITYFUNC( CrashTouch ),
 
 	DEFINE_BASENPCINTERACTABLE_DATADESC(),
@@ -2614,9 +2618,20 @@ EyeGlow_t * CNPC_Manhack::GetEyeGlowData(int index)
 		}
 		else
 		{
-			eyeGlow->red = 255;
-			eyeGlow->green = 0;
-			eyeGlow->blue = 0;
+#ifdef EZ2
+			if (m_bNemesis)
+			{
+				eyeGlow->red = 0;
+				eyeGlow->green = 255;
+				eyeGlow->blue = 255;
+			}
+			else
+#endif
+			{
+				eyeGlow->red = 255;
+				eyeGlow->green = 0;
+				eyeGlow->blue = 0;
+			}
 		}
 		eyeGlow->renderMode = kRenderTransAdd;
 		eyeGlow->scale = 0.25f;
@@ -2639,9 +2654,20 @@ EyeGlow_t * CNPC_Manhack::GetEyeGlowData(int index)
 		}
 		else
 		{
-			eyeGlow->red = 255;
-			eyeGlow->green = 0;
-			eyeGlow->blue = 0;
+#ifdef EZ2
+			if (m_bNemesis)
+			{
+				eyeGlow->red = 0;
+				eyeGlow->green = 255;
+				eyeGlow->blue = 255;
+			}
+			else
+#endif
+			{
+				eyeGlow->red = 255;
+				eyeGlow->green = 0;
+				eyeGlow->blue = 0;
+			}
 		}
 		eyeGlow->renderMode = kRenderTransAdd;
 		eyeGlow->scale = 0.25f;

--- a/sp/src/game/server/hl2/npc_manhack.h
+++ b/sp/src/game/server/hl2/npc_manhack.h
@@ -206,7 +206,7 @@ public:
 #ifdef EZ2
 	void		TurnIntoNemesis() { m_bNemesis = true; }
 
-	void		InputSetNemesis( inputdata_t &inputdata )
+	void		InputSetNemesisManhack( inputdata_t &inputdata )
 	{
 		// Turn the sprites off and on again so their colors will change.
 		KillSprites(0.0f);

--- a/sp/src/game/server/hl2/npc_manhack.h
+++ b/sp/src/game/server/hl2/npc_manhack.h
@@ -205,6 +205,14 @@ public:
 
 #ifdef EZ2
 	void		TurnIntoNemesis() { m_bNemesis = true; }
+
+	void		InputSetNemesis( inputdata_t &inputdata )
+	{
+		// Turn the sprites off and on again so their colors will change.
+		KillSprites(0.0f);
+		m_bNemesis = inputdata.value.Bool();
+		StartEye();
+	}
 #endif
 
 	DEFINE_CUSTOM_AI;


### PR DESCRIPTION
This PR fixes a problem with nemesis manhacks initializing their eyes to be red. This usually manifested when a save is loaded and would fix itself when the manhack's eye state changes, such as when it opens up to attack.

This PR also adds a new `SetNemesis` input, which allows manhacks to be switched between normal and nemesis manhacks in-game, rather than only when spawned.