### PR TITLE
Enable zombigaunt interactions

### DIFF
--- a/sp/src/game/server/ez2/npc_zombigaunt.h
+++ b/sp/src/game/server/ez2/npc_zombigaunt.h
@@ -44,11 +44,6 @@ protected:
 	bool IsJumpLegal( const Vector &startPos, const Vector &apex, const Vector &endPos ) const;
 	bool MovementCost( int moveType, const Vector &vecStart, const Vector &vecEnd, float *pCost );
 
-	// Since all dynamic interactions are shared with vortigaunts, zombigaunts cannot use dynamic interactions
-	// TODO - Replace this with code that checks that the other NPC isn't a vortigaunt.
-	// Hypothetically, this shouldn't be an issue - but vortigaunts and zombigaunts still use antlion dynamic intaeractions on each other occasionally.
-	virtual bool CanRunAScriptedNPCInteraction( bool bForced = false ) { return false;  }
-
 	// Zombigaunts have a much slower recharge time than vortigaunts, making them more likely to close in for the kill
 	virtual float GetNextRangeAttackTime( void ) { return gpGlobals->curtime + random->RandomFloat( 5.0f, 10.0f ); }
 	virtual float GetNextDispelTime( void );


### PR DESCRIPTION
Originally, zombigaunts were made incapable of performing dynamic interactions because they conflicted with regular vortigaunts, causing them to perform awkward and misplaced motions on each other. Mapbase technically had provisions to prevent this, but limitations in how dynamic interactions were parsed prevented the zombigaunts from being recognized to have the same interactions.

However, in Mapbase v7.0, a pull request on the Mapbase repo (https://github.com/mapbase-source/source-sdk-2013/pull/182) fixed the limitations with dynamic interaction parsing and allowed vortigaunts and zombigaunts to recognize that they have the same interactions. As a result, this check is no longer necessary, and removing it will allow zombigaunts to perform (or become victims of) dynamic interactions.