### PR TITLE
Predator dynamic interaction events and AI fixes + Option for mid-animation eating

### DIFF
--- a/sp/src/game/server/ez2/npc_basepredator.h
+++ b/sp/src/game/server/ez2/npc_basepredator.h
@@ -150,6 +150,8 @@ public:
 	virtual int MeleeAttack1Conditions( float flDot, float flDist );
 	virtual int MeleeAttack2Conditions( float flDot, float flDist );
 
+	virtual bool CanStartDynamicInteractionDuringMelee() { return true; }
+
 	virtual float GetMaxSpitWaitTime( void ) { return 0.0f; };
 	virtual float GetMinSpitWaitTime( void ) { return 0.0f; };
 	virtual float GetBiteDamage( void ) { return 0.0f; };
@@ -172,6 +174,8 @@ public:
 	virtual void OnFed();
 	virtual CBaseEntity *	BiteAttack( float flDist, const Vector &mins, const Vector &maxs ) { return NULL; }
 	virtual void			EatAttack();
+	bool		GetNearestInteractionDir( CAI_BaseNPC *pHurt, Vector &vecDir );
+	bool		GetMyNearestInteractionTranslation( const CAI_BaseNPC *pHurt, Vector &vecTranslation ) const;
 
 	virtual bool IsPrey( CBaseEntity* pTarget ) { return false; } // Override this method to choose an NPC to get excited about - like bullsquids with headcrabs
 	virtual bool IsSameSpecies( CBaseEntity* pTarget ) { return Classify() == pTarget->Classify(); } // Is this NPC the same species as me?
@@ -182,6 +186,7 @@ public:
 	virtual bool ShouldAttackObstruction( CBaseEntity *pEntity );
 	virtual bool ShouldImmediatelyAttackObstructions(); // If true, NPCs will immediately attack obstructions instead of waiting for the pathfinder to find a way around
 	virtual bool ShouldMeleeDamageAnyNPC() { return IsCurSchedule( SCHED_PREDATOR_ATTACK_TARGET, false ); }
+	virtual bool ShouldApplyHitVelocityToTarget( CBaseEntity *pHurt ) const;
 
 	virtual bool IsBaby() { return m_bIsBaby; };
 	virtual void SetIsBaby( bool bIsBaby ) { m_bIsBaby = bIsBaby; };
@@ -202,6 +207,7 @@ public:
 	virtual int SelectFailSchedule( int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode );
 	virtual int SelectBossSchedule( void );
 	virtual int TranslateSchedule( int scheduleType );
+	virtual void OnScheduleChange();
 
 	virtual void	GatherConditions( void );
 
@@ -221,6 +227,8 @@ public:
 #ifdef EZ2
 	virtual bool	HandleInteraction( int interactionType, void *data, CBaseCombatCharacter* sourceEnt );
 #endif
+
+	virtual void	HandleAnimEvent( animevent_t *pEvent );
 
 	DEFINE_CUSTOM_AI;
 
@@ -247,6 +255,8 @@ protected:
 
 	virtual void PredMsg( const tchar * pMsg ); // Print a message to the developer console
 	float m_flNextPredMsgTime; // Don't print messages constantly
+
+	bool m_bFiredEatEvent; // Whether or not this predator fired the eat animation event
 
 public:
 	void			InputSpawnNPC( inputdata_t &inputdata );

--- a/sp/src/game/server/ez2/npc_bullsquid.cpp
+++ b/sp/src/game/server/ez2/npc_bullsquid.cpp
@@ -11,6 +11,7 @@
 #include "npc_bullsquid.h"
 #include "grenade_spit.h"
 #include "movevars_shared.h"
+#include "npc_BaseZombie.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -42,6 +43,8 @@ int ACT_SQUID_EXCITED;
 int ACT_SQUID_EAT;
 int ACT_SQUID_DETECT_SCENT;
 int ACT_SQUID_INSPECT_FLOOR;
+
+int AE_BULLSQUID_EAT_HEADCRAB_OFF_ZOMBIE;
 
 //---------------------------------------------------------
 // Save/Restore
