### PR TITLE
Make husk code species-agnostic + Add VScript functionality

### DIFF
--- a/sp/src/game/server/ez2/npc_husk_police.cpp
+++ b/sp/src/game/server/ez2/npc_husk_police.cpp
@@ -32,6 +32,15 @@ BEGIN_DATADESC( CNPC_HuskPolice )
 END_DATADESC()
 
 //---------------------------------------------------------
+// VScript
+//---------------------------------------------------------
+BEGIN_ENT_SCRIPTDESC( CNPC_HuskPolice, CAI_BaseActor, "Husk metrocop." )
+
+	DEFINE_BASE_HUSK_SCRIPTDESC()
+
+END_SCRIPTDESC()
+
+//---------------------------------------------------------
 // Custom Client entity
 //---------------------------------------------------------
 IMPLEMENT_SERVERCLASS_ST( CNPC_HuskPolice, DT_NPC_HuskPolice )

--- a/sp/src/game/server/ez2/npc_husk_police.h
+++ b/sp/src/game/server/ez2/npc_husk_police.h
@@ -6,8 +6,8 @@
 //
 //=============================================================================//
 
-#ifndef NPC_HUSK_SOLDIER_H
-#define NPC_HUSK_SOLDIER_H
+#ifndef NPC_HUSK_POLICE_H
+#define NPC_HUSK_POLICE_H
 #ifdef _WIN32
 #pragma once
 #endif
@@ -22,6 +22,7 @@ class CNPC_HuskPolice : public CAI_BaseHusk<CNPC_MetroPolice>
 {
 	DECLARE_CLASS( CNPC_HuskPolice, CAI_BaseHusk<CNPC_MetroPolice> );
 	DECLARE_DATADESC();
+	DECLARE_ENT_SCRIPTDESC();
 	DECLARE_SERVERCLASS();
 
 public:
@@ -42,6 +43,8 @@ public:
 	NPC_STATE	SelectIdealState( void );
 	int			SelectAlertSchedule( void );
 	int			SelectCombatSchedule( void );
+
+	bool		HasHumanGibs( void ) { return true; }
 
 	WeaponProficiency_t		CalcWeaponProficiency( CBaseCombatWeapon *pWeapon );
 
@@ -64,4 +67,4 @@ private:
 	};
 };
 
-#endif // NPC_HUSK_SOLDIER_H
+#endif // NPC_HUSK_POLICE_H

--- a/sp/src/game/server/ez2/npc_husk_soldier.cpp
+++ b/sp/src/game/server/ez2/npc_husk_soldier.cpp
@@ -173,6 +173,15 @@ BEGIN_DATADESC( CNPC_HuskSoldier )
 END_DATADESC()
 
 //---------------------------------------------------------
+// VScript
+//---------------------------------------------------------
+BEGIN_ENT_SCRIPTDESC( CNPC_HuskSoldier, CAI_BaseActor, "Husk Combine soldier." )
+
+	DEFINE_BASE_HUSK_SCRIPTDESC()
+
+END_SCRIPTDESC()
+
+//---------------------------------------------------------
 // Custom Client entity
 //---------------------------------------------------------
 IMPLEMENT_SERVERCLASS_ST( CNPC_HuskSoldier, DT_NPC_HuskSoldier )

--- a/sp/src/game/server/ez2/npc_husk_soldier.h
+++ b/sp/src/game/server/ez2/npc_husk_soldier.h
@@ -39,6 +39,7 @@ class CNPC_HuskSoldier : public CAI_BaseHusk<CNPC_Combine>
 {
 	DECLARE_CLASS( CNPC_HuskSoldier, CAI_BaseHusk<CNPC_Combine> );
 	DECLARE_DATADESC();
+	DECLARE_ENT_SCRIPTDESC();
 	DECLARE_SERVERCLASS();
 
 public:
@@ -91,6 +92,7 @@ public:
 	bool		IsHeavyDamage( const CTakeDamageInfo &info );
 
 	bool		AllowedToIgnite( void ) { return true; }
+	bool		HasHumanGibs( void ) { return true; }
 
 	bool		Crouch( void );
 


### PR DESCRIPTION
This PR fixes parts of the husk code to support innate range attacks and specifies soldier/metrocop husks to use human gibs. The "species-agnostic" label is arbitrary and may be a little exaggerated due to the small scale of the changes.

This PR also adds husk VScript functionality which can be implemented in each class in the same way as datadesc and sendprops vars. At the moment, it only exposes functions to get a husk's aggression level and cognition flags.