### PR TITLE
Fix antlions not using interactions on commandable soldiers

### DIFF
--- a/sp/src/game/server/hl2/npc_antlion.cpp
+++ b/sp/src/game/server/hl2/npc_antlion.cpp
@@ -424,6 +424,8 @@ void CNPC_Antlion::Spawn( void )
 		sInteraction01.flMaxAngleDiff = 180.0f; // Initiate from any angle
 #ifdef EZ
 		sInteraction01.iFlags |= SCNPC_FLAG_TEST_SQUADMATE_HEALTH;
+		sInteraction01.flHealthRatio = 0.25f;
+		sInteraction01.MiscCriteria = AllocPooledString( "their_health:<100" );
 #endif
 
 		ScriptedNPCInteraction_t sInteraction02;
@@ -440,6 +442,8 @@ void CNPC_Antlion::Spawn( void )
 		sInteraction02.flMaxAngleDiff = 180.0f; // Initiate from any angle
 #ifdef EZ
 		sInteraction02.iFlags |= SCNPC_FLAG_TEST_SQUADMATE_HEALTH;
+		sInteraction02.flHealthRatio = 0.25f;
+		sInteraction02.MiscCriteria = AllocPooledString( "their_health:<100" );
 #endif
 		AddScriptedNPCInteraction(&sInteraction01);
 		AddScriptedNPCInteraction(&sInteraction02);


### PR DESCRIPTION
This PR fixes antlions not using their dynamic interactions on commandable soldiers. The issue stems from the fact that they used the flag to test squadmate health, but didn't set a health ratio. This ratio has been set to `0.25`, meaning antlions will now use dynamic interactions on soldiers that are at 25% health.

This PR also adds an additional check to not use the interactions on other NPCs with 100 health or greater. This prevents antlions from using the interactions on non-commandable soldiers at full health, uninjured Combine elites, Clone Cop, or other non-soldier NPCs which are not commandable but shouldn't go down immediately. Note that I made this change a long time ago and it may have been arbitrary.