### PR TITLE
Exploding stukabat ragdolls

### DIFF
--- a/sp/src/game/server/ez2/npc_flyingpredator.cpp
+++ b/sp/src/game/server/ez2/npc_flyingpredator.cpp
@@ -18,6 +18,7 @@
 #include "ai_link.h"
 #include "ai_network.h"
 #include "hl2_shareddefs.h"
+#include "eventqueue.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -914,6 +915,26 @@ void CNPC_FlyingPredator::OnFed()
 
 //-----------------------------------------------------------------------------
 // Purpose: 
+// Output : Returns true on success, false on failure.
+//-----------------------------------------------------------------------------
+void CNPC_FlyingPredator::Event_Killed( const CTakeDamageInfo & info )
+{
+	BaseClass::Event_Killed( info );
+
+	if (m_hDeathRagdoll)
+	{
+		if (GetGroundEntity() == NULL || info.GetDamageType() & DMG_CLUB)
+		{
+			// Ragdoll falls down to earth and explodes when dying in mid-air or from kick
+			// (need to wait a bit to avoid unfairly exploding in the player's face)
+			variant_t emptyVariant;
+			g_EventQueue.AddEvent( m_hDeathRagdoll, "EnableFirstCollisionInteractions", 0.4f, info.GetAttacker(), this );
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
 // Input  : &info - 
 // Output : Returns true on success, false on failure.
 //-----------------------------------------------------------------------------
@@ -927,9 +948,20 @@ bool CNPC_FlyingPredator::ShouldGib( const CTakeDamageInfo &info )
 	if ( m_bIsBaby )
 		return true;
 
-	// Stukabats gib for any non-crush, non-blast damage greater than 15 (TODO: cvar?)
-	if ( info.GetDamage() > 15.0f || (info.GetDamageType() & (DMG_CRUSH | DMG_BLAST) ) )
+	if ( info.GetDamageType() & ( DMG_CRUSH | DMG_BLAST ) )
 		return true;
+
+	// Stukabats in mid-air (or kicked/clubbed) gib instantly for damage greater than 100, stukabats on the ground gib for damage greater than 50 (TODO: cvar?)
+	if (GetGroundEntity() == NULL || info.GetDamageType() & DMG_CLUB)
+	{
+		if ( info.GetDamage() > 100.0f)
+			return true;
+	}
+	else
+	{
+		if ( info.GetDamage() > 50.0f )
+			return true;
+	}
 
 	return IsBoss() || BaseClass::ShouldGib( info );
 }
@@ -1104,6 +1136,14 @@ bool CNPC_FlyingPredator::HandleInteraction( int interactionType, void *data, CB
 	// YEET - Similar to how base predator handles baby predator kicks, but for all stukabats
 	if ( interactionType == g_interactionBadCopKick )
 	{
+		KickInfo_t *pInfo = static_cast<KickInfo_t *>(data);
+		CTakeDamageInfo *pDamageInfo = pInfo->dmgInfo;
+		pDamageInfo->SetDamage( GetMaxHealth() ); // Instant-kill
+		pDamageInfo->ScaleDamageForce( 100 );
+		ApplyAbsVelocityImpulse( (pInfo->tr->endpos - pInfo->tr->startpos) * 100 );
+		DispatchTraceAttack( *pDamageInfo, pDamageInfo->GetDamageForce(), pInfo->tr );
+
+#if 0
 		// Set the stukabat into falling mode
 		// MAKE SURE the stukabat enters falling mode before any forces are applied, as falling mode resets velocity
 		SetFlyingState( FlyState_Falling );
@@ -1115,6 +1155,7 @@ bool CNPC_FlyingPredator::HandleInteraction( int interactionType, void *data, CB
 		DispatchTraceAttack( *pDamageInfo, pDamageInfo->GetDamageForce(), pInfo->tr );
 	 
 		ApplyAbsVelocityImpulse( (pInfo->tr->endpos - pInfo->tr->startpos) * 500 );
+#endif
 
 		// Already handled the kick
 		return true;

--- a/sp/src/game/server/ez2/npc_flyingpredator.h
+++ b/sp/src/game/server/ez2/npc_flyingpredator.h
@@ -73,6 +73,7 @@ public:
 	// No fly. Jump good!
 	bool IsJumpLegal( const Vector & startPos, const Vector & apex, const Vector & endPos ) const { return true; }
 
+	void		Event_Killed( const CTakeDamageInfo &info );
 
 	bool		ShouldGib( const CTakeDamageInfo &info );
 	bool		CorpseGib( const CTakeDamageInfo &info );

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -42,6 +42,10 @@ ConVar ragdoll_always_allow_use( "ragdoll_always_allow_use", "0", FCVAR_NONE, "A
 ConVar ragdoll_ai_scent_radius( "ragdoll_ai_scent_radius", "2048", FCVAR_NONE, "Radius for server ragdoll AI scents" );
 ConVar ragdoll_ai_scent_time( "ragdoll_ai_scent_time", "15", FCVAR_NONE, "Duration for server ragdoll AI scents" );
 ConVar ragdoll_gibs( "ragdoll_gibs", "1", FCVAR_NONE, "Should death ragdolls be destructible?" );
+
+// TODO: Unique cvars?
+extern ConVar sk_flyingpredator_dmg_explode;
+extern ConVar sk_flyingpredator_radius_explode;
 #endif
 
 //-----------------------------------------------------------------------------
@@ -115,6 +119,8 @@ BEGIN_DATADESC(CRagdollProp)
 	DEFINE_INPUTFUNC( FIELD_VOID, "DisableScent", InputDisableScent ),
 
 	DEFINE_INPUTFUNC( FIELD_VOID, "Gib", InputGib ),
+
+	DEFINE_INPUTFUNC( FIELD_VOID, "EnableFirstCollisionInteractions", InputEnableFirstCollisionInteractions ),
 #endif
 
 #ifdef MAPBASE
@@ -832,7 +838,11 @@ void CRagdollProp::HandleFirstCollisionInteractions( int index, gamevcollisionev
 		info.SetDamage( m_iHealth );
 		info.SetAttacker( this );
 		info.SetInflictor( this );
+#ifdef EZ2
+		info.SetDamageType( DMG_CRUSH | DMG_ALWAYSGIB );
+#else
 		info.SetDamageType( DMG_GENERIC );
+#endif
 
 		Vector vecPosition;
 		Vector vecVelocity;
@@ -1116,6 +1126,18 @@ int	CRagdollProp::OnTakeDamage( const CTakeDamageInfo &info )
 			else
 			{
 				CGib::SpawnRandomGibs( this, 4, GIB_ALIEN );	// throw some alien gibs.
+			}
+
+			if ( HasPhysgunInteraction( "onbreak", "explode_acid" ) )
+			{
+				// TODO - Replace this with a unique particle
+				DispatchParticleEffect( "bullsquid_explode", WorldSpaceCenter(), GetAbsAngles() );
+
+				// TODO: Unique cvars?
+				CTakeDamageInfo info( this, this, sk_flyingpredator_dmg_explode.GetFloat(), DMG_BLAST_SURFACE | DMG_ACID | DMG_ALWAYSGIB );
+
+				RadiusDamage( info, GetAbsOrigin(), sk_flyingpredator_radius_explode.GetFloat(), CLASS_NONE, this );
+				EmitSound( "NPC_FlyingPredator.Explode" );
 			}
 		}
 	}

--- a/sp/src/game/server/physics_prop_ragdoll.h
+++ b/sp/src/game/server/physics_prop_ragdoll.h
@@ -156,6 +156,8 @@ public:
 	void			InputDisableScent( inputdata_t &inputdata );
 
 	void			InputGib( inputdata_t &inputdata );
+
+	void			InputEnableFirstCollisionInteractions( inputdata_t &inputdata ) { m_bFirstCollisionAfterLaunch = true; }
 #endif
 
 	DECLARE_DATADESC();


### PR DESCRIPTION
This PR adds support for exploding stukabat ragdolls, adjusting stukabat death/gibbing code accordingly.

Ragdolls now have a new `onbreak > explode_acid` interaction which causes a ragdoll to explode like a stukabat when it breaks. In conjunction with the `onfirstimpact > break` interaction, this allows stukabats to explode when they impact a surface.

Stukabat death/gibbing code has been changed in the following ways:
* Upon dying while in the air (or melee killed), stukabats will tell their death ragdoll that it should do first impact interactions (i.e. explode on impact).
* Stukabats will now only gib at 50 damage if on the ground, 100 damage if in the air (or kicked), as opposed to always just 15 damage. Stukabats will continue to always gib when crushed or blown up.
* Kicked stukabats will now launch as ragdolls to explode, rather than being launched as NPCs to explode.