### PR TITLE
Enemy memory cvar for citizen suppressive fire + readiness aim fix for sound investigation

### DIFF
--- a/sp/src/game/server/hl2/npc_citizen17.cpp
+++ b/sp/src/game/server/hl2/npc_citizen17.cpp
@@ -2614,6 +2614,17 @@ int CNPC_Citizen::SelectRangeAttack2Schedule()
 	return BaseClass::SelectRangeAttack2Schedule();
 }
 
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+void CNPC_Citizen::OnStartSchedule( int schedule )
+{
+	// Stop aiming our gun at hints if we're investigating a sound
+	if ( schedule == SCHED_INVESTIGATE_SOUND )
+		StopAiming( "Investigating sound" );
+
+	BaseClass::OnStartSchedule( schedule );
+}
+
 #define CITIZEN_DECOY_RADIUS 128.0f
 #define CITIZEN_NUM_DECOYS 10
 #define CITIZEN_DECOY_MAX_MASS 200.0f

--- a/sp/src/game/server/hl2/npc_citizen17.h
+++ b/sp/src/game/server/hl2/npc_citizen17.h
@@ -232,6 +232,7 @@ public:
 	int 			TranslateWillpowerSchedule(int scheduleType);
 	int				TranslateSuppressingFireSchedule(int scheduleType);
 	int				SelectRangeAttack2Schedule();
+	void			OnStartSchedule( int scheduleType );
 	bool			FindDecoyObject(void);
 	bool			FindEnemyCoverTarget(void);
 	void			AimGun();


### PR DESCRIPTION
This PR contains two changes, separated into two commits.

---

### Option to allow citizen suppressive fire to respect enemy memory

Citizen suppressive fire can now respect enemy memory if the `ai_suppression_use_enemy_memory` cvar is enabled. Normally, suppressive fire uses the enemy's actual position, regardless of where the NPC thinks the enemy is and effectively preventing the player from eluding citizens in E:Z2. However, this is gated behind a cvar that is disabled by default because existing maps were already designed around this version of suppressive fire. As a result, this should not affect behavior in default E:Z2.

### Fix citizens continuing to aim at hints while investigating sounds

The other change makes citizens stop aiming at visually interesting hints when investigating a sound. Previously, citizens would continue to aim at and face a visually interesting hint while running to investigate a sound, which looks strange and prevents the citizen from seeing potential danger near the sound.

For clarification, the `StopAiming` function is only used by the idle readiness system. This change will not affect citizens in combat.