### PR TITLE
Misc. predator fixes

### DIFF
--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -207,7 +207,7 @@ void CNPC_BasePredator::FoundEnemySound( void )
 	if (gpGlobals->curtime >= m_nextSoundTime)
 	{
 		EmitSound( UTIL_VarArgs( "%s.FoundEnemy", GetSoundscriptClassname() ) );
-		m_nextSoundTime	= gpGlobals->curtime + random->RandomInt( 1.5, 3.0 );
+		m_nextSoundTime	= gpGlobals->curtime + random->RandomFloat( 1.5, 3.0 );
 	}
 }
 
@@ -219,7 +219,7 @@ void CNPC_BasePredator::GrowlSound( void )
 	if (gpGlobals->curtime >= m_nextSoundTime)
 	{
 		EmitSound( UTIL_VarArgs( "%s.Growl", GetSoundscriptClassname() ) );
-		m_nextSoundTime	= gpGlobals->curtime + random->RandomInt( 1.5, 3.0 );
+		m_nextSoundTime	= gpGlobals->curtime + random->RandomFloat( 1.5, 3.0 );
 	}
 }
 
@@ -1125,8 +1125,9 @@ int CNPC_BasePredator::SelectSchedule( void )
 		// No longer dormant
 		m_bDormant = false;
 
-		if ( HasCondition( COND_LIGHT_DAMAGE ) || HasCondition( COND_HEAVY_DAMAGE ) )
+		if ( (HasCondition( COND_LIGHT_DAMAGE ) || HasCondition( COND_HEAVY_DAMAGE )) && gpGlobals->curtime - GetLastEnemyTime() > 5.0f )
 		{
+			// Hop if we suddenly take damage after not seeing an enemy for 5 seconds
 			return SCHED_PREDATOR_HURTHOP;
 		}
 	}
