### PR TITLE
Vort barrel propdata interaction (explode_zap)

### DIFF
--- a/sp/src/game/server/props.h
+++ b/sp/src/game/server/props.h
@@ -44,6 +44,10 @@ public:
 	// Attempt to replace a dynamic_cast
 	virtual bool IsPropPhysics() { return false; }
 #endif
+
+#ifdef EZ2
+	virtual void PostPropDataPrecache( void ) {}
+#endif
 };
 
 
@@ -61,6 +65,9 @@ public:
 
 	virtual void Spawn();
 	virtual void Precache();
+#ifdef EZ2
+	virtual void PostPropDataPrecache( void );
+#endif
 	virtual float GetAutoAimRadius() { return 24.0f; }
 
 #ifdef MAPBASE

--- a/sp/src/game/shared/props_shared.cpp
+++ b/sp/src/game/shared/props_shared.cpp
@@ -172,6 +172,14 @@ propdata_interaction_s sPropdataInteractionSections[PROPINTER_NUM_INTERACTIONS] 
 	{ "physgun_interactions", "allow_overhead", "yes" },	// 	PROPINTER_PHYSGUN_ALLOW_OVERHEAD,
 
 	{ "world_interactions", "onworldimpact", "bloodsplat" },	// PROPINTER_WORLD_BLOODSPLAT,
+
+#ifdef EZ2
+	// HACKHACK: This interaction didn't have an entry in this array and is needed for subsequent interactions to work.
+	// TODO: This change would be more fitting for Mapbase since it's needed to add any new interactions.
+	{ "physgun_interactions", "onfirstimpact", "notify_children" }, // PROPINTER_PHYSGUN_NOTIFY_CHILDREN,
+
+	{ "physgun_interactions", "onbreak", "explode_zap" },		// PROPINTER_PHYSGUN_BREAK_ZAP,
+#endif
 };
 #else
 extern propdata_interaction_s sPropdataInteractionSections[PROPINTER_NUM_INTERACTIONS];

--- a/sp/src/game/shared/props_shared.h
+++ b/sp/src/game/shared/props_shared.h
@@ -72,6 +72,10 @@ enum propdata_interactions_t
 	
 	PROPINTER_PHYSGUN_NOTIFY_CHILDREN,	// "onfirstimpact" cause attached flechettes to explode
 
+#ifdef EZ2
+	PROPINTER_PHYSGUN_BREAK_ZAP,		// "onbreak"		"explode_zap"
+#endif
+
 	// If we get more than 32 of these, we'll need a different system
 
 	PROPINTER_NUM_INTERACTIONS,


### PR DESCRIPTION
This pull request adds an `explode_zap` interaction, used for explosive barrels of vortigaunt energy in Axon Pariah. Behavior is derived from regular explosive barrels with the following differences:
* Explosion sound is replaced with new electrical explosion sound
* Fireball is replaced with new electrical explosion particle
* Ragdolls boogie in the same way vortigaunts make them boogie
* Explosion damage additionally includes `DMG_SHOCK`
---
Ideas for the future:
* Replace fire on ignite with electric crackling, etc.
* Port interaction fix to Mapbase (see comment in `props_shared.cpp`)