### PR TITLE
Fix headcrabs producing carcass decal and scent after dying with no ragdoll

### DIFF
--- a/sp/src/game/server/hl2/npc_headcrab.cpp
+++ b/sp/src/game/server/hl2/npc_headcrab.cpp
@@ -1881,9 +1881,11 @@ void CBaseHeadcrab::Event_Killed( const CTakeDamageInfo &info )
 #ifdef EZ
 	// Create a little decal underneath the headcrab
 	if (
-		sk_headcrab_carcass_smell.GetBool() ||
+		(sk_headcrab_carcass_smell.GetBool() ||
 		// This type of damage combination happens from dynamic scripted sequences
-		info.GetDamageType() & (DMG_GENERIC | DMG_PREVENT_PHYSICS_FORCE)
+		info.GetDamageType() & (DMG_GENERIC | DMG_PREVENT_PHYSICS_FORCE))
+		// Don't do this if there was no carcass
+		&& !(info.GetDamageType() & DMG_REMOVENORAGDOLL)
 		)
 	{
 		trace_t	tr;


### PR DESCRIPTION
This PR stops headcrabs from producing decals or scents when they die with the `DMG_REMOVENORAGDOLL` type. This mainly happens during dynamic interactions with bullsquids that eat them whole, and it prevents bullsquids that just ate a headcrab whole from immediately eating at the floor afterwards.

There's a counterargument to be made that a bullsquid eating a headcrab would produce enough fluids for a decal and a scent, and it would make sense for a bullsquid to eat the scraps if it has nothing better to do. Further input is welcome