### PR TITLE
Xenbies support forced headcrab release

### DIFF
--- a/sp/src/game/server/hl2/npc_BaseZombie.cpp
+++ b/sp/src/game/server/hl2/npc_BaseZombie.cpp
@@ -900,7 +900,6 @@ HeadcrabRelease_t CNPC_BaseZombie::ShouldReleaseHeadcrab( const CTakeDamageInfo 
 	{
 		// Xenbies never release headcrabs. Headcrabs in the original Half-Life were
 		// permanently attached to their zombies. 
-		// Additionally, our assets do not support separating headcrabs.
 		// 1upD
 		return RELEASE_NO;
 	}
@@ -2744,14 +2743,6 @@ bool CNPC_BaseZombie::HeadcrabFits( CBaseAnimating *pCrab )
 //-----------------------------------------------------------------------------
 void CNPC_BaseZombie::ReleaseHeadcrab( const Vector &vecOrigin, const Vector &vecVelocity, bool fRemoveHead, bool fRagdollBody, bool fRagdollCrab )
 {
-#ifdef EZ
-	// Since Xenbies don't drop headcrabs, we need to make sure nothing happens here for when dynamic interactions cause a headcrab to drop.
-	if ( m_tEzVariant == EZ_VARIANT_XEN )
-	{
-		return;
-	}
-#endif
-
 	CAI_BaseNPC		*pCrab;
 	Vector vecSpot = vecOrigin;
 


### PR DESCRIPTION
Originally, xenbies had a void underneath their headcrabs. However, xenbies will soon have a zombine-like jawbone, so there will no longer be a technical need to prevent them from dropping headcrabs.

That being said, we had tied this limitation to their lore: Headcrabs in the original HL1 never detached from their zombies, so E:Z2's xencrabs shouldn't either. This PR maintains that functionality in `ShouldReleaseHeadcrab()`. However, there was also a hard stop in `ReleaseHeadcrab()` itself which prevented xenbies from releasing headcrabs even when `ShouldReleaseHeadcrab()` was bypassed, such as during dynamic interactions (e.g. when a vortigaunt pulls a headcrab off a zombie). Some features, such as barnacles eating headcrabs off of zombies, still ignored this and showed the void anyway, but now that there's a jawbone, the hard stop isn't necessary.

This PR removes the check from `ReleaseHeadcrab()`, but maintains the check in `ShouldReleaseHeadcrab()` and only tweaks a comment about the asset limitation. This will allow xenbies to release their headcrabs in dynamic interaction events and anything else which "forces" a headcrab release outside of normal combat conditions.