### PR TITLE
Make dual wielded pistols capable of being fired with IN_ATTACK2 (both mouse buttons)

### DIFF
--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -667,6 +667,8 @@ public:
 
 	virtual bool Reload( void ) { return false; } // The pulse pistol does not reload
 
+	bool	DualWieldOverridesSecondary() const { return false; }
+
 	virtual int GetMaxClip2( void ) const
 	{
 		int iBase = BaseClass::GetMaxClip2();

--- a/sp/src/game/shared/hl2/basehlcombatweapon_shared.cpp
+++ b/sp/src/game/shared/hl2/basehlcombatweapon_shared.cpp
@@ -8,6 +8,7 @@
 #include "basehlcombatweapon_shared.h"
 #if defined(EZ2) && defined(GAME_DLL)
 #include "npcevent.h"
+#include "in_buttons.h"
 #endif
 
 #include "hl2_player_shared.h"
@@ -261,6 +262,42 @@ void CBaseHLCombatWeapon::WeaponIdle( void )
 }
 
 #ifdef EZ2
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CBaseHLCombatWeapon::ItemPostFrame( void )
+{
+#ifdef GAME_DLL
+	// When dual wielding, secondary attack is synonymous with primary attack
+	if (IsDualWielding() && DualWieldOverridesSecondary())
+	{
+		CBasePlayer *pOwner = ToBasePlayer( GetOwner() );
+		if ( pOwner != NULL )
+		{
+			if (pOwner->m_nButtons & IN_ATTACK2)
+			{
+				pOwner->m_nButtons |= IN_ATTACK;
+				pOwner->m_nButtons &= ~IN_ATTACK2;
+			}
+
+			if (pOwner->m_afButtonPressed & IN_ATTACK2)
+			{
+				pOwner->m_afButtonPressed |= IN_ATTACK;
+				pOwner->m_afButtonPressed &= ~IN_ATTACK2;
+			}
+
+			if (pOwner->m_afButtonReleased & IN_ATTACK2)
+			{
+				pOwner->m_afButtonReleased |= IN_ATTACK;
+				pOwner->m_afButtonReleased &= ~IN_ATTACK2;
+			}
+		}
+	}
+#endif
+
+	BaseClass::ItemPostFrame();
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/shared/hl2/basehlcombatweapon_shared.h
+++ b/sp/src/game/shared/hl2/basehlcombatweapon_shared.h
@@ -57,12 +57,14 @@ public:
 	//
 	// Dual wielding
 	//
+	virtual void		ItemPostFrame( void );
 	virtual const char *GetViewModel( int viewmodelindex = 0 ) const;
 	
 	virtual CHudTexture const	*GetSpriteActive( void ) const;
 	virtual CHudTexture const	*GetSpriteInactive( void ) const;
 
 	virtual bool			CanDualWield() const { return false; }
+	virtual bool			DualWieldOverridesSecondary() const { return true; }
 	bool					IsDualWielding() const { return m_hLeftHandGun != NULL; }
 
 	CBaseAnimating			*GetLeftHandGun() const { return m_hLeftHandGun; }


### PR DESCRIPTION
This PR allows dual pistols to fire with both attack buttons. Both behave identically.

`weapon_pulsepistol` is excluded from this because it already has a secondary attack.