### PR TITLE
Fix certain soldiers staring at the player for potentially hundreds of seconds after Bad Cop says something

### DIFF
--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -1533,7 +1533,7 @@ void CEZ2_Player::PostSpeakDispatchResponse( AIConcept_t concept, AI_Response *r
 		{
 			CAI_BaseActor *pActor = dynamic_cast<CAI_BaseActor*>(pTarget);
 			if (pActor)
-				pActor->AddLookTarget( this, 0.75, GetExpresser()->GetTimeSpeechComplete() + 3.0f );
+				pActor->AddLookTarget( this, 0.75, (GetExpresser()->GetTimeSpeechComplete() - gpGlobals->curtime) + 3.0f );
 		}
 
 		// Notify the speech target for a response


### PR DESCRIPTION
This PR fixes an issue in which soldiers selected to respond to Bad Cop stare at the player for a time value which wasn't subtracted from the server clock. More specifically, they stare at the player for 3 seconds more than the value the server clock will be when Bad Cop stops speaking, rather than simply staring at the player for the amount of time Bad Cop is speaking plus 3 seconds. While additional look targets can still be assigned, the player look target remains in the background and always reemerges if its duration has not passed. This also prevents the regular idle/tactical look target code from running, as it requires the soldier to not have any active look targets. This not only prevents soldiers from looking at hints or other entities in the world, but it also prevents soldiers from looking at or sometimes even noticing enemies in combat, as they are dead-set on staring at Bad Cop.

This issue appears to have been present since late 2019, and it most likely went unnoticed because the usual number of soldiers in the player's squad made it more difficult to notice that one of them was constantly staring at you, and the fact that it exponentially increases with the server clock means that this will mainly become a problem during longer playthroughs, when you're less likely to look at each individual soldier and realize one of them has been staring at you for 4 years because you had the gall to say something.