### PR TITLE
Predators ignore props with 2x mass in obstruction behavior

### DIFF
--- a/sp/src/game/server/ez2/npc_basepredator.cpp
+++ b/sp/src/game/server/ez2/npc_basepredator.cpp
@@ -485,8 +485,8 @@ bool CNPC_BasePredator::ShouldAttackObstruction( CBaseEntity *pEntity )
 	if ( !pEntity->MyCombatCharacterPointer() && pEntity->GetMoveType() != MOVETYPE_VPHYSICS )
 		return false;
 
-	// Don't attack props which don't have motion enabled
-	if ( pEntity->VPhysicsGetObject() && !pEntity->VPhysicsGetObject()->IsMotionEnabled() )
+	// Don't attack props which don't have motion enabled or have more than 2x mass than us
+	if ( pEntity->VPhysicsGetObject() && (!pEntity->VPhysicsGetObject()->IsMotionEnabled() || pEntity->VPhysicsGetObject()->GetMass()*2 > GetMass()) )
 		return false;
 
 	// Don't attack NPCs in the same squad


### PR DESCRIPTION
This PR stops predators from attacking props with 2x the mass they have, as props of that size will not be affected. [An identical check already exists on Combine soldiers.](https://github.com/entropy-zero/source-sdk-2013/blob/ez2/mapbase/sp/src/game/server/hl2/npc_combine.cpp#L3947)