### PR TITLE
Initialize save_history_count to the default value of sv_save_history_count_archived

### DIFF
--- a/sp/src/game/server/ez2/ez2_save_metadata.cpp
+++ b/sp/src/game/server/ez2/ez2_save_metadata.cpp
@@ -14,6 +14,15 @@
 class CCustomSaveMetadata : public CAutoGameSystem
 {
 public:
+	bool Init()
+	{
+		ConVarRef save_history_count("save_history_count");
+		ConVarRef sv_save_history_count_archived("sv_save_history_count_archived");
+		Msg("Setting save_history_count to %d....\n", sv_save_history_count_archived.GetInt());
+		save_history_count.SetValue(sv_save_history_count_archived.GetInt());
+		return true;
+	}
+
 
 	void OnSave()
 	{


### PR DESCRIPTION
This is a fix for a case where the value of sv_save_history_count_archived has not yet been archived. When the game starts, it should copy the value of sv_save_history_count_archived into save_history_count. This might be the original, unarchived value. Once the value is archived, the callback in the ConVar will handle setting save_history_count.

---
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
