### PR TITLE
sv_save_history_count_archived ConVar archives save_history_count

### DIFF
--- a/sp/src/game/server/ez2/ez2_save_metadata.cpp
+++ b/sp/src/game/server/ez2/ez2_save_metadata.cpp
@@ -144,3 +144,17 @@ protected:
 		filesystem->RenameFile(pszFilenameToRotate, pszNewMetadataFilename, "MOD");
 	}
 } g_CustomSaveMetadata;
+
+
+//=============================================================================
+// Archived ConVar to set save_history_count
+//=============================================================================
+void CV_SaveHistoryCountUpdate(IConVar* var, const char* pOldValue, float flOldValue);
+ConVar	sv_save_history_count_archived("sv_save_history_count_archived", "10", FCVAR_ARCHIVE, "Archived variable which sets the engine var save_history_count.", CV_SaveHistoryCountUpdate);
+
+void CV_SaveHistoryCountUpdate(IConVar* var, const char* pOldValue, float flOldValue)
+{
+	int iNewValue = sv_save_history_count_archived.GetInt();
+	ConVarRef save_history_count("save_history_count");
+	save_history_count.SetValue(iNewValue);
+}


### PR DESCRIPTION
New ConVar sv_save_history_count_archived is an archived var that changes the value of the engine ConVar save_history_count. It can be used to make save_history_count into a main menu option.

---
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
