### PR TITLE
Rewrite stukabat NPC to support optional fly nav, divebomb telegraphing, ragdolling, unique stukapup model, etc.

### DIFF
--- a/sp/src/game/server/ez2/npc_flyingpredator.h
+++ b/sp/src/game/server/ez2/npc_flyingpredator.h
@@ -37,6 +37,10 @@ public:
 
 	virtual int RangeAttack1Conditions( float flDot, float flDist );
 
+	// Used by base LOS functions
+	virtual float	InnateRange1MinRange( void ) { return 64.0f; }
+	virtual float	InnateRange1MaxRange( void ) { return m_flDistTooFar; }
+
 	float GetMaxSpitWaitTime( void );
 	float GetMinSpitWaitTime( void );
 	float GetEatInCombatPercentHealth( void );
@@ -53,6 +57,9 @@ public:
 	virtual Activity NPC_TranslateActivity( Activity eNewActivity );
 	virtual int TranslateSchedule( int scheduleType );
 	virtual int SelectSchedule( void );
+	virtual int SelectFailSchedule( int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode );
+	virtual void BuildScheduleTestBits();
+	virtual void OnStartScene();
 
 	void StartTask ( const Task_t *pTask );
 	void RunTask( const Task_t * pTask );
@@ -67,21 +74,33 @@ public:
 	bool IsJumpLegal( const Vector & startPos, const Vector & apex, const Vector & endPos ) const { return true; }
 
 
-	bool		ShouldGib( const CTakeDamageInfo &info ) { return true; };
+	bool		ShouldGib( const CTakeDamageInfo &info );
 	bool		CorpseGib( const CTakeDamageInfo &info );
 	void		ExplosionEffect( void );
 
 	bool SpawnNPC( const Vector position, bool isBaby );
 
 	virtual bool	QueryHearSound( CSound *pSound );
+	
+	void		ModifyOrAppendCriteria( AI_CriteriaSet& set );
+	void		ModifyOrAppendCriteriaForPlayer( CBasePlayer *pPlayer, AI_CriteriaSet& set );
 
 	virtual bool	HandleInteraction( int interactionType, void *data, CBaseCombatCharacter* sourceEnt );
 
+	void HandleAnimEvent( animevent_t *pEvent );
+	void DiveBombAttack();
+
 // Flight
 public:
+	inline bool IsFlying( void ) const { return m_tFlyState == FlyState_Flying; }
+	bool CapableOfFlyNav( void );
+	bool CanUseFlyNav( void );
 	void SetFlyingState( FlyState_t eState );
 
 	virtual bool		OverrideMove( float flInterval );
+
+	void MoveFly( float flInterval );
+	bool Probe( const Vector &vecMoveDir, float flSpeed, Vector &vecDeflect );
 
 	void MoveToDivebomb( float flInterval );
 	void MoveInDirection( float flInterval, const Vector &targetDir,
@@ -92,10 +111,20 @@ public:
 	void InputForceFlying( inputdata_t &inputdata );
 	void InputFly( inputdata_t &inputdata );
 
+	virtual int		DrawDebugTextOverlays( void );
+
 protected:
 	FlyState_t m_tFlyState;
 	Vector				m_vecDiveBombDirection;		// The direction we dive bomb.
 	float m_flDiveBombRollForce;
+
+	bool		m_bCanUseFlyNav;
+
+	bool		m_bReachedMoveGoal;
+	Vector		m_vLastStoredOrigin;
+	float		m_flLastStuckCheck;
+	Vector		m_vDesiredTarget;
+	Vector		m_vCurrentTarget;
 
 	DEFINE_CUSTOM_AI;
 };


### PR DESCRIPTION
This PR makes several changes to the stukabat (or "flying predator") NPC. The highlights of these changes include:

* Stukabats will now have the ability to use air nodes through a new `CanUseFlyNav` keyvalue. This allows them to fly around in a similar fashion to crows, dive bombing from different heights and locations around the enemy. This behavior will be disabled by default and must be enabled manually in Hammer or through `npc_create` KV.
* The dive bomb animation will now have an approximately ⅔-second "warning" phase before the stukabat actually dive bombs, in an effort to telegraph the attack and make it less abrupt.
* When killed with minimal damage (e.g. with SMG bullets), stukabats will now ragdoll.
* Stukapups now have their own model.
* The field of view of stukabats is now 216 degrees (`-0.2`, which is relatively common) instead of 45 degrees (`0.75`). The 45-degree viewcone seems to have been an oversight, as a comment mentions increasing the FOV to prevent tunnel vision, yet the viewcone is smaller than nearly any other NPC. This new FOV also fits in better with the positions of the stukabat's eyes.
* Stukabats will now have audible wing flapping.