### PR TITLE
Add archived E:ZU2 cvars for Gamepad UI options

### DIFF
--- a/sp/src/game/server/ezu/ezu_cvars.cpp
+++ b/sp/src/game/server/ezu/ezu_cvars.cpp
@@ -1,0 +1,10 @@
+//=============================================================================//
+//
+// Purpose: 	E:ZU options cvars. May be used by VScripts.
+//
+//=============================================================================//
+
+#include "cbase.h"
+
+ConVar ezu_fps_death( "ezu_fps_death", "1", FCVAR_ARCHIVE, "" );
+ConVar ezu_flashbang_clr( "ezu_flashbang_clr", "0", FCVAR_ARCHIVE, "" );

--- a/sp/src/game/server/server_ez2.vpc
+++ b/sp/src/game/server/server_ez2.vpc
@@ -96,6 +96,7 @@ $Project "Server (Entropy Zero 2)"
 		{
 			$File	"ezu\npc_bec.cpp"
 			$File	"ezu\npc_red.cpp"
+			$File	"ezu\ezu_cvars.cpp"
 		}
 		$File	"ai_eventresponse.cpp"
 		$File	"ai_eventresponse.h"


### PR DESCRIPTION
Some new cvars to allow some of E:ZU2's VScript-driven game behavior to be modified through the Gamepad UI options menu.

These cannot be declared in VScript because VScript cvars only exist while a level is active, and I'm not sure if they'd archive properly anyway.