### PR TITLE
fix: Vortigaunts and zombigaunts clean up env_physexplosion entity

### DIFF
--- a/sp/src/game/server/hl2/npc_vortigaunt_episodic.cpp
+++ b/sp/src/game/server/hl2/npc_vortigaunt_episodic.cpp
@@ -3316,6 +3316,7 @@ void CNPC_Vortigaunt::DispelAntlions( const Vector &vecOrigin, float flRadius, b
 		// EXPLOSION!
 		pPhysExplosion->Spawn();
 		pPhysExplosion->Explode( this, this );
+		UTIL_Remove(pPhysExplosion);
 	}
 
 	// It's dangerous to go alone. Take this with you!


### PR DESCRIPTION
Vortigaunts and zombigaunts should clean up any env_physexplosion entities they create during DIspel attacks.
---

#### Does this PR close any issues?
* close entropy-zero/source-sdk-2013#285

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
