### PR TITLE
Add husk soldier class to ai_allymanager

### DIFF
--- a/sp/src/game/server/hl2/ai_allymanager.cpp
+++ b/sp/src/game/server/hl2/ai_allymanager.cpp
@@ -164,7 +164,7 @@ void CAI_AllyManager::CountAllies( int *pTotal, int *pMedics )
 
 #ifdef EZ
 			// Blixibon - The soldiers' "IsCommandable" function only checks the spawnflag, so it's fine here
-			if( FClassnameIs( ppAIs[i], "npc_combine_s" ) ) 
+			if( FClassnameIs( ppAIs[i], "npc_combine_s" ) || FClassnameIs( ppAIs[i], "npc_husk_soldier" ) ) 
 			{
 				CNPC_Combine *pCombine = assert_cast<CNPC_Combine*>(ppAIs[i]);
 				if ( !pCombine->IsCommandable() )


### PR DESCRIPTION
This PR adds `npc_husk_soldier` to `ai_allymanager` as an alternate classname for Combine soldiers. This allows `ai_allymanager` to respect commandable husks when determining how many allies the player has available.

Note that `CNPC_HuskSoldier::IsCommandable` explicitly checks whether the husk likes the player, so this will only count husks which are both commandable and friendly with the player.