### PR TITLE
Dual wield tracer fix

### DIFF
--- a/sp/src/game/server/baseentity.h
+++ b/sp/src/game/server/baseentity.h
@@ -1844,6 +1844,9 @@ private:
 
 	// Computes the tracer start position
 	void ComputeTracerStartPosition( const Vector &vecShotSrc, Vector *pVecTracerStart );
+#ifdef EZ2
+	virtual void OverrideTracerStartPosition( const Vector &vecShotSrc, Vector *pVecTracerStart ) {}
+#endif
 
 	// Computes the tracer start position
 	void CreateBubbleTrailTracer( const Vector &vecShotSrc, const Vector &vecShotEnd, const Vector &vecShotDir );

--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -1994,6 +1994,20 @@ void CEZ2_Player::Weapon_HandleEquip( CBaseCombatWeapon *pWeapon )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Overrides bullet tracers
+//-----------------------------------------------------------------------------
+void CEZ2_Player::OverrideTracerStartPosition( const Vector &vecShotSrc, Vector *pVecTracerStart )
+{
+	// TODO: Identify when doing dual wield secondary attack
+	/*if ()
+	{
+		Vector right;
+		EyeVectors( NULL, &right, NULL );
+		*pVecTracerStart -= right * 4;
+	}*/
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Event fired upon picking up a new weapon
 //-----------------------------------------------------------------------------
 void CEZ2_Player::Event_FirstDrawWeapon( CBaseCombatWeapon *pWeapon )

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -184,6 +184,7 @@ public:
 	bool			HandleRemoveFromPlayerSquad( CAI_BaseNPC *pNPC );
 
 	void			Weapon_HandleEquip( CBaseCombatWeapon *pWeapon );
+	void			OverrideTracerStartPosition( const Vector &vecShotSrc, Vector *pVecTracerStart );
 
 	void			Event_FirstDrawWeapon( CBaseCombatWeapon *pWeapon );
 	void			Event_ThrewGrenade( CBaseCombatWeapon *pWeapon );

--- a/sp/src/game/shared/baseentity_shared.cpp
+++ b/sp/src/game/shared/baseentity_shared.cpp
@@ -2279,6 +2279,11 @@ void CBaseEntity::ComputeTracerStartPosition( const Vector &vecShotSrc, Vector *
 			}
 		}
 	}
+
+#if defined(EZ2) && defined(GAME_DLL)
+	// For dual wielded weapons
+	OverrideTracerStartPosition( vecShotSrc, pVecTracerStart );
+#endif
 }
 
 


### PR DESCRIPTION
This PR fixes bullet tracers always coming out of one gun instead of both guns while dual wielding.

This is in draft because I haven't figured out how to differentiate between guns yet.