### PR TITLE
Stasis grenade: NPCs should not teleport when unfrozen

### DIFF
--- a/sp/src/game/server/ai_playerally.cpp
+++ b/sp/src/game/server/ai_playerally.cpp
@@ -18,6 +18,7 @@
 #ifdef EZ2
 #include "ez2/ai_concept_response.h"
 #include "ez2/ez2_player.h"
+#include "ai_interactions.h"
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -1339,6 +1340,37 @@ bool CAI_PlayerAlly::CanFlinch( void )
 		return false;
 
 	return BaseClass::CanFlinch();
+}
+#endif
+
+#ifdef EZ2
+extern int g_interactionStasisGrenadeFreeze;
+extern int g_interactionStasisGrenadeUnfreeze;
+
+//-----------------------------------------------------------------------------
+// Purpose:  This is a generic function (to be implemented by sub-classes) to
+//			 handle specific interactions between different types of characters
+//			 (For example the barnacle grabbing an NPC)
+// Input  :  Constant for the type of interaction
+// Output :	 true  - if sub-class has a response for the interaction
+//			 false - if sub-class has no response
+//-----------------------------------------------------------------------------
+bool CAI_PlayerAlly::HandleInteraction(int interactionType, void* data, CBaseCombatCharacter* sourceEnt)
+{
+	if (interactionType == g_interactionStasisGrenadeFreeze)
+	{
+		CapabilitiesRemove(bits_CAP_TURN_HEAD);
+		// Handle unfreeze normally
+		return false;
+	}
+	else if (interactionType == g_interactionStasisGrenadeUnfreeze)
+	{
+		CapabilitiesAdd(bits_CAP_TURN_HEAD);
+		// Handle unfreeze normally
+		return false;
+	}
+
+	return BaseClass::HandleInteraction(interactionType, data, sourceEnt);
 }
 #endif
 

--- a/sp/src/game/server/ai_playerally.h
+++ b/sp/src/game/server/ai_playerally.h
@@ -349,6 +349,10 @@ public:
 	virtual bool		CanFlinch( void );
 #endif
 
+#ifdef EZ2
+	bool		HandleInteraction(int interactionType, void* data, CBaseCombatCharacter* sourceEnt);
+#endif
+
 	//---------------------------------
 	// Combat
 	//---------------------------------

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -106,6 +106,7 @@ int g_interactionXenGrenadeHop			= 0;
 int g_interactionXenGrenadeRagdoll      = 0;
 
 int	g_interactionStasisGrenadeFreeze	= 0;
+int	g_interactionStasisGrenadeUnfreeze  = 0;
 #endif
 
 #ifdef EZ2
@@ -2366,6 +2367,7 @@ void CGrenadeHopwire::Precache( void )
 		g_interactionXenGrenadeRagdoll = CBaseCombatCharacter::GetInteractionID();
 
 		g_interactionStasisGrenadeFreeze = CBaseCombatCharacter::GetInteractionID();
+		g_interactionStasisGrenadeUnfreeze = CBaseCombatCharacter::GetInteractionID();
 	}
 
 	if (GetHopwireStyle() == HOPWIRE_XEN)
@@ -3014,7 +3016,8 @@ void CStasisVortexController::PullThink( void )
 		if (pEnts[i]->MyCombatCharacterPointer())
 		{
 			// If this NPC has already been frozen, don't refreeze
-			if (pEnts[i]->GetNextThink() == TICK_NEVER_THINK)
+			// if (pEnts[i]->GetNextThink() == TICK_NEVER_THINK)
+			if (pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false))
 			{
 				continue;
 			}
@@ -3028,11 +3031,11 @@ void CStasisVortexController::PullThink( void )
 			pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezeNPCThink, m_flEndTime, "StasisGrenadeUnfreeze" );
 
 			// Don't cancel the think function until the NPC picks up SCHED_NPC_FREEZE
-			if (pEnts[i]->MyNPCPointer() && !(pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false)))
-				continue;
+			//if (pEnts[i]->MyNPCPointer() && !(pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false)))
+			//	continue;
 
-			pEnts[i]->SetNextThink( TICK_NEVER_THINK );
-			DevMsg( "NPC '%s' caught in stasis field! Thinking stopped\n", pEnts[i]->GetDebugName() );
+			//pEnts[i]->SetNextThink( TICK_NEVER_THINK );
+			//DevMsg( "NPC '%s' caught in stasis field! Thinking stopped\n", pEnts[i]->GetDebugName() );
 
 			continue;
 		}
@@ -3109,11 +3112,21 @@ void CStasisVortexController::UnfreezeNPCThink( void )
 	if (MyNPCPointer() == NULL)
 		return;
 
+	// Dispatch interaction. Skip unfreezing if it returns true
+	if (MyNPCPointer()->DispatchInteraction(g_interactionStasisGrenadeUnfreeze, NULL, GetThrower()))
+	{
+		return;
+	}
+
 	MyNPCPointer()->TaskInterrupt();
 	MyNPCPointer()->ClearCondition( COND_NPC_FREEZE );
 	MyNPCPointer()->SetCondition( COND_NPC_UNFREEZE );
-	MyNPCPointer()->Think();
-	SetNextThink( gpGlobals->curtime );
+
+	// Reset the animation playback rate to 1.0f
+	MyNPCPointer()->m_flPlaybackRate = 1.0f;
+
+	// MyNPCPointer()->Think();
+	// SetNextThink( gpGlobals->curtime );
 }
 
 //-----------------------------------------------------------------------------
@@ -3159,7 +3172,7 @@ void CStasisVortexController::StartPull( const Vector &origin, float radius, flo
 	m_flStrength= strength;
 
 	// Play a danger sound throughout the duration of the vortex so that NPCs run away
-	CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), radius, duration, this );
+	CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), radius * 1.25f, duration, this );
 
 	SetDefLessFunc( m_SpawnList );
 	m_SpawnList.EnsureCapacity( 16 );

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2440,11 +2440,7 @@ void CGrenadeHopwire::DelayThink()
 
 	if( !m_bHasWarnedAI && gpGlobals->curtime >= m_flWarnAITime )
 	{
-//#ifndef EZ2
 		CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), 400, 1.5, this );
-//#else
-//		CSoundEnt::InsertSound( SOUND_DANGER, GetAbsOrigin(), 400, m_flDetonateTime - gpGlobals->curtime, this );
-//#endif
 		m_bHasWarnedAI = true;
 	}
 	
@@ -3024,7 +3020,6 @@ void CStasisVortexController::PullThink( void )
 			{
 				pEnts[i]->SetNextThink(MAX(pEnts[i]->GetNextThink(), m_flEndTime - TICK_INTERVAL));
 				pEnts[i]->SetAbsVelocity(vec3_origin);
-				//pEnts[i]->MyNPCPointer()->SetPlaybackRate(0.0f);
 				continue;
 			}
 
@@ -3119,11 +3114,6 @@ void CStasisVortexController::UnfreezeNPCThink( void )
 
 	MyNPCPointer()->ClearCondition( COND_NPC_FREEZE );
 	MyNPCPointer()->SetCondition( COND_NPC_UNFREEZE );
-
-	//if (MyNPCPointer()->GetPlaybackRate() == 0)
-	//{
-	//	MyNPCPointer()->SetPlaybackRate(1.0f);
-	//}
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2440,11 +2440,11 @@ void CGrenadeHopwire::DelayThink()
 
 	if( !m_bHasWarnedAI && gpGlobals->curtime >= m_flWarnAITime )
 	{
-#ifndef EZ2
+//#ifndef EZ2
 		CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), 400, 1.5, this );
-#else
-		CSoundEnt::InsertSound( SOUND_DANGER, GetAbsOrigin(), 400, m_flDetonateTime - gpGlobals->curtime, this );
-#endif
+//#else
+//		CSoundEnt::InsertSound( SOUND_DANGER, GetAbsOrigin(), 400, m_flDetonateTime - gpGlobals->curtime, this );
+//#endif
 		m_bHasWarnedAI = true;
 	}
 	
@@ -3033,21 +3033,22 @@ void CStasisVortexController::PullThink( void )
 				pEnts[i]->MyNPCPointer()->TaskInterrupt();
 
 			}
-
-			pEnts[i]->SetContextThink(&CStasisVortexController::UnfreezeNPCThink, m_flEndTime, "StasisGrenadeUnfreeze");
+			// Add tick interval to the unfreeze time to make sure that the unfreeze is after the end time
+			pEnts[i]->SetContextThink(&CStasisVortexController::UnfreezeNPCThink, m_flEndTime + TICK_INTERVAL, "StasisGrenadeUnfreeze");
 
 			continue;
 		}
 
 		if (FClassnameIs( pEnts[i], "prop_ragdoll" ))
 		{
-			pRagdoll = dynamic_cast< CRagdollProp* >(this);
+			pRagdoll = dynamic_cast< CRagdollProp* >(pEnts[i]);
 		}
 
-		if (pRagdoll)
+		if (pRagdoll && pRagdoll->IsMotionEnabled())
 		{
 			pRagdoll->DisableMotion();
-			pRagdoll->SetContextThink( &CStasisVortexController::UnfreezePhysicsObjectThink, m_flEndTime, "StasisGrenadeUnfreeze" );
+			// Add tick interval to the unfreeze time to make sure that the unfreeze is after the end time
+			pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezePhysicsObjectThink, m_flEndTime + TICK_INTERVAL, "StasisGrenadeUnfreeze" );
 			continue;
 		}
 
@@ -3067,7 +3068,8 @@ void CStasisVortexController::PullThink( void )
 
 		pPhysObject->EnableMotion(false);
 		pPhysObject->EnableGravity( false );
-		pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezePhysicsObjectThink, m_flEndTime, "StasisGrenadeUnfreeze" );
+		// Add tick interval to the unfreeze time to make sure that the unfreeze is after the end time
+		pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezePhysicsObjectThink, m_flEndTime + TICK_INTERVAL, "StasisGrenadeUnfreeze" );
 	}
 
 	// Keep going if need-be
@@ -3131,15 +3133,17 @@ void CStasisVortexController::UnfreezePhysicsObjectThink( void )
 
 	SetContextThink( NULL, TICK_NEVER_THINK, "StasisGrenadeUnfreeze" );
 
-	if (FClassnameIs( this, "prop_ragdoll" ))
+	if (FClassnameIs( GetBaseEntity(), "prop_ragdoll"))
 	{
-		pRagdoll = dynamic_cast< CRagdollProp* >(this);
+		pRagdoll = dynamic_cast< CRagdollProp* >(GetBaseEntity());
 	}
 
 	if (pRagdoll)
 	{
-		inputdata_t dummy;
-		pRagdoll->InputEnableMotion( dummy );
+		inputdata_t ragdollData;
+		ragdollData.value.SetFloat(0.1f);
+		pRagdoll->InputEnableMotion(ragdollData);
+		pRagdoll->InputStartRadgollBoogie(ragdollData);
 		return;
 	}
 

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -2440,7 +2440,11 @@ void CGrenadeHopwire::DelayThink()
 
 	if( !m_bHasWarnedAI && gpGlobals->curtime >= m_flWarnAITime )
 	{
+#ifndef EZ2
 		CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), 400, 1.5, this );
+#else
+		CSoundEnt::InsertSound( SOUND_DANGER, GetAbsOrigin(), 400, m_flDetonateTime - gpGlobals->curtime, this );
+#endif
 		m_bHasWarnedAI = true;
 	}
 	
@@ -3012,30 +3016,25 @@ void CStasisVortexController::PullThink( void )
 		// Reset ragdoll
 		pRagdoll = NULL;
 
-		// Freeze NPCs by stopping their think function
+		// Freeze NPCs
 		if (pEnts[i]->MyCombatCharacterPointer())
 		{
 			// If this NPC has already been frozen, don't refreeze
 			// if (pEnts[i]->GetNextThink() == TICK_NEVER_THINK)
-			if (pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false))
+			if (pEnts[i]->MyNPCPointer() && pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false))
 			{
 				continue;
 			}
 
 			if (pEnts[i]->MyNPCPointer())
-			{			
-				pEnts[i]->MyNPCPointer()->SetCondition( COND_NPC_FREEZE );
+			{
+				pEnts[i]->MyNPCPointer()->SetEnemy(NULL);
+				pEnts[i]->MyNPCPointer()->SetCondition(COND_NPC_FREEZE);
 				pEnts[i]->MyNPCPointer()->TaskInterrupt();
+
 			}
 
-			pEnts[i]->SetContextThink( &CStasisVortexController::UnfreezeNPCThink, m_flEndTime, "StasisGrenadeUnfreeze" );
-
-			// Don't cancel the think function until the NPC picks up SCHED_NPC_FREEZE
-			//if (pEnts[i]->MyNPCPointer() && !(pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false)))
-			//	continue;
-
-			//pEnts[i]->SetNextThink( TICK_NEVER_THINK );
-			//DevMsg( "NPC '%s' caught in stasis field! Thinking stopped\n", pEnts[i]->GetDebugName() );
+			pEnts[i]->SetContextThink(&CStasisVortexController::UnfreezeNPCThink, m_flEndTime, "StasisGrenadeUnfreeze");
 
 			continue;
 		}
@@ -3121,12 +3120,6 @@ void CStasisVortexController::UnfreezeNPCThink( void )
 	MyNPCPointer()->TaskInterrupt();
 	MyNPCPointer()->ClearCondition( COND_NPC_FREEZE );
 	MyNPCPointer()->SetCondition( COND_NPC_UNFREEZE );
-
-	// Reset the animation playback rate to 1.0f
-	MyNPCPointer()->m_flPlaybackRate = 1.0f;
-
-	// MyNPCPointer()->Think();
-	// SetNextThink( gpGlobals->curtime );
 }
 
 //-----------------------------------------------------------------------------
@@ -3172,7 +3165,7 @@ void CStasisVortexController::StartPull( const Vector &origin, float radius, flo
 	m_flStrength= strength;
 
 	// Play a danger sound throughout the duration of the vortex so that NPCs run away
-	CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), radius * 1.25f, duration, this );
+	CSoundEnt::InsertSound ( SOUND_DANGER, GetAbsOrigin(), radius * 1.25f, duration * 1.25f, this );
 
 	SetDefLessFunc( m_SpawnList );
 	m_SpawnList.EnsureCapacity( 16 );

--- a/sp/src/game/server/episodic/grenade_hopwire.cpp
+++ b/sp/src/game/server/episodic/grenade_hopwire.cpp
@@ -3017,22 +3017,20 @@ void CStasisVortexController::PullThink( void )
 		pRagdoll = NULL;
 
 		// Freeze NPCs
-		if (pEnts[i]->MyCombatCharacterPointer())
+		if (pEnts[i]->MyNPCPointer())
 		{
-			// If this NPC has already been frozen, don't refreeze
-			// if (pEnts[i]->GetNextThink() == TICK_NEVER_THINK)
-			if (pEnts[i]->MyNPCPointer() && pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false))
+			// If this NPC is in the freeze schedule, set it's think to the end of the vortex
+			if (pEnts[i]->MyNPCPointer()->IsCurSchedule(SCHED_NPC_FREEZE, false))
 			{
+				pEnts[i]->SetNextThink(MAX(pEnts[i]->GetNextThink(), m_flEndTime - TICK_INTERVAL));
+				pEnts[i]->SetAbsVelocity(vec3_origin);
+				//pEnts[i]->MyNPCPointer()->SetPlaybackRate(0.0f);
 				continue;
 			}
 
-			if (pEnts[i]->MyNPCPointer())
-			{
-				pEnts[i]->MyNPCPointer()->SetEnemy(NULL);
-				pEnts[i]->MyNPCPointer()->SetCondition(COND_NPC_FREEZE);
-				pEnts[i]->MyNPCPointer()->TaskInterrupt();
+			pEnts[i]->MyNPCPointer()->SetCondition(COND_NPC_FREEZE);
+			pEnts[i]->MyNPCPointer()->TaskInterrupt();
 
-			}
 			// Add tick interval to the unfreeze time to make sure that the unfreeze is after the end time
 			pEnts[i]->SetContextThink(&CStasisVortexController::UnfreezeNPCThink, m_flEndTime + TICK_INTERVAL, "StasisGrenadeUnfreeze");
 
@@ -3119,9 +3117,13 @@ void CStasisVortexController::UnfreezeNPCThink( void )
 		return;
 	}
 
-	MyNPCPointer()->TaskInterrupt();
 	MyNPCPointer()->ClearCondition( COND_NPC_FREEZE );
 	MyNPCPointer()->SetCondition( COND_NPC_UNFREEZE );
+
+	//if (MyNPCPointer()->GetPlaybackRate() == 0)
+	//{
+	//	MyNPCPointer()->SetPlaybackRate(1.0f);
+	//}
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/npc_metropolice.cpp
+++ b/sp/src/game/server/hl2/npc_metropolice.cpp
@@ -3737,7 +3737,6 @@ bool CNPC_MetroPolice::HandleInteraction(int interactionType, void *data, CBaseC
 	if (interactionType == g_interactionStasisGrenadeFreeze)
 	{
 		CapabilitiesRemove(bits_CAP_TURN_HEAD);
-		//SetCondition(COND_METROPOLICE_HIT_BY_BUGBAIT);
 		// Handle unfreeze normally
 		return false;
 	}

--- a/sp/src/game/server/hl2/npc_metropolice.cpp
+++ b/sp/src/game/server/hl2/npc_metropolice.cpp
@@ -107,6 +107,10 @@ int g_interactionMetrocopIdleChatter = 0;
 int g_interactionMetrocopClearSentenceQueues = 0;
 
 extern int g_interactionHitByPlayerThrownPhysObj;
+#ifdef EZ2
+extern int g_interactionStasisGrenadeFreeze;
+extern int g_interactionStasisGrenadeUnfreeze;
+#endif
 
 ConVar	sk_metropolice_stitch_reaction( "sk_metropolice_stitch_reaction","1.0");
 ConVar	sk_metropolice_stitch_tight_hitcount( "sk_metropolice_stitch_tight_hitcount","2");
@@ -3728,6 +3732,22 @@ bool CNPC_MetroPolice::HandleInteraction(int interactionType, void *data, CBaseC
 
 		return true;
 	}
+
+#ifdef EZ2
+	if (interactionType == g_interactionStasisGrenadeFreeze)
+	{
+		CapabilitiesRemove(bits_CAP_TURN_HEAD);
+		//SetCondition(COND_METROPOLICE_HIT_BY_BUGBAIT);
+		// Handle unfreeze normally
+		return false;
+	}
+	else if (interactionType == g_interactionStasisGrenadeUnfreeze)
+	{
+		CapabilitiesAdd(bits_CAP_TURN_HEAD);
+		// Handle unfreeze normally
+		return false;
+	}
+#endif
 
 	return BaseClass::HandleInteraction( interactionType, data, sourceEnt );
 }

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -2002,6 +2002,23 @@ void CRagdollProp::GetAngleOverrideFromCurrentState( char *pOut, int size )
 	}
 }
 
+#ifdef EZ2
+bool CRagdollProp::IsMotionEnabled(void)
+{
+	for (int iRagdoll = 0; iRagdoll < m_ragdoll.listCount; ++iRagdoll)
+	{
+		IPhysicsObject* pPhysicsObject = m_ragdoll.list[iRagdoll].pObject;
+		if (pPhysicsObject != NULL && !pPhysicsObject->IsMotionEnabled())
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+#endif
+
+
 void CRagdollProp::DisableMotion( void )
 {
 	for ( int iRagdoll = 0; iRagdoll < m_ragdoll.listCount; ++iRagdoll )

--- a/sp/src/game/server/physics_prop_ragdoll.h
+++ b/sp/src/game/server/physics_prop_ragdoll.h
@@ -123,6 +123,9 @@ public:
 	void			SetKiller( CBaseEntity *pKiller ) { m_hKiller = pKiller; }
 	void			GetAngleOverrideFromCurrentState( char *pOut, int size );
 
+#ifdef EZ2
+	bool			IsMotionEnabled(void);
+#endif
 	void			DisableMotion( void );
 
 	// Input/Output


### PR DESCRIPTION
This PR changes the way that freezing and unfreezing of NPCs by the stasis grenade works so that it does not stop the think function. This is to prevent a bug where the think function, when scheduled again, would handle time passed since the previous think and cause NPCs to change position immediately.

---

#### Does this PR close any issues?
* https://github.com/entropy-zero/source-sdk-2013/issues/256
* https://github.com/entropy-zero/source-sdk-2013/issues/255

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
