### PR TITLE
Save metadata files need to rotate according to save_history_count

### DIFF
--- a/sp/src/game/server/ez2/ez2_save_metadata.cpp
+++ b/sp/src/game/server/ez2/ez2_save_metadata.cpp
@@ -45,6 +45,9 @@ public:
 			// Map Version
 			pCustomSaveMetadata->SetInt( "mapversion", gpGlobals->mapversion );
 
+			// Map name
+			pCustomSaveMetadata->SetString("map", STRING(gpGlobals->mapname));
+
 			// UNDONE: Host Name
 			//{
 			//	char szHostName[128];
@@ -83,16 +86,20 @@ public:
 protected:
 
 	// Recursive function to rotate metadata files
-	void RotateFile(char name[MAX_PATH], char const* pchSaveFile, int save_history_count, int counter=1)
+	void RotateFile(char pszFilenameToRotate[MAX_PATH], char const* pchOriginalSaveFilename, int iSaveHistoryCount, int iCounter=1)
 	{
+		char pszNewMetadataFilename[MAX_PATH];
+		char pszNewSaveFilename[MAX_PATH];
+
+
 		// Base case: File does not exist
-		if (!filesystem->FileExists(name, "MOD"))
+		if (!filesystem->FileExists(pszFilenameToRotate, "MOD"))
 		{
 			return;
 		}
 
-		// If this file is not an autosave, do not rotate
-		const char* pszFileName = V_GetFileName(pchSaveFile);
+		// If this file is not an autosave or quicksave, do not rotate
+		const char* pszFileName = V_GetFileName(pchOriginalSaveFilename);
 		if (!(V_stricmp(pszFileName, "autosave.sav") == 0 || V_stricmp(pszFileName, "quick.sav") == 0))
 		{
 			return;
@@ -100,46 +107,40 @@ protected:
 
 		// autosave.txt -> autosave01.txt
 		// quick.txt -> quick01.txt
-		char pszNewMetadataFilename[MAX_PATH];
-		Q_StripExtension(pchSaveFile, pszNewMetadataFilename, sizeof(pszNewMetadataFilename));
+		Q_StripExtension(pchOriginalSaveFilename, pszNewMetadataFilename, sizeof(pszNewMetadataFilename));
 		Q_strlower(pszNewMetadataFilename);
-		Q_FixSlashes(name);
+		Q_FixSlashes(pszFilenameToRotate);
 
 		// If the counter is below 10, append a leading 0
-		const char* pszMetadataFileSuffix = counter < 10 ? CFmtStr("0%d.txt", counter) : CFmtStr("%d.txt", counter);
+		const char* pszMetadataFileSuffix = iCounter < 10 ? CFmtStr("0%d", iCounter) : CFmtStr("%d", iCounter);
 
 		Q_strncat(pszNewMetadataFilename, pszMetadataFileSuffix, sizeof(pszNewMetadataFilename));
+		Q_strncpy(pszNewSaveFilename, pszNewMetadataFilename, sizeof(pszNewMetadataFilename));
 
-		char pszNewSaveFilename[MAX_PATH];
-		Q_StripExtension(pchSaveFile, pszNewSaveFilename, sizeof(pszNewSaveFilename));
-		Q_strlower(pszNewSaveFilename);
-		Q_FixSlashes(name);
-
-		// If the counter is below 10, append a leading 0
-		const char* pszSaveFileSuffix = counter < 10 ? CFmtStr("0%d.sav", counter) : CFmtStr("%d.sav", counter);
-
-		Q_strncat(pszNewSaveFilename, pszSaveFileSuffix, sizeof(pszNewSaveFilename));
+		// Add file extensions
+		Q_strncat(pszNewMetadataFilename, ".txt", sizeof(pszNewMetadataFilename));
+		Q_strncat(pszNewSaveFilename, ".sav", sizeof(pszNewSaveFilename));
 
 		// If the save associated with the next filename exists, rotate the next filename first
 		if (filesystem->FileExists(pszNewSaveFilename, "MOD"))
 		{
-			RotateFile(pszNewMetadataFilename, pchSaveFile, save_history_count, counter + 1);
+			RotateFile(pszNewMetadataFilename, pchOriginalSaveFilename, iSaveHistoryCount, iCounter + 1);
 		}
 		else if(filesystem->FileExists(pszNewMetadataFilename, "MOD"))
 		{
-			Msg("File %s does not exist. Removing metadata files %s and %s\n", pszNewSaveFilename, name, pszNewMetadataFilename);
-			filesystem->RemoveFile(name, "MOD");
+			Msg("File %s does not exist. Removing metadata files %s and %s\n", pszNewSaveFilename, pszFilenameToRotate, pszNewMetadataFilename);
+			filesystem->RemoveFile(pszFilenameToRotate, "MOD");
 			filesystem->RemoveFile(pszNewMetadataFilename, "MOD");
 			return;
 		}
 		// If we have passed the save history count, remove the files instead of rotating
-		else if (counter > save_history_count)
+		else if (iCounter > iSaveHistoryCount)
 		{
-			Msg("Tried to rotate to save metadata file %s but save history count is %d. Removing file %s\n", pszNewMetadataFilename, save_history_count, name);
-			filesystem->RemoveFile(name, "MOD");
+			Msg("Tried to rotate to save metadata file %s but save history count is %d. Removing file %s\n", pszNewMetadataFilename, iSaveHistoryCount, pszFilenameToRotate);
+			filesystem->RemoveFile(pszFilenameToRotate, "MOD");
 			return;
 		}
 
-		filesystem->RenameFile(name, pszNewMetadataFilename, "MOD");
+		filesystem->RenameFile(pszFilenameToRotate, pszNewMetadataFilename, "MOD");
 	}
 } g_CustomSaveMetadata;

--- a/sp/src/game/server/ez2/ez2_save_metadata.cpp
+++ b/sp/src/game/server/ez2/ez2_save_metadata.cpp
@@ -30,29 +30,8 @@ public:
 		Q_SetExtension( name, ".txt", sizeof( name ) );
 		Q_FixSlashes( name );
 
-		if (filesystem->FileExists( name, "MOD" ))
-		{
-			const char *pszFileName = V_GetFileName( pchSaveFile );
-			bool bAutoOrQuickSave = (V_stricmp( pszFileName, "autosave.sav" ) == 0 || V_stricmp( pszFileName, "quick.sav" ) == 0);
-
-			// autosave.txt -> autosave01.txt
-			// quick.txt -> quick01.txt
-			// (TODO: Account for save_history_count)
-			if (bAutoOrQuickSave)
-			{
-				char name2[MAX_PATH];
-				Q_StripExtension( pchSaveFile, name2, sizeof( name2 ) );
-				Q_strlower( name2 );
-				Q_FixSlashes( name );
-
-				Q_strncat( name2, "01.txt", sizeof( name2 ) );
-
-				if ( filesystem->FileExists( name2, "MOD" ) )
-					filesystem->RemoveFile( name2, "MOD" );
-
-				filesystem->RenameFile( name, name2, "MOD" );
-			}
-		}
+		ConVarRef save_history_count("save_history_count");
+		RotateFile(name, pchSaveFile, save_history_count.GetInt());
 
 		KeyValues *pCustomSaveMetadata = new KeyValues( "CustomSaveMetadata" );
 		if (pCustomSaveMetadata)
@@ -101,4 +80,66 @@ public:
 		pCustomSaveMetadata->deleteThis();
 	}
 
+protected:
+
+	// Recursive function to rotate metadata files
+	void RotateFile(char name[MAX_PATH], char const* pchSaveFile, int save_history_count, int counter=1)
+	{
+		// Base case: File does not exist
+		if (!filesystem->FileExists(name, "MOD"))
+		{
+			return;
+		}
+
+		// If this file is not an autosave, do not rotate
+		const char* pszFileName = V_GetFileName(pchSaveFile);
+		if (!(V_stricmp(pszFileName, "autosave.sav") == 0 || V_stricmp(pszFileName, "quick.sav") == 0))
+		{
+			return;
+		}
+
+		// autosave.txt -> autosave01.txt
+		// quick.txt -> quick01.txt
+		char pszNewMetadataFilename[MAX_PATH];
+		Q_StripExtension(pchSaveFile, pszNewMetadataFilename, sizeof(pszNewMetadataFilename));
+		Q_strlower(pszNewMetadataFilename);
+		Q_FixSlashes(name);
+
+		// If the counter is below 10, append a leading 0
+		const char* pszMetadataFileSuffix = counter < 10 ? CFmtStr("0%d.txt", counter) : CFmtStr("%d.txt", counter);
+
+		Q_strncat(pszNewMetadataFilename, pszMetadataFileSuffix, sizeof(pszNewMetadataFilename));
+
+		char pszNewSaveFilename[MAX_PATH];
+		Q_StripExtension(pchSaveFile, pszNewSaveFilename, sizeof(pszNewSaveFilename));
+		Q_strlower(pszNewSaveFilename);
+		Q_FixSlashes(name);
+
+		// If the counter is below 10, append a leading 0
+		const char* pszSaveFileSuffix = counter < 10 ? CFmtStr("0%d.sav", counter) : CFmtStr("%d.sav", counter);
+
+		Q_strncat(pszNewSaveFilename, pszSaveFileSuffix, sizeof(pszNewSaveFilename));
+
+		// If the save associated with the next filename exists, rotate the next filename first
+		if (filesystem->FileExists(pszNewSaveFilename, "MOD"))
+		{
+			RotateFile(pszNewMetadataFilename, pchSaveFile, save_history_count, counter + 1);
+		}
+		else if(filesystem->FileExists(pszNewMetadataFilename, "MOD"))
+		{
+			Msg("File %s does not exist. Removing metadata files %s and %s\n", pszNewSaveFilename, name, pszNewMetadataFilename);
+			filesystem->RemoveFile(name, "MOD");
+			filesystem->RemoveFile(pszNewMetadataFilename, "MOD");
+			return;
+		}
+		// If we have passed the save history count, remove the files instead of rotating
+		else if (counter > save_history_count)
+		{
+			Msg("Tried to rotate to save metadata file %s but save history count is %d. Removing file %s\n", pszNewMetadataFilename, save_history_count, name);
+			filesystem->RemoveFile(name, "MOD");
+			return;
+		}
+
+		filesystem->RenameFile(name, pszNewMetadataFilename, "MOD");
+	}
 } g_CustomSaveMetadata;


### PR DESCRIPTION
This PR updates the CCustomSaveMetadata class to rotate save metadata files in accordance with the set ConVar ``save_history_count``. It should rotate the metadata files for autosaves and quicksaves to match the number of save files that are retained.

I am opening this PR in draft status while I work on it. Feel free to review but please understand the code will probably be updated before it is ready to be merged.

---
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
