### PR TITLE
Predator "aiming" support

### DIFF
--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -142,6 +142,8 @@ void CNPC_BasePredator::OnRestore()
 void CNPC_BasePredator::SetupGlobalModelData()
 {
 	CollisionProp()->SetSurroundingBoundsType( USE_HITBOXES );
+
+	m_nAttachForward = LookupAttachment( "forward" );
 }
 
 //-----------------------------------------------------------------------------
@@ -368,6 +370,25 @@ float CNPC_BasePredator::MaxYawSpeed( void )
 	}
 
 	return flYS;
+}
+
+//=========================================================
+//  Weapon_ShootPosition
+// 
+// This allows the predator's body/mouth to turn using the "forward" attachment as a pivot.
+// Use bits_CAP_AIM_GUN to enable.
+//=========================================================
+Vector CNPC_BasePredator::Weapon_ShootPosition( void )
+{
+	if (m_nAttachForward > -1 && !(CapabilitiesGet() & bits_CAP_WEAPON_RANGE_ATTACK1))
+	{
+		Vector vecOrigin;
+		QAngle angDir;
+		GetAttachment( m_nAttachForward, vecOrigin, angDir );
+		return vecOrigin;
+	}
+
+	return BaseClass::Weapon_ShootPosition();
 }
 
 //=========================================================

--- a/sp/src/game/server/ez2/npc_basepredator.h
+++ b/sp/src/game/server/ez2/npc_basepredator.h
@@ -143,6 +143,8 @@ public:
 
 	float MaxYawSpeed ( void );
 
+	Vector	Weapon_ShootPosition( void );
+
 	virtual void BuildScheduleTestBits();
 	virtual bool OnObstructionPreSteer( AILocalMoveGoal_t *pMoveGoal, float distClear, AIMoveResult_t *pResult );
 
@@ -276,6 +278,8 @@ protected:
 
 private:
 	float m_nextSoundTime;
+
+	int m_nAttachForward;
 };
 
 #endif // NPC_BASEPREDATOR_H

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -320,6 +320,7 @@ void CNPC_Gonome::Spawn()
 	CapabilitiesAdd( bits_CAP_MOVE_GROUND | bits_CAP_INNATE_RANGE_ATTACK1 | bits_CAP_INNATE_MELEE_ATTACK1 | bits_CAP_INNATE_MELEE_ATTACK2 );
 	CapabilitiesAdd( bits_CAP_MOVE_JUMP | bits_CAP_MOVE_CLIMB );
 	CapabilitiesAdd( bits_CAP_OPEN_DOORS | bits_CAP_AUTO_DOORS | bits_CAP_DOORS_GROUP );
+	CapabilitiesAdd( bits_CAP_AIM_GUN ); // Technically aiming body; see CNPC_BasePredator::AimGun()
 	
 	m_fCanThreatDisplay	= TRUE;
 	m_flNextSpitTime = gpGlobals->curtime;


### PR DESCRIPTION
This PR gives predators the optional ability to "aim" their bodies using `bits_CAP_AIM_GUN` functionality. Ideally, this makes certain predators look more natural when attacking enemies which are above or below them.

This currently works best with gonomes, which are the only predators this PR enables this functionality on. I wanted to get this working on bullsquids as well, but my experiments made their mouths look weird at close range and some additional work may be needed before that can be added.

To demonstrate what this looks like, here's two quick videos respectively showing a gonome attacking a stukabat at two different elevations and a gonome attacking a player situated high above it:

https://github.com/entropy-zero/source-sdk-2013/assets/19228257/5a53a997-1a9b-42c1-840a-38295c874d8f

https://github.com/entropy-zero/source-sdk-2013/assets/19228257/be665a91-5811-46f4-ab2c-3ba4105b8e03