### PR TITLE
Stasis grenade effects

### DIFF
--- a/sp/src/game/client/episodic/c_weapon_hopwire.cpp
+++ b/sp/src/game/client/episodic/c_weapon_hopwire.cpp
@@ -44,6 +44,9 @@ public:
 	void			StopExplosion( void );
 	void			StartPreExplosion( void );
 
+	void			SetExplosionType(int explosionType) {
+		m_iExplosionType = explosionType;}
+
 private:
 	CInterpolatedValue		m_FXCoreScale;
 	CInterpolatedValue		m_FXCoreAlpha;
@@ -54,6 +57,8 @@ private:
 	TimedEvent			m_ParticleTimer;
 
 	CHandle<C_BaseEntity>	m_hOwner;
+
+	int m_iExplosionType;
 };
 
 //-----------------------------------------------------------------------------
@@ -138,7 +143,7 @@ void C_HopwireExplosion::AddParticles( void )
 
 		// Base of the core effect
 #ifdef EZ2
-		sParticle = (SimpleParticle *) m_pSimpleEmitter->AddParticle( sizeof(SimpleParticle), m_pSimpleEmitter->GetPMaterial( "effects/XenGrenadeFlash" ), GetRenderOrigin() );
+		sParticle = (SimpleParticle *) m_pSimpleEmitter->AddParticle( sizeof(SimpleParticle), m_iExplosionType == 1 ? m_pSimpleEmitter->GetPMaterial("effects/strider_muzzle") : m_pSimpleEmitter->GetPMaterial( "effects/XenGrenadeFlash" ), GetRenderOrigin() );
 #else
 		sParticle = (SimpleParticle *) m_pSimpleEmitter->AddParticle( sizeof(SimpleParticle), m_pSimpleEmitter->GetPMaterial( "effects/strider_muzzle" ), GetRenderOrigin() );
 #endif
@@ -351,6 +356,9 @@ public:
 private:
 
 	C_HopwireExplosion	m_ExplosionEffect;	// Explosion effect information and drawing
+#ifdef EZ2
+	int					m_iHopwireType;
+#endif
 };
 
 IMPLEMENT_CLIENTCLASS_DT( C_GrenadeHopwire, DT_GrenadeHopwire, CGrenadeHopwire )
@@ -359,6 +367,7 @@ END_RECV_TABLE()
 #define	HOPWIRE_START_EXPLOSION		0
 #define	HOPWIRE_STOP_EXPLOSION		1
 #define	HOPWIRE_START_PRE_EXPLOSION	2
+#define	STASIS_START_EXPLOSION		3
 
 //-----------------------------------------------------------------------------
 // Constructor
@@ -366,6 +375,10 @@ END_RECV_TABLE()
 C_GrenadeHopwire::C_GrenadeHopwire( void )
 {
 	m_ExplosionEffect.SetActive( false );
+
+#ifdef EZ2
+	m_iHopwireType = 0;
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -385,8 +398,15 @@ void C_GrenadeHopwire::ReceiveMessage( int classID, bf_read &msg )
 	int messageType = msg.ReadByte();
 	switch( messageType )
 	{
+#ifdef EZ2
+	case STASIS_START_EXPLOSION:
+		m_iHopwireType = 1;
+		// DO NOT BREAK, pass through to next case
+#endif
+
 	case HOPWIRE_START_EXPLOSION:
 		{
+			m_ExplosionEffect.SetExplosionType( m_iHopwireType );
 			m_ExplosionEffect.SetActive();
 			m_ExplosionEffect.SetOwner( this );
 			m_ExplosionEffect.StartExplosion();
@@ -424,4 +444,3 @@ int	C_GrenadeHopwire::DrawModel( int flags )
 
 	return BaseClass::DrawModel( flags );
 }
-

--- a/sp/src/game/client/episodic/c_weapon_hopwire.cpp
+++ b/sp/src/game/client/episodic/c_weapon_hopwire.cpp
@@ -143,7 +143,15 @@ void C_HopwireExplosion::AddParticles( void )
 
 		// Base of the core effect
 #ifdef EZ2
-		sParticle = (SimpleParticle *) m_pSimpleEmitter->AddParticle( sizeof(SimpleParticle), m_iExplosionType == 1 ? m_pSimpleEmitter->GetPMaterial("effects/strider_muzzle") : m_pSimpleEmitter->GetPMaterial( "effects/XenGrenadeFlash" ), GetRenderOrigin() );
+		if (m_iExplosionType == 1)
+		{
+			sParticle = (SimpleParticle*)m_pSimpleEmitter->AddParticle(sizeof(SimpleParticle), m_pSimpleEmitter->GetPMaterial("effects/stasis_grenade_flash"), GetRenderOrigin());
+		}
+		else
+		{
+			sParticle = (SimpleParticle*)m_pSimpleEmitter->AddParticle(sizeof(SimpleParticle), m_pSimpleEmitter->GetPMaterial("effects/XenGrenadeFlash"), GetRenderOrigin());
+		}
+
 #else
 		sParticle = (SimpleParticle *) m_pSimpleEmitter->AddParticle( sizeof(SimpleParticle), m_pSimpleEmitter->GetPMaterial( "effects/strider_muzzle" ), GetRenderOrigin() );
 #endif

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2717,7 +2717,6 @@ void CGrenadeHopwire::Detonate( void )
 	switch (GetHopwireStyle())
 	{
 		case HOPWIRE_STASIS:
-			EmitSound("WeaponStasisGrenade.Explode");
 			SetModel(szWorldModelOpen);
 
 			EmitSound("WeaponStasisGrenade.Hop");
@@ -3264,6 +3263,9 @@ void CGrenadeStasis::CombatThink( void )
 	VPhysicsDestroyObject();
 	SetAbsVelocity( vec3_origin );
 	SetMoveType( MOVETYPE_NONE );
+
+	// Stasis grenades play explosion sound when the vortex is created
+	EmitSound("WeaponStasisGrenade.Explode");
 
 	m_hVortexController = CStasisVortexController::Create( GetAbsOrigin(), stasis_radius.GetFloat(), stasis_strength.GetFloat(), stasis_duration.GetFloat(), this );
 

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2239,6 +2239,7 @@ BEGIN_DATADESC( CGrenadeHopwire )
 
 	// Inputs
 	DEFINE_INPUTFUNC( FIELD_FLOAT, "SetTimer", InputSetTimer ),
+	DEFINE_INPUTFUNC( FIELD_VOID, "DetonateImmediately", InputDetonateImmediately),
 
 	DEFINE_THINKFUNC( DelayThink ),
 	DEFINE_THINKFUNC( SpriteOff ),
@@ -2383,11 +2384,35 @@ void CGrenadeHopwire::InputSetTimer( inputdata_t &inputdata )
 
 void CGrenadeHopwire::DelayThink()
 {
+#ifdef EZ2
+	int i_ColorRed = 255;
+	int i_ColorGreen = 255;
+	int i_ColorBlue = 255;
+	int i_ColorAlpha = 255;
+
+	switch (GetHopwireStyle())
+	{
+		case HOPWIRE_STASIS:
+			i_ColorRed = 0;
+			i_ColorGreen = 200;
+			break;
+		default:
+			i_ColorRed = 0;
+			i_ColorBlue = 0;
+			break;
+	}
+
+#endif
+
 	if( gpGlobals->curtime > m_flDetonateTime )
 	{
 		if (m_pMainGlow)
 		{
+#ifndef EZ2
 			m_pMainGlow->SetTransparency( kRenderTransAdd, 0, 255, 0, 255, kRenderFxNoDissipation );
+#else
+			m_pMainGlow->SetTransparency( kRenderTransAdd, i_ColorRed, i_ColorGreen, i_ColorBlue, i_ColorAlpha, kRenderFxNoDissipation );
+#endif
 			m_pMainGlow->SetBrightness( 255 );
 			m_pMainGlow->TurnOn();
 			SetContextThink( NULL, TICK_NEVER_THINK, g_SpriteOffContext );
@@ -2449,6 +2474,25 @@ void CGrenadeHopwire::OnRestore( void )
 //-----------------------------------------------------------------------------
 void CGrenadeHopwire::CreateEffects( void )
 {
+#ifdef EZ2
+	int i_ColorRed = 255;
+	int i_ColorGreen = 255;
+	int i_ColorBlue = 255;
+	int i_ColorAlpha = 255;
+
+	switch (GetHopwireStyle())
+	{
+	case HOPWIRE_STASIS:
+		i_ColorRed = 0;
+		i_ColorGreen = 200;
+		break;
+	default:
+		i_ColorRed = 0;
+		break;
+	}
+
+#endif
+
 	// Start up the eye glow
 	m_pMainGlow = CSprite::SpriteCreate( "sprites/redglow2.vmt", GetLocalOrigin(), false );
 
@@ -2458,7 +2502,13 @@ void CGrenadeHopwire::CreateEffects( void )
 	{
 		m_pMainGlow->FollowEntity( this );
 		m_pMainGlow->SetAttachment( this, nAttachment );
+
+#ifndef EZ2
 		m_pMainGlow->SetTransparency( kRenderGlow, 0, 255, 255, 255, kRenderFxNoDissipation );
+#else
+		m_pMainGlow->SetTransparency( kRenderGlow, i_ColorRed, i_ColorGreen, i_ColorBlue, i_ColorAlpha, kRenderFxNoDissipation );
+#endif
+
 		m_pMainGlow->SetBrightness( 192 );
 		m_pMainGlow->SetScale( 0.5f );
 		m_pMainGlow->SetGlowProxySize( 4.0f );
@@ -2850,6 +2900,11 @@ CStasisVortexController *CStasisVortexController::Create( const Vector &origin, 
 	// Start the vortex working
 	pVortex->StartPull( origin, radius, strength, duration );
 
+	trace_t	tr;
+	AI_TraceLine(origin + Vector(0, 0, 1), origin - Vector(0, 0, 128), MASK_SOLID_BRUSHONLY, pVortex, COLLISION_GROUP_NONE, &tr);
+
+	UTIL_DecalTrace(&tr, "Glowbie.Puddle");
+
 	return pVortex;
 }
 
@@ -3177,7 +3232,7 @@ void CGrenadeStasis::CombatThink( void )
 
 	// Start our client-side effect
 	EntityMessageBegin( this, true );
-	WRITE_BYTE( 0 );
+	WRITE_BYTE( 3 );
 	MessageEnd();
 
 	// Begin to stop in two seconds

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -77,11 +77,13 @@ ConVar hopwire_schlorp_small_mass( "hopwire_schlorp_small_mass", "30" );
 ConVar hopwire_schlorp_medium_mass( "hopwire_schlorp_medium_mass", "100" );
 ConVar hopwire_schlorp_large_mass( "hopwire_schlorp_large_mass", "350" );
 ConVar hopwire_schlorp_huge_mass( "hopwire_schlorp_huge_mass", "600" );
+ConVar hopwire_timer("hopwire_timer", "2.0");
 
 ConVar stasis_freeze_player("stasis_freeze_player", "1");
-ConVar stasis_radius("stasis_radius", "128");
+ConVar stasis_radius("stasis_radius", "256");
 ConVar stasis_strength("stasis_strength", "150");
 ConVar stasis_duration("stasis_duration", "3.0");
+ConVar stasis_timer("stasis_timer", "0.25");
 
 // Move this elsewhere if this concept is expanded
 ConVar ez2_spoilers_enabled( "ez2_spoilers_enabled", "0", FCVAR_NONE, "Enables the you-know-whats and you-know-whos that shouldn't shown in streams, but might make accidental cameos. This is on by default as a precaution." );

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2905,7 +2905,7 @@ CStasisVortexController *CStasisVortexController::Create( const Vector &origin, 
 	trace_t	tr;
 	AI_TraceLine(origin + Vector(0, 0, 1), origin - Vector(0, 0, 128), MASK_SOLID_BRUSHONLY, pVortex, COLLISION_GROUP_NONE, &tr);
 
-	UTIL_DecalTrace(&tr, "Glowbie.Puddle");
+	UTIL_DecalTrace(&tr, "StasisGrenade.Splash");
 
 	return pVortex;
 }

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2328,16 +2328,28 @@ void CGrenadeHopwire::Precache( void )
 #ifndef EZ2	
 	PrecacheModel( DENSE_BALL_MODEL );
 #else
-	PrecacheScriptSound( "WeaponXenGrenade.Explode" );
-	PrecacheScriptSound( "WeaponXenGrenade.SpawnXenPC" );
-	PrecacheScriptSound( "WeaponXenGrenade.Blip" );
-	PrecacheScriptSound( "WeaponXenGrenade.Hop" );
+	switch (GetHopwireStyle())
+	{
+	case HOPWIRE_STASIS:
+		PrecacheScriptSound("WeaponStasisGrenade.Explode");
+		PrecacheScriptSound("WeaponStasisGrenade.Blip");
+		PrecacheScriptSound("WeaponStasisGrenade.Hop");
+		break;
+	default:
+		PrecacheScriptSound("WeaponXenGrenade.Explode");
+		PrecacheScriptSound("WeaponXenGrenade.SpawnXenPC");
+		PrecacheScriptSound("WeaponXenGrenade.Blip");
+		PrecacheScriptSound("WeaponXenGrenade.Hop");
 
-	PrecacheScriptSound( "WeaponXenGrenade.Schlorp_Huge" );
-	PrecacheScriptSound( "WeaponXenGrenade.Schlorp_Large" );
-	PrecacheScriptSound( "WeaponXenGrenade.Schlorp_Medium" );
-	PrecacheScriptSound( "WeaponXenGrenade.Schlorp_Small" );
-	PrecacheScriptSound( "WeaponXenGrenade.Schlorp_Tiny" );
+		PrecacheScriptSound("WeaponXenGrenade.Schlorp_Huge");
+		PrecacheScriptSound("WeaponXenGrenade.Schlorp_Large");
+		PrecacheScriptSound("WeaponXenGrenade.Schlorp_Medium");
+		PrecacheScriptSound("WeaponXenGrenade.Schlorp_Small");
+		PrecacheScriptSound("WeaponXenGrenade.Schlorp_Tiny");
+		break;
+	}
+
+
 
 	PrecacheParticleSystem( "xenpc_spawn" );
 
@@ -2457,6 +2469,19 @@ void CGrenadeHopwire::SpriteOff()
 {
 	if (m_pMainGlow)
 		m_pMainGlow->TurnOff();
+}
+
+void CGrenadeHopwire::BlipSound()
+{
+	switch (GetHopwireStyle())
+	{
+	case HOPWIRE_STASIS:
+		EmitSound("WeaponStasisGrenade.Blip");
+		break;
+	default:
+		EmitSound("WeaponXenGrenade.Blip");
+		break;
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -2689,10 +2714,20 @@ void CGrenadeHopwire::Detonate( void )
 		GetThrower()->DispatchInteraction( g_interactionXenGrenadeHop, this, GetThrower() );
 	}
 
-	EmitSound("WeaponXenGrenade.Explode");
-	SetModel( szWorldModelOpen );
+	switch (GetHopwireStyle())
+	{
+		case HOPWIRE_STASIS:
+			EmitSound("WeaponStasisGrenade.Explode");
+			SetModel(szWorldModelOpen);
 
-	EmitSound( "WeaponXenGrenade.Hop" );
+			EmitSound("WeaponStasisGrenade.Hop");
+			break;
+		default:
+			EmitSound("WeaponXenGrenade.Explode");
+			SetModel(szWorldModelOpen);
+
+			EmitSound("WeaponXenGrenade.Hop");
+	}
 
 	//Find out how tall the ceiling is and always try to hop halfway
 	trace_t	tr;

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -213,7 +213,7 @@ public:
 
 	void	DelayThink();
 	void	SpriteOff();
-	void	BlipSound() { EmitSound( "WeaponXenGrenade.Blip" ); }
+	void	BlipSound();
 	void	OnRestore( void );
 	void	CreateEffects( void );
 

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -220,9 +220,10 @@ public:
 	void	InputSetTimer( inputdata_t &inputdata );
 
 #ifdef EZ
-	void	InputDetonateImmediately(inputdata_t& inputdata) { 
+	virtual void InputDetonateImmediately(inputdata_t& inputdata) { 
 				SetThink(&CGrenadeHopwire::CombatThink);
 				SetNextThink(gpGlobals->curtime);
+				EmitSound("WeaponXenGrenade.Explode"); // Start explosion sound again in case the grenade never hopped
 	}
 #endif
 
@@ -273,6 +274,11 @@ public:
 
 	virtual void	EndThink( void );		// Last think before going away
 	virtual void	CombatThink( void );	// Makes the main explosion go off
+
+	virtual void InputDetonateImmediately(inputdata_t& inputdata) {
+		SetThink(&CGrenadeStasis::CombatThink);
+		SetNextThink(gpGlobals->curtime);
+	}
 
 };
 

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -16,6 +16,9 @@
 extern ConVar hopwire_trap;
 
 #ifdef EZ2
+extern ConVar hopwire_timer;
+extern ConVar stasis_timer;
+
 enum HopwireStyle {
 	HOPWIRE_XEN = 0,
 	HOPWIRE_STASIS

--- a/sp/src/game/server/episodic/grenade_hopwire.h
+++ b/sp/src/game/server/episodic/grenade_hopwire.h
@@ -86,6 +86,7 @@ public:
 	bool	CanConsumeEntity( CBaseEntity *pEnt );
 
 	void	InputDetonate( inputdata_t &inputdata ) { StartPull( GetAbsOrigin(), m_flRadius, m_flStrength, m_flEndTime ); }
+
 	void	InputFakeSpawnEntity( inputdata_t &inputdata ) { inputdata.value.Entity() ? (void)TrySpawnRecipeNPC( inputdata.value.Entity(), false ) : Warning("Warning: FakeSpawnEntity cannot spawn null entity\n"); }
 	void	InputCreateXenLife( inputdata_t &inputdata ) { CreateXenLife(); }
 
@@ -214,6 +215,13 @@ public:
 	void	CreateEffects( void );
 
 	void	InputSetTimer( inputdata_t &inputdata );
+
+#ifdef EZ
+	void	InputDetonateImmediately(inputdata_t& inputdata) { 
+				SetThink(&CGrenadeHopwire::CombatThink);
+				SetNextThink(gpGlobals->curtime);
+	}
+#endif
 
 	virtual void	EndThink( void );		// Last think before going away
 	virtual void	CombatThink( void );	// Makes the main explosion go off

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -61,6 +61,7 @@ public:
 
 
 	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_XEN; }
+	virtual float GetGrenadeTime(void) { return 2.0f; }
 
 protected:
 	virtual void	ThrowGrenade( CBasePlayer *pPlayer );
@@ -110,6 +111,7 @@ class CWeaponStasisGrenade : public CWeaponHopwire
 public:
 
 	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_STASIS; }
+	virtual float GetGrenadeTime(void) { return 0.5f; }
 
 	DECLARE_SERVERCLASS();
 };
@@ -504,10 +506,10 @@ void CWeaponHopwire::ThrowGrenade( CBasePlayer *pPlayer )
 	switch (GetHopwireStyle())
 	{
 	case HOPWIRE_STASIS:
-		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel()));
 		break;
 	default:
-		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 
 	}
@@ -550,10 +552,10 @@ void CWeaponHopwire::LobGrenade( CBasePlayer *pPlayer )
 	switch (GetHopwireStyle())
 	{
 	case HOPWIRE_STASIS:
-		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 	default:
-		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 
 	}
@@ -608,10 +610,10 @@ void CWeaponHopwire::RollGrenade( CBasePlayer *pPlayer )
 	switch (GetHopwireStyle())
 	{
 	case HOPWIRE_STASIS:
-		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 	default:
-		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, GRENADE_TIMER, GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 
 	}

--- a/sp/src/game/server/episodic/weapon_hopwire.cpp
+++ b/sp/src/game/server/episodic/weapon_hopwire.cpp
@@ -61,7 +61,6 @@ public:
 
 
 	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_XEN; }
-	virtual float GetGrenadeTime(void) { return 2.0f; }
 
 protected:
 	virtual void	ThrowGrenade( CBasePlayer *pPlayer );
@@ -111,7 +110,6 @@ class CWeaponStasisGrenade : public CWeaponHopwire
 public:
 
 	virtual HopwireStyle GetHopwireStyle() { return HOPWIRE_STASIS; }
-	virtual float GetGrenadeTime(void) { return 0.5f; }
 
 	DECLARE_SERVERCLASS();
 };
@@ -506,10 +504,10 @@ void CWeaponHopwire::ThrowGrenade( CBasePlayer *pPlayer )
 	switch (GetHopwireStyle())
 	{
 	case HOPWIRE_STASIS:
-		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel()));
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, stasis_timer.GetFloat(), GetWorldModel(), GetSecondaryWorldModel()));
 		break;
 	default:
-		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 600, random->RandomInt( -1200, 1200 ), 0 ), pPlayer, hopwire_timer.GetFloat(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 
 	}
@@ -552,10 +550,10 @@ void CWeaponHopwire::LobGrenade( CBasePlayer *pPlayer )
 	switch (GetHopwireStyle())
 	{
 	case HOPWIRE_STASIS:
-		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, stasis_timer.GetFloat(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 	default:
-		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, vec3_angle, vecThrow, AngularImpulse( 200, random->RandomInt( -600, 600 ), 0 ), pPlayer, hopwire_timer.GetFloat(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 
 	}
@@ -610,10 +608,10 @@ void CWeaponHopwire::RollGrenade( CBasePlayer *pPlayer )
 	switch (GetHopwireStyle())
 	{
 	case HOPWIRE_STASIS:
-		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeStasis *> (StasisGrenade_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, stasis_timer.GetFloat(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 	default:
-		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, GetGrenadeTime(), GetWorldModel(), GetSecondaryWorldModel() ));
+		m_hActiveHopWire = static_cast<CGrenadeHopwire *> (HopWire_Create( vecSrc, orientation, vecThrow, rotSpeed, pPlayer, hopwire_timer.GetFloat(), GetWorldModel(), GetSecondaryWorldModel() ));
 		break;
 
 	}


### PR DESCRIPTION
This PR includes changes to separate the stasis grenade sprite color and particle effect from the hopwire/xen grenade. Instead of 0 message being sent to the client, 3 is sent instead to trigger a stasis grenade effect instead of a xen grenade effect.

Stasis grenades will create decals underneath where they were set off.

Some ConVar defaults have also been changed in this request.