### PR TITLE
Player dual wielding support

### DIFF
--- a/sp/src/game/client/weapons_resource.cpp
+++ b/sp/src/game/client/weapons_resource.cpp
@@ -176,6 +176,28 @@ void WeaponsResource::LoadWeaponSprites( WEAPON_FILE_INFO_HANDLE hWeaponFileInfo
 			}
 		}
 
+#ifdef EZ2
+		p = FindHudTextureInDict( tempList, "weapon_dual" );
+		if ( p )
+		{
+			pWeaponInfo->iconInactiveDual = gHUD.AddUnsearchableHudIconToList( *p );
+			if ( pWeaponInfo->iconInactiveDual)
+			{
+				pWeaponInfo->iconInactiveDual->Precache();
+			}
+		}
+
+		p = FindHudTextureInDict( tempList, "weapon_dual_s" );
+		if ( p )
+		{
+			pWeaponInfo->iconActiveDual = gHUD.AddUnsearchableHudIconToList( *p );
+			if ( pWeaponInfo->iconActiveDual)
+			{
+				pWeaponInfo->iconActiveDual->Precache();
+			}
+		}
+#endif
+
 		p = FindHudTextureInDict( tempList, "weapon_small" );
 		if ( p )
 		{

--- a/sp/src/game/server/ez2/npc_assassin.cpp
+++ b/sp/src/game/server/ez2/npc_assassin.cpp
@@ -1880,26 +1880,7 @@ void CNPC_Assassin::AddLeftHandGun( CBaseCombatWeapon *pWeapon )
 		return;
 	}
 
-	// Create a fake second pistol
-	CBaseEntity *pEnt = CBaseEntity::CreateNoSpawn( "prop_dynamic_override", this->GetLocalOrigin(), this->GetLocalAngles(), this );
-	if (pEnt)
-	{
-		// HACKHACK: Just add "_left" to the end of the model name
-		char szLeftModel[MAX_PATH];
-		V_StripExtension( pWeapon->GetWorldModel(), szLeftModel, sizeof( szLeftModel ) );
-		V_strncat( szLeftModel, "_left.mdl", sizeof( szLeftModel ) );
-
-		pEnt->SetModelName( MAKE_STRING( szLeftModel ) );
-		pEnt->SetRenderMode( kRenderTransColor );
-		DispatchSpawn( pEnt );
-		pEnt->FollowEntity( this, true );
-		pEnt->SetOwnerEntity( pWeapon );
-
-		m_hLeftHandGun = static_cast<CBaseAnimating *>(pEnt);
-
-		// Make it dual-wielded
-		assert_cast<CBaseHLCombatWeapon*>(pWeapon)->SetLeftHandGun( m_hLeftHandGun );
-	}
+	m_hLeftHandGun = assert_cast<CBaseHLCombatWeapon*>(pWeapon)->CreateLeftHandGun();
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/weapon_357.cpp
+++ b/sp/src/game/server/hl2/weapon_357.cpp
@@ -98,12 +98,6 @@ public:
 	virtual void			SetActivity( Activity act, float duration );
 
 	bool				CanDualWield() const { return true; }
-	CBaseAnimating		*GetLeftHandGun() const { return m_hLeftHandGun; }
-	void				SetLeftHandGun( CBaseAnimating *pGun ) { m_hLeftHandGun = pGun; }
-
-private:
-
-	CHandle<CBaseAnimating> m_hLeftHandGun;
 #endif
 };
 

--- a/sp/src/game/shared/hl2/basehlcombatweapon_shared.h
+++ b/sp/src/game/shared/hl2/basehlcombatweapon_shared.h
@@ -53,30 +53,52 @@ public:
 
 	virtual void	ItemHolsterFrame( void );
 
-#if defined(EZ2) && defined(GAME_DLL)
+#ifdef EZ2
+	//
+	// Dual wielding
+	//
+	virtual const char *GetViewModel( int viewmodelindex = 0 ) const;
+	
+	virtual CHudTexture const	*GetSpriteActive( void ) const;
+	virtual CHudTexture const	*GetSpriteInactive( void ) const;
+
+	virtual bool			CanDualWield() const { return false; }
+	bool					IsDualWielding() const { return m_hLeftHandGun != NULL; }
+
+	CBaseAnimating			*GetLeftHandGun() const { return m_hLeftHandGun; }
+	void					SetLeftHandGun( CBaseAnimating *pGun ) { m_hLeftHandGun = pGun; }
+	
+	int GetMaxClip1( void ) const
+	{
+		return IsDualWielding() ? BaseClass::GetMaxClip1() * 2 : BaseClass::GetMaxClip1();
+	}
+	int GetDefaultClip1( void ) const
+	{
+		return IsDualWielding() ? BaseClass::GetDefaultClip1() * 2 : BaseClass::GetDefaultClip1();
+	}
+
+#ifdef GAME_DLL
 	virtual void		Operator_HandleAnimEvent( animevent_t *pEvent, CBaseCombatCharacter *pOperator );
 	virtual void		FireNPCPrimaryAttack( CBaseCombatCharacter *pOperator, Vector &vecShootOrigin, Vector &vecShootDir ) {}
 	virtual Activity	ActivityOverride( Activity baseAct, bool *pRequired );
 
-	// Dual wielding stubs (used for the Combine assassin)
-	virtual bool			CanDualWield() const { return false; }
-	virtual CBaseAnimating	*GetLeftHandGun() const { return NULL; }
-	virtual void			SetLeftHandGun( CBaseAnimating *pGun ) {}
-	
-	int GetMaxClip1( void ) const
-	{
-		return (GetLeftHandGun() != NULL) ? BaseClass::GetMaxClip1() * 2 : BaseClass::GetMaxClip1();
-	}
-	int GetDefaultClip1( void ) const
-	{
-		return (GetLeftHandGun() != NULL) ? BaseClass::GetDefaultClip1() * 2 : BaseClass::GetDefaultClip1();
-	}
+	virtual void		Drop( const Vector &vecVelocity );
+
+	CBaseAnimating			*CreateLeftHandGun();
+	void					InputCreateLeftHandGun( inputdata_t &inputdata );
+
+protected:
+
+	CNetworkHandle( CBaseAnimating, m_hLeftHandGun );
 
 private:
 
 	static acttable_t m_dual_acttable[];
 
 public:
+#else
+	CHandle<C_BaseAnimating>	m_hLeftHandGun;
+#endif
 #endif
 
 	int				m_iPrimaryAttacks;		// # of primary attacks performed with this weapon

--- a/sp/src/game/shared/weapon_parse.cpp
+++ b/sp/src/game/shared/weapon_parse.cpp
@@ -528,6 +528,9 @@ void FileWeaponInfo_t::Parse( KeyValues *pKeyValuesData, const char *szWeaponNam
 #ifdef EZ2
 	m_bAlwaysFirstDraw = (pKeyValuesData->GetInt( "AlwaysFirstDraw", 0 ) != 0) ? true : false;
 	m_bPreventPlayerSwap = (pKeyValuesData->GetInt( "PreventPlayerSwap", 0 ) != 0) ? true : false;
+
+	Q_strncpy( szWorldModelDual, pKeyValuesData->GetString( "playermodel_dual" ), MAX_WEAPON_STRING );
+	Q_strncpy( szViewModelDual, pKeyValuesData->GetString( "viewmodel_dual" ), MAX_WEAPON_STRING );
 #endif
 
 #ifndef MAPBASE // Mapbase makes weapons in the same slot & position swap each other out, which is a feature mods can intentionally use.

--- a/sp/src/game/shared/weapon_parse.h
+++ b/sp/src/game/shared/weapon_parse.h
@@ -149,6 +149,9 @@ public:
 #ifdef EZ2
 	bool					m_bAlwaysFirstDraw;			// This weapon defaults to playing the first draw animation, even if dropped by an enemy 
 	bool					m_bPreventPlayerSwap;		// If the player is holding another weapon in the same slot as this weapon, prevent picking up this weapon 
+
+	char					szWorldModelDual[MAX_WEAPON_STRING];	// World model when dual wielding
+	char					szViewModelDual[MAX_WEAPON_STRING];		// View model when dual wielding
 #endif
 
 // CLIENT DLL
@@ -163,6 +166,11 @@ public:
 	CHudTexture 					*iconZoomedCrosshair;
 	CHudTexture 					*iconZoomedAutoaim;
 	CHudTexture						*iconSmall;
+#ifdef EZ2
+	// For dual wielding
+	CHudTexture						*iconActiveDual;
+	CHudTexture	 					*iconInactiveDual;
+#endif
 
 // TF2 specific
 	bool					bShowUsageHint;							// if true, then when you receive the weapon, show a hint about it


### PR DESCRIPTION
This PR allows the player to use dual pistols in the same way that `npc_assassin` can. For the time being, this can only be initiated via a new `CreateLeftHandGun` input. Dual wielding generally allows the player to fire their weapon twice as fast with twice as much ammo, but the weapon also becomes twice as inaccurate over time. Dual wielded weapons can also (optionally) use their own viewmodel or icons specified in the weapon script.

This PR currently only integrates player dual wielding into `weapon_pistol` and `weapon_pulsepistol`.