@@ -1273,8 +1274,8 @@ NPC_STATE CNPC_BasePredator::SelectIdealState( void )
 	{
 	case NPC_STATE_COMBAT:
 	{
-		// COMBAT goes to ALERT upon death of enemy
-		if ( GetEnemy() != NULL && ( HasCondition( COND_LIGHT_DAMAGE ) || HasCondition( COND_HEAVY_DAMAGE ) ) && IsPrey( GetEnemy() ) )
+		// m_flLastHurtTime is not assigned when attacked by a prey, so this check ensures they were last attacked by a non-prey rather than a prey
+		if ( GetEnemy() != NULL && ( HasCondition( COND_LIGHT_DAMAGE ) || HasCondition( COND_HEAVY_DAMAGE ) ) && IsPrey( GetEnemy() ) && gpGlobals->curtime - m_flLastHurtTime < 1.0f )
 		{
 			// if the predator has a prey enemy and something hurts it, it's going to forget about the prey for a while.
 			SetEnemy( NULL );

--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -517,8 +517,13 @@ int CNPC_BasePredator::RangeAttack1Conditions( float flDot, float flDist )
 //=========================================================
 int CNPC_BasePredator::MeleeAttack1Conditions( float flDot, float flDist )
 {
-	if (GetEnemy()->m_iHealth <= GetWhipDamage() && flDist <= 85 && flDot >= 0.7)
+	CBaseEntity *pEnemy = GetEnemy();
+	if (pEnemy->m_iHealth <= GetWhipDamage() && flDist <= 85 && flDot >= 0.7)
 	{
+		float flZDiff = ( pEnemy->GetAbsOrigin().z - GetAbsOrigin().z );
+		if ( flZDiff >= GetMeleeZRange( pEnemy ) || flZDiff <= -GetMeleeZRangeBelow( pEnemy ) )
+			return COND_NONE;
+
 		return (COND_CAN_MELEE_ATTACK1);
 	}
 
@@ -535,7 +540,14 @@ int CNPC_BasePredator::MeleeAttack1Conditions( float flDot, float flDist )
 int CNPC_BasePredator::MeleeAttack2Conditions( float flDot, float flDist )
 {
 	if (flDist <= 85 && flDot >= 0.7 && !HasCondition( COND_CAN_MELEE_ATTACK1 ))		// The player & predator (bullsquid) can be as much as their bboxes 
+	{
+		CBaseEntity *pEnemy = GetEnemy();
+		float flZDiff = ( pEnemy->GetAbsOrigin().z - GetAbsOrigin().z );
+		if ( flZDiff >= GetMeleeZRange( pEnemy ) || flZDiff <= -GetMeleeZRangeBelow( pEnemy ) )
+			return COND_NONE;
+
 		return (COND_CAN_MELEE_ATTACK2);
+	}
 
 	return(COND_NONE);
 }

--- a/sp/src/game/server/ez2/npc_basepredator.h
+++ b/sp/src/game/server/ez2/npc_basepredator.h
@@ -154,6 +154,8 @@ public:
 	virtual float GetMinSpitWaitTime( void ) { return 0.0f; };
 	virtual float GetBiteDamage( void ) { return 0.0f; };
 	virtual float GetWhipDamage( void ) { return 0.0f; };
+	virtual float GetMeleeZRange( CBaseEntity *pEnemy ) { return GetHullHeight(); };
+	virtual float GetMeleeZRangeBelow( CBaseEntity *pEnemy ) { return pEnemy->IsNPC() ? pEnemy->MyNPCPointer()->GetHullHeight() * 0.75f : (pEnemy->EyePosition().z - pEnemy->GetAbsOrigin().z); };
 	virtual float GetSprintDistance( void ) { return 256.0f; };
 	virtual float GetEatInCombatPercentHealth( void ) { return 1.0f; };
 

--- a/sp/src/game/server/ez2/npc_zassassin.cpp
+++ b/sp/src/game/server/ez2/npc_zassassin.cpp
@@ -332,8 +332,6 @@ void CNPC_Gonome::Spawn()
 
 	// Separate convar for gonome look distance to make them "blind"
 	SetDistLook( sk_zombie_assassin_look_dist.GetFloat() );
-
-	m_poseArmsOut = LookupPoseParameter( "arms_out" );
 }
 
 //=========================================================
@@ -395,6 +393,16 @@ void CNPC_Gonome::Precache()
 	// Placeholder gib and soundscript
 	PrecacheParticleSystem( "glownome_explode" );
 	PrecacheScriptSound( "npc_zassassin.kickburst" );
+}
+
+//=========================================================
+// SetupGlobalModelData
+//=========================================================
+void CNPC_Gonome::SetupGlobalModelData()
+{
+	BaseClass::SetupGlobalModelData();
+
+	m_poseArmsOut = LookupPoseParameter( "arms_out" );
 }
 
 //---------------------------------------------------------
@@ -732,37 +740,6 @@ void CNPC_Gonome::IdleSound( void )
 }
 
 //=========================================================
-// PainSound 
-//=========================================================
-void CNPC_Gonome::PainSound( const CTakeDamageInfo &info )
-{
-	// Burning creatures shouldn't play pain sounds constantly
-	if ( !( IsOnFire() && info.GetDamageType() & DMG_BURN ) )
-	{
-		CPASAttenuationFilter filter( this );
-		EmitSound( filter, entindex(), "Gonome.Pain" );
-	}
-}
-
-//=========================================================
-// AlertSound
-//=========================================================
-void CNPC_Gonome::AlertSound( void )
-{
-	CPASAttenuationFilter filter( this );
-	EmitSound( filter, entindex(), "Gonome.Alert" );	
-}
-
-//=========================================================
-// DeathSound
-//=========================================================
-void CNPC_Gonome::DeathSound( const CTakeDamageInfo &info )
-{
-	CPASAttenuationFilter filter( this );
-	EmitSound( filter, entindex(), "Gonome.Die" );	
-}
-
-//=========================================================
 // AttackSound
 //=========================================================
 void CNPC_Gonome::AttackSound( void )
@@ -778,15 +755,6 @@ void CNPC_Gonome::GrowlSound( void )
 {
 	CPASAttenuationFilter filter( this );
 	EmitSound( filter, entindex(), "Gonome.Growl" );
-}
-
-//=========================================================
-// Found Enemy
-//=========================================================
-void CNPC_Gonome::FoundEnemySound(void)
-{
-	CPASAttenuationFilter filter(this);
-	EmitSound(filter, entindex(), "Gonome.FoundEnemy");
 }
 
 //=========================================================

--- a/sp/src/game/server/ez2/npc_zassassin.h
+++ b/sp/src/game/server/ez2/npc_zassassin.h
@@ -28,16 +28,14 @@ public:
 	void Precache( void );
 	Class_T	Classify( void );
 
+	void	SetupGlobalModelData( void );
+
 	bool	CreateBehaviors();
 	
 	virtual const char * GetSoundscriptClassname() { return "Gonome"; }
 	void IdleSound( void );
-	void PainSound( const CTakeDamageInfo &info );
-	void AlertSound( void );
-	void DeathSound( const CTakeDamageInfo &info );
 	void AttackSound( void );
 	void GrowlSound( void );
-	void FoundEnemySound(void);
 	void RetreatModeSound(void);
 	void BerserkModeSound(void);
 	void EatSound( void );


### PR DESCRIPTION
This PR fixes the following issues involving predators, especially gonomes:

* Predators will now only melee attack enemies within a certain Z range, which is calculated using hull height and/or the distance between the enemy's origin and eye position, depending on if the predator's target is a NPC or player. This fixes issues with predators getting stuck in a loop trying to attack enemies that are outside of its melee trace height (e.g. on displacements in the Xentarium).
* Predators won't hurthop when alert if they last saw an enemy less than 5 seconds ago. Being attacked while hunting prey also won't cause the predator to stop hunting if the attacker was the prey itself *(checked by evaluating `m_flLastHurtTime`, which is only assigned when attacked by non-prey)*. This fixes gonomes getting caught in a loop while fighting citizens.
* Remove redundant functions on `CNPC_Gonome` which overrode `CNPC_BasePredator` functionality, most importantly `m_nextSoundTime`.
* Move `CNPC_Gonome::m_poseArmsOut` initialization to `SetupGlobalModelData()`, which is more appropriate and properly runs on save/restore.
* Fix `m_nextSoundTime` random value using the wrong data type.