### PR TITLE
Fix overflow in constant arithmetic error in npc_lost_soul

### DIFF
--- a/sp/src/game/server/mod/npc_lost_soul.cpp
+++ b/sp/src/game/server/mod/npc_lost_soul.cpp
@@ -225,7 +225,7 @@ void CNPC_LostSoul::Spawn( void )
 	CEntityFlame *pFlame = CEntityFlame::Create(this);
 	if (pFlame)
 	{
-		pFlame->SetLifetime(HUGE_VAL);
+		pFlame->SetLifetime(FLT_MAX);
 		SetEffectEntity(pFlame);
 		pFlame->SetSize(8);
 		pFlame->SetDamage(0.0f);


### PR DESCRIPTION
This fixes a compile error that's been occurring in the GitHub Actions workflow.

At some point in the past few months, `npc_lost_soul` began producing the following error:
```
source-sdk-2013\sp\src\game\server\mod\npc_lost_soul.cpp(228,1): warning C4756: overflow in constant arithmetic [D:\a\source-sdk-2013\source-sdk-2013\sp\src\game\server\server_ez2.vcxproj
```
This went undetected due to an unrelated issue with the workflow not canceling after a compilation failure. This error also does not seem to occur on Linux.

This hasn't happened to me locally, so something may have changed on GitHub's end which began producing this error. Doing some research online, it may be related to the latest version of the Windows SDK, but I can't say that conclusively.

In terms of how the PR fixes the compile error, it replaces an instance of `HUGE_VAL` with `FLT_MAX`. They differ in the following ways:
* `HUGE_VAL` expands to `((double)INFINITY)`, which then expands to `((double)((float)(1e+300*1e+300)))`. `HUGE_VAL` seems to be intended to overflow a value of type `double`.
* `FLT_MAX` expands to `3.402823466e+38F`. `FLT_MAX` refers directly to the maximum `float` value and is used much more commonly within Source.