@@ -304,6 +307,56 @@ int CNPC_Bullsquid::MeleeAttack1Conditions( float flDot, float flDist )
 //=========================================================
 void CNPC_Bullsquid::HandleAnimEvent( animevent_t *pEvent )
 {
+	if (pEvent->type & AE_TYPE_NEWEVENTSYSTEM)
+	{
+		if (pEvent->event == AE_BULLSQUID_EAT_HEADCRAB_OFF_ZOMBIE)
+		{
+			// Remove the headcrab from the zombie interaction partner
+			CNPC_BaseZombie *pInteractionPartner = dynamic_cast<CNPC_BaseZombie*>( GetInteractionPartner() );
+			if ( pInteractionPartner )
+			{	
+				// Get head location
+				Vector vecHeadcrabOrigin;
+				QAngle angHeadcrabAngles;
+				int iCrabAttachment = pInteractionPartner->LookupAttachment( "headcrab" );
+				if (iCrabAttachment > 0)
+					pInteractionPartner->GetAttachment( iCrabAttachment, vecHeadcrabOrigin, angHeadcrabAngles );
+				else
+					pInteractionPartner->HeadTarget( vecHeadcrabOrigin );
+
+				// Show blood at head location
+				if (UTIL_ShouldShowBlood( BLOOD_COLOR_YELLOW ))
+				{
+					UTIL_BloodImpact( vecHeadcrabOrigin, Vector( 0, 0, 1 ), BLOOD_COLOR_YELLOW, 1 );
+
+					for (int i = 0; i < 3; i++)
+					{
+						Vector vecSpot = vecHeadcrabOrigin;
+
+						vecSpot.x += random->RandomFloat( -8, 8 );
+						vecSpot.y += random->RandomFloat( -8, 8 );
+						vecSpot.z += random->RandomFloat( -8, 8 );
+
+						UTIL_BloodDrips( vecSpot, vec3_origin, BLOOD_COLOR_YELLOW, 50 );
+					}
+				}
+
+				// Remove the head
+				pInteractionPartner->RemoveHead();
+
+				// Now kill the zombie itself
+				CTakeDamageInfo info = CTakeDamageInfo( this, this, pInteractionPartner->GetMaxHealth(), DMG_PREVENT_PHYSICS_FORCE );
+				pInteractionPartner->TakeDamage( info );
+
+				OnFed();
+				//m_bFiredEatEvent = true;
+			}
+		}
+		else
+			BaseClass::HandleAnimEvent( pEvent );
+		return;
+	}
+
 	switch( pEvent->event )
 	{
 		case PREDATOR_AE_SPIT:
@@ -460,7 +513,7 @@ void CNPC_Bullsquid::HandleAnimEvent( animevent_t *pEvent )
 				if ( pHurt->GetFlags() & ( FL_NPC | FL_CLIENT ) )
 					 pHurt->ViewPunch( QAngle( 20, 0, -20 ) );
 			
-				if ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS )
+				if ( ShouldApplyHitVelocityToTarget( pHurt ) )
 				{
 					Vector right, up;
 					AngleVectors( GetAbsAngles(), NULL, &right, &up );
@@ -559,11 +612,23 @@ CBaseEntity * CNPC_Bullsquid::BiteAttack( float flDist, const Vector & mins, con
 			m_flHungryTime = gpGlobals->curtime + 10.0f; // Headcrabs only satiate the squid for 10 seconds
 		}
 		// I don't want that!
-		else if( pVictim || pHurt->GetMoveType() == MOVETYPE_FLY )
+		else if( ShouldApplyHitVelocityToTarget( pHurt ) || pHurt->GetMoveType() == MOVETYPE_FLY )
 		{
 			Vector forward, up;
 			AngleVectors( GetAbsAngles(), &forward, NULL, &up );
-			pHurt->ApplyAbsVelocityImpulse( 100 * (up-forward) * GetModelScale() * ( m_bIsBaby ? 0.5f : 1.0f ) );
+
+			Vector vecImpulse = 100 * (up - forward);
+			if (pHurt->IsNPC())
+			{
+				Vector vecInteractionDir;
+				if ( GetNearestInteractionDir( pHurt->MyNPCPointer(), vecInteractionDir ) )
+				{
+					// Push the target in the direction of the interaction
+					vecImpulse = vecInteractionDir + (100 * up);
+				}
+			}
+
+			pHurt->ApplyAbsVelocityImpulse( vecImpulse * GetModelScale() * ( m_bIsBaby ? 0.5f : 1.0f ) );
 			pHurt->SetGroundEntity( NULL );
 		}
 	}
@@ -757,7 +822,7 @@ int CNPC_Bullsquid::OnTakeDamage_Alive( const CTakeDamageInfo &inputInfo )
 	}
 #endif
 
-	if( IsSameSpecies( inputInfo.GetAttacker() ) )
+	if( IsSameSpecies( inputInfo.GetAttacker() ) && inputInfo.GetAttacker() != this )
 	{
 		// Infant squids shouldn't take damage from adults
 		// There were too many accidents in testing
@@ -1144,6 +1209,8 @@ AI_BEGIN_CUSTOM_NPC( npc_bullsquid, CNPC_Bullsquid )
 	DECLARE_ACTIVITY( ACT_SQUID_EXCITED )
 	DECLARE_ACTIVITY( ACT_SQUID_DETECT_SCENT )
 	DECLARE_ACTIVITY( ACT_SQUID_INSPECT_FLOOR )
+
+	DECLARE_ANIMEVENT( AE_BULLSQUID_EAT_HEADCRAB_OFF_ZOMBIE )
 
 	DECLARE_INTERACTION( g_interactionBullsquidThrow )
 	DECLARE_INTERACTION( g_interactionBullsquidMonch )

--- a/sp/src/game/server/ez2/npc_pitdrone.cpp
+++ b/sp/src/game/server/ez2/npc_pitdrone.cpp
@@ -340,7 +340,7 @@ void CNPC_PitDrone::HandleAnimEvent( animevent_t *pEvent )
 			}
 
 			// Apply a velocity to hit entity if it is a character or if it has a physics movetype
-			if ( pHurt && ( pHurt->MyCombatCharacterPointer() || pHurt->GetMoveType() == MOVETYPE_VPHYSICS ) )
+			if ( pHurt && ShouldApplyHitVelocityToTarget( pHurt ) )
 			{
 				Vector forward, up;
 				AngleVectors( GetAbsAngles(), &forward, NULL, &up );

--- a/sp/src/game/server/ez2/npc_zassassin.h
+++ b/sp/src/game/server/ez2/npc_zassassin.h
@@ -57,6 +57,7 @@ public:
 	bool ShouldIgnite( const CTakeDamageInfo &info );
 
 	void OnChangeActivity( Activity eNewActivity );
+	void OnStateChange( NPC_STATE OldState, NPC_STATE NewState );
 
 	bool OverrideMoveFacing( const AILocalMoveGoal_t &move, float flInterval );
 	float MaxYawSpeed( void );		// Get max yaw speed


### PR DESCRIPTION
This PR adds new animation events and tweaks some of the predator AI to make predators able to perform certain dynamic interactions. Due to the changes being intertwined, this PR also adds support for eating to occur mid-animation via new animation events.

---

Overall, this PR includes five new animation events:

* `AE_PREDATOR_EAT` — Triggers an eat attack and feeds the predator. *(equivalent to what happens at the end of an eating animation)*
* `AE_PREDATOR_EAT_NOATTACK` — Instantly feeds the predator without performing an eat attack.
* `AE_PREDATOR_GIB_INTERACTION_PARTNER` — Gibs the predator's dynamic interaction partner and feeds the predator.
* `AE_PREDATOR_SWALLOW_INTERACTION_PARTNER` — Removes the predator's dynamic interaction partner and feeds the predator.
* `AE_BULLSQUID_EAT_HEADCRAB_OFF_ZOMBIE` — A bullsquid-only event which kills and removes the headcrab from a dynamic interaction partner derived from `CNPC_BaseZombie`, also feeding the predator.

When one of the eating events is used during an eating animation, it will override the "eat attack" normally used at the end of it. Currently, I've only set up this animation event on the gonome, so all other predators will retain the default behavior.

---

The "AI fixes" mainly entail fixing issues with predators running `scripted_sequence`s in general (or attacking other NPCs running them), as certain parts of their code overrode or interfered with the scripted state. There is, however, one liberty taken to encourage their use.

Normally, predators pull NPCs towards them after melee attacks. With this PR, they check if there's any dynamic interactions they can perform on the enemy. If there is one, they will push the enemy towards the dynamic interaction's ideal position instead. For predators attacking other predators, this will also work in reverse: If the attacked predator has their own dynamic interactions on the attacker, then the attacked predator will be pushed to where they can perform it on the attacker.