### PR TITLE
info_remarkable support for CAI_PlayerAlly

### DIFF
--- a/sp/src/game/server/ai_playerally.h
+++ b/sp/src/game/server/ai_playerally.h
@@ -423,6 +423,8 @@ public:
 	// So Will-E can override idle speech stuff
 	virtual void HandlePrescheduleIdleSpeech();
 	inline void SetNextIdleSpeechTime( float flTime ) { m_flNextIdleSpeechTime = flTime; }
+
+	bool		Remark( AI_CriteriaSet &modifiers, CBaseEntity *pRemarkable ) { return SpeakIfAllowed( TLK_REMARK, modifiers ); }
 #endif
 
 	//---------------------------------


### PR DESCRIPTION
This PR allows any NPC derived from `CAI_PlayerAlly` to use `info_remarkable`.