### PR TITLE
Fix dropship containers being displaceable

### DIFF
--- a/sp/src/game/server/hl2/npc_combinedropship.cpp
+++ b/sp/src/game/server/hl2/npc_combinedropship.cpp
@@ -180,6 +180,11 @@ public:
 	bool AllowsAnyDamage( const CTakeDamageInfo &info );
 #endif
 
+#ifdef EZ
+	// Don't displace dropship containers
+	virtual bool	IsDisplacementImpossible() { return true; }
+#endif
+
 private:
 	enum
 	{


### PR DESCRIPTION
This PR fixes dropship containers being sucked up by Xen grenades or displaced by portal pistols.