### PR TITLE
New cheat field in save metadata

### DIFF
--- a/sp/src/game/server/ez2/ez2_save_metadata.cpp
+++ b/sp/src/game/server/ez2/ez2_save_metadata.cpp
@@ -7,6 +7,7 @@
 #include "cbase.h"
 #include "tier3/tier3.h"
 #include "vgui/ILocalize.h"
+#include "achievementmgr.h"
 #include "npc_wilson.h"
 
 //=============================================================================
@@ -83,6 +84,13 @@ public:
 			if (CNPC_Wilson *pWilson = CNPC_Wilson::GetWilson())
 			{
 				pCustomSaveMetadata->SetBool("wilson", true );
+			}
+
+			// Cheated
+			CAchievementMgr *pAchievementMgr = dynamic_cast<CAchievementMgr *>(engine->GetAchievementMgr());
+			if (pAchievementMgr)
+			{
+				pCustomSaveMetadata->SetBool( "cheated", pAchievementMgr->WereCheatsEverOn() );
 			}
 
 			Msg( "Saving custom metadata to %s\n", name );


### PR DESCRIPTION
This PR adds a new field to record whether the player cheated in this save via the achievement manager. It also stops save metadata from always putting Wilson in the corner when he is omniscient (i.e. AP saves).

The cheated field could perhaps be used in the future to mark saves which are nonviable for achievements.