### PR TITLE
Vortigaunt standoff behavior + misc. AP vort fixes

### DIFF
--- a/sp/src/game/server/ai_behavior_standoff.h
+++ b/sp/src/game/server/ai_behavior_standoff.h
@@ -163,6 +163,10 @@ protected:
 	// Don't do death poses while crouching
 	bool		ShouldPickADeathPose( void ) { return (GetPosture() != AIP_CROUCHING && GetPosture() != AIP_PEEKING) && BaseClass::ShouldPickADeathPose(); }
 #endif
+
+#ifdef EZ2
+	const AI_StandoffParams_t &GetParams() { return m_params; }
+#endif
 	
 private:
 	

--- a/sp/src/game/server/hl2/npc_vortigaunt_episodic.h
+++ b/sp/src/game/server/hl2/npc_vortigaunt_episodic.h
@@ -100,6 +100,7 @@ public:
 	virtual int		SelectSchedule( void );
 	virtual int		SelectFailSchedule( int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode );
 	virtual bool	IsValidEnemy( CBaseEntity *pEnemy );
+	virtual Vector	GetShootEnemyDir( const Vector &shootOrigin, bool bNoisy = true );
 	bool			IsLeading( void ) { return ( GetRunningBehavior() == &m_LeadBehavior && m_LeadBehavior.HasGoal() ); }
 
 	void			DeathSound( const CTakeDamageInfo &info );
@@ -305,6 +306,31 @@ private:
 	COutputEvent	m_OnFinishedExtractingBugbait;
 	COutputEvent	m_OnFinishedChargingTarget;
 	COutputEvent	m_OnPlayerUse;
+
+#ifdef EZ2
+	class CVortigauntStandoffBehavior : public CAI_StandoffBehavior
+	{
+		typedef CAI_StandoffBehavior BaseClass;
+
+	public:
+		virtual int SelectScheduleUpdateWeapon();
+		virtual int SelectScheduleAttack()
+		{
+			int result = GetOuterVort()->SelectRangeAttack2Schedule();
+			if ( result == SCHED_NONE )
+				result = BaseClass::SelectScheduleAttack();
+			return result;
+		}
+
+		virtual int TranslateSchedule( int schedule );
+
+		inline CNPC_Vortigaunt *GetOuterVort() { return static_cast<CNPC_Vortigaunt*>(GetOuter()); }
+	};
+
+	virtual CAI_StandoffBehavior &GetStandoffBehavior( void ) { return m_StandoffBehavior; }
+
+	CVortigauntStandoffBehavior	m_StandoffBehavior;
+#endif
 
 #ifdef EZ
 // Child classes need these attachments!


### PR DESCRIPTION
This PR adds support for unique vortigaunt standoff behavior and fixes a few minor issues for vortigaunts in Axon Pariah.

The standoff behavior allows vortigaunts to use cover animations and standoff AI with their default ranged attack. This behavior is not completely finished, as I still need to fix a common LOS failure (see `CNPC_Vortigaunt::CVortigauntStandoffBehavior::TranslateSchedule`), but it is functional and does not affect existing behavior unless there is an `ai_behavior_standoff` entity targeting a vortigaunt.

The AP-related fixes are the following:
* A fix for friendly antlions being caught in vortigaunt dispel attacks. This moves a relationship check from line 3440 to line 3400 and reverses it.
* An additional line-of-fire check for vortigaunts beams which tests the enemy's eye position if the default position won't hit. This is meant for when vault cops are in standoffs and peek out of cover, as most of their bodies are blocked, but enough of their bodies are visible that it seems odd for vortigaunts to not hit them.
* A fix for vortigaunts in healing AI facing the player instead of their healing target.

Note that vortigaunt standoffs are currently only used by Lung in the scrapped/unfinished revolt demo.