### PR TITLE
point_detonatable

### DIFF
--- a/sp/src/game/client/ez2/c_ez2_player.h
+++ b/sp/src/game/client/ez2/c_ez2_player.h
@@ -6,6 +6,23 @@
 
 #include "c_basehlplayer.h"
 
+class C_PointDetonatable : public C_BaseEntity
+{
+public:
+	DECLARE_CLASS( C_PointDetonatable, C_BaseEntity );
+	DECLARE_CLIENTCLASS();
+	DECLARE_PREDICTABLE();
+
+	C_PointDetonatable();
+	~C_PointDetonatable();
+
+	bool		ShouldDraw() { return false; }
+
+	bool		m_bDisabled;
+	EHANDLE		m_hThrower;
+	EHANDLE		m_hGlowTarget;
+};
+
 class C_EZ2_Player : public C_BaseHLPlayer
 {
 public:
@@ -33,6 +50,7 @@ public:
 
 	CUtlVector<EHANDLE>	m_hActiveSatchels;
 	CUtlVector<EHANDLE>	m_hActiveTripmines;
+	CUtlVector< CHandle<C_PointDetonatable> >	m_hActiveDetonatables;
 	CUtlVector<CGlowObject*>	m_pSLAMGlowEffects;
 };
 

--- a/sp/src/game/client/hl2/c_hl2_playerlocaldata.cpp
+++ b/sp/src/game/client/hl2/c_hl2_playerlocaldata.cpp
@@ -32,6 +32,7 @@ BEGIN_RECV_TABLE_NOBASE( C_HL2PlayerLocalData, DT_HL2Local )
 #ifdef EZ2
 	RecvPropInt( RECVINFO( m_iSatchelCount ) ),
 	RecvPropInt( RECVINFO( m_iTripmineCount ) ),
+	RecvPropInt( RECVINFO( m_iDetonatableCount ) ),
 #endif
 END_RECV_TABLE()
 

--- a/sp/src/game/client/hl2/c_hl2_playerlocaldata.h
+++ b/sp/src/game/client/hl2/c_hl2_playerlocaldata.h
@@ -48,6 +48,7 @@ public:
 #ifdef EZ2
 	int		m_iSatchelCount;
 	int		m_iTripmineCount;
+	int		m_iDetonatableCount;	// Misc. explosives that aren't satchels or tripmines, but can be tracked and detonated
 #endif
 
 	// Ladder related data

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -416,6 +416,39 @@ protected:
 };
 
 //-----------------------------------------------------------------------------
+// Purpose: Mapper-controlled detonatable object
+//-----------------------------------------------------------------------------
+class CPointDetonatable : public CBaseEntity
+{
+public:
+	DECLARE_CLASS( CPointDetonatable, CBaseEntity );
+	DECLARE_DATADESC();
+	DECLARE_SERVERCLASS();
+
+	CPointDetonatable();
+	~CPointDetonatable();
+
+	void			Spawn();
+	int				UpdateTransmitState();
+	void			VerifyGlowTarget( CBaseEntity *pActivator, CBaseEntity *pCaller );
+
+	void			InputEnable( inputdata_t &inputdata );
+	void			InputDisable( inputdata_t &inputdata );
+	void			InputSetGlowTarget( inputdata_t &inputdata );
+	void			InputDetonate( inputdata_t &inputdata );
+
+	CNetworkVar( bool, m_bDisabled );
+
+	string_t		m_iszThrower;
+	CNetworkHandle( CBaseCombatCharacter, m_hThrower );
+
+	string_t		m_iszGlowTarget;
+	CNetworkHandle( CBaseEntity, m_hGlowTarget );
+
+	COutputEvent	m_OnDetonate;
+};
+
+//-----------------------------------------------------------------------------
 // Purpose: Kick data for interaction.
 // (Blixibon)
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/hl2_player.cpp
+++ b/sp/src/game/server/hl2/hl2_player.cpp
@@ -4299,6 +4299,17 @@ void CHL2_Player::UpdateClientData( void )
 		}
 	}
 	m_HL2Local.m_iTripmineCount = m_hActiveTripmines.Count();
+
+	if (m_hActiveDetonatables.Count() > 0)
+	{
+		// Clean up nonexistent detonatables
+		for (int i = m_hActiveDetonatables.Count()-1; i >= 0; i--)
+		{
+			if (m_hActiveDetonatables[i] == NULL || m_hActiveDetonatables[i]->IsMarkedForDeletion())
+				m_hActiveDetonatables.Remove( i );
+		}
+	}
+	m_HL2Local.m_iDetonatableCount = m_hActiveDetonatables.Count();
 #endif
 
 	BaseClass::UpdateClientData();
@@ -4327,6 +4338,13 @@ void CHL2_Player::OnRestore()
 		pGrenade = static_cast<CBaseGrenade*>(pEntity);
 		if (pGrenade->GetThrower() == this)
 			m_hActiveTripmines.AddToTail( pEntity );
+	}
+
+	while ((pEntity = gEntList.FindEntityByClassname( pEntity, "point_detonatable" )) != NULL)
+	{
+		CPointDetonatable *pDetonatable = static_cast<CPointDetonatable*>(pEntity);
+		if (!pDetonatable->m_bDisabled && pDetonatable->m_hThrower.Get() == this)
+			m_hActiveDetonatables.AddToTail( pEntity );
 	}
 #endif
 }
@@ -4902,6 +4920,12 @@ void CHL2_Player::OnSetupTripmine( CBaseEntity *pTripmine )
 	m_hActiveTripmines.AddToTail( pTripmine );
 }
 
+void CHL2_Player::OnSetupDetonatable( CBaseEntity *pDetonatable )
+{
+	//Msg( "OnSetupDetonatable\n" );
+	m_hActiveDetonatables.AddToTail( pDetonatable );
+}
+
 void CHL2_Player::OnSatchelExploded( CBaseEntity *pSatchel, CBaseEntity *pAttacker )
 {
 	// send a message to the client, to notify the hud of the loss
@@ -4924,6 +4948,23 @@ void CHL2_Player::OnTripmineExploded( CBaseEntity *pTripmine, CBaseEntity *pAtta
 	MessageEnd();
 
 	m_hActiveTripmines.FindAndRemove( pTripmine );
+}
+
+void CHL2_Player::OnDetonatableExploded( CBaseEntity *pDetonatable, CBaseEntity *pAttacker )
+{
+	// send a message to the client, to notify the hud of the loss
+	CSingleUserRecipientFilter user( this );
+	user.MakeReliable();
+	UserMessageBegin( user, "SLAMExploded" );
+		WRITE_BOOL( pAttacker != this );
+	MessageEnd();
+
+	m_hActiveDetonatables.FindAndRemove( pDetonatable );
+}
+
+void CHL2_Player::OnDetonatableDisabled( CBaseEntity *pDetonatable )
+{
+	m_hActiveDetonatables.FindAndRemove( pDetonatable );
 }
 #endif
 

--- a/sp/src/game/server/hl2/hl2_player.h
+++ b/sp/src/game/server/hl2/hl2_player.h
@@ -198,8 +198,11 @@ public:
 
 	void		OnDropSatchel( CBaseEntity *pSatchel );
 	void		OnSetupTripmine( CBaseEntity *pTripmine );
+	void		OnSetupDetonatable( CBaseEntity *pDetonatable );
 	void		OnSatchelExploded( CBaseEntity *pSatchel, CBaseEntity *pAttacker );
 	void		OnTripmineExploded( CBaseEntity *pTripmine, CBaseEntity *pAttacker );
+	void		OnDetonatableExploded( CBaseEntity *pDetonatable, CBaseEntity *pAttacker );
+	void		OnDetonatableDisabled( CBaseEntity *pDetonatable );
 #endif
 
 	// Apply a battery
@@ -456,6 +459,7 @@ private:
 #ifdef EZ2
 	CUtlVector<CBaseEntity*>	m_hActiveSatchels;
 	CUtlVector<CBaseEntity*>	m_hActiveTripmines;
+	CUtlVector<CBaseEntity*>	m_hActiveDetonatables;
 #endif
 
 	Vector				m_vecMissPositions[16];

--- a/sp/src/game/server/hl2/hl2_playerlocaldata.cpp
+++ b/sp/src/game/server/hl2/hl2_playerlocaldata.cpp
@@ -35,6 +35,7 @@ BEGIN_SEND_TABLE_NOBASE( CHL2PlayerLocalData, DT_HL2Local )
 #ifdef EZ2
 	SendPropInt( SENDINFO( m_iSatchelCount ) ),
 	SendPropInt( SENDINFO( m_iTripmineCount ) ),
+	SendPropInt( SENDINFO( m_iDetonatableCount ) ),
 #endif
 END_SEND_TABLE()
 
@@ -55,6 +56,7 @@ BEGIN_SIMPLE_DATADESC( CHL2PlayerLocalData )
 #ifdef EZ2
 	DEFINE_FIELD( m_iSatchelCount, FIELD_INTEGER ),
 	DEFINE_FIELD( m_iTripmineCount, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iDetonatableCount, FIELD_INTEGER ),
 #endif
 	// Ladder related stuff
 	DEFINE_FIELD( m_hLadder, FIELD_EHANDLE ),

--- a/sp/src/game/server/hl2/hl2_playerlocaldata.h
+++ b/sp/src/game/server/hl2/hl2_playerlocaldata.h
@@ -47,6 +47,7 @@ public:
 #ifdef EZ2
 	CNetworkVar( int,	m_iSatchelCount );
 	CNetworkVar( int,	m_iTripmineCount );
+	CNetworkVar( int,	m_iDetonatableCount );	// Misc. explosives that aren't satchels or tripmines, but can be tracked and detonated
 #endif
 
 	// Ladder related data


### PR DESCRIPTION
A mapper-controlled detonatable object which hooks directly into the player's detonation code, constituting a new class of explosive separate from satchels and tripmines. This can be used to essentially make players detonate non-SLAM objects.

This is currently in draft status due to variable implementation.