### PR TITLE
Natural player dual wielding + unison with npc_assassin dual wielding

### DIFF
--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -2476,6 +2476,14 @@ void CBaseCombatCharacter::Weapon_HandleEquip( CBaseCombatWeapon *pWeapon )
 				if (pWeapon->GetSlot() == m_hMyWeapons[i]->GetSlot() &&
 					pWeapon->GetPosition() == m_hMyWeapons[i]->GetPosition())
 				{
+#ifdef EZ2
+					if (Weapon_EquipDual( pWeapon, m_hMyWeapons[i] ))
+					{
+						// Weapon has been merged with the existing weapon
+						return;
+					}
+#endif
+
 					// Replace our existing weapon in this slot
 					Weapon_Drop(m_hMyWeapons[i]);
 					{

--- a/sp/src/game/server/basecombatcharacter.h
+++ b/sp/src/game/server/basecombatcharacter.h
@@ -239,6 +239,10 @@ public:
 	virtual void		Weapon_Equip( CBaseCombatWeapon *pWeapon );			// Adds weapon to player
 	virtual void		Weapon_EquipHolstered( CBaseCombatWeapon *pWeapon );	// Pretty much only useful for NPCs
 	virtual void		Weapon_HandleEquip( CBaseCombatWeapon *pWeapon );
+#ifdef EZ2
+	// Used by CEZ2_Player and CNPC_Assassin
+	virtual bool		Weapon_EquipDual( CBaseCombatWeapon *pWeapon, CBaseCombatWeapon *pExistingWeapon ) { return false; }
+#endif
 #else
 	virtual void		Weapon_Equip( CBaseCombatWeapon *pWeapon );			// Adds weapon to player
 #endif

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -184,6 +184,7 @@ public:
 	bool			HandleRemoveFromPlayerSquad( CAI_BaseNPC *pNPC );
 
 	void			Weapon_HandleEquip( CBaseCombatWeapon *pWeapon );
+	bool			Weapon_EquipDual( CBaseCombatWeapon *pWeapon, CBaseCombatWeapon *pExistingWeapon );
 
 	void			Event_FirstDrawWeapon( CBaseCombatWeapon *pWeapon );
 	void			Event_ThrewGrenade( CBaseCombatWeapon *pWeapon );
@@ -209,6 +210,9 @@ public:
 	inline void			SetInAScript( bool bScript ) { m_bInAScript = bScript; }
 	void				InputStartScripting( inputdata_t &inputdata );
 	void				InputStopScripting( inputdata_t &inputdata );
+
+	void				InputEnableDualWield( inputdata_t &inputdata ) { m_bCanDualWield = true; }
+	void				InputDisableDualWield( inputdata_t &inputdata ) { m_bCanDualWield = false; }
 
 	// Blixibon - Speech thinking implementation
 	void				DoSpeechAI();
@@ -301,6 +305,8 @@ private:
 	CEZ2_PlayerMemory	m_MemoryComponent;
 
 	EHANDLE			m_hSpeechTarget;
+
+	bool			m_bCanDualWield;
 
 	int				m_iVisibleEnemies;
 	int				m_iCloseEnemies;

--- a/sp/src/game/server/ez2/npc_assassin.cpp
+++ b/sp/src/game/server/ez2/npc_assassin.cpp
@@ -1999,24 +1999,28 @@ void CNPC_Assassin::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecT
 }
 
 //-----------------------------------------------------------------------------
-// Purpose:	
+// Purpose:	Equips a dual weapon
 //-----------------------------------------------------------------------------
-void CNPC_Assassin::Weapon_Equip( CBaseCombatWeapon *pWeapon )
+bool CNPC_Assassin::Weapon_EquipDual( CBaseCombatWeapon *pWeapon, CBaseCombatWeapon *pExistingWeapon )
 {
-	if ( GetActiveWeapon() && GetActiveWeapon()->GetClassname() == pWeapon->GetClassname() )
+	if (GetActiveWeapon() != pExistingWeapon)
+		return false;
+
+	// For now, only identical weapons can be dual wielded
+	if (pWeapon->GetClassname() != pExistingWeapon->GetClassname())
+		return false;
+
+	CBaseHLCombatWeapon *pHLWeapon = dynamic_cast<CBaseHLCombatWeapon*>(pWeapon);
+	if (pHLWeapon && pHLWeapon->CanDualWield() && !m_bDualWeapons)
 	{
-		CBaseHLCombatWeapon *pHLWeapon = dynamic_cast<CBaseHLCombatWeapon*>(pWeapon);
-		if ( pHLWeapon && pHLWeapon->CanDualWield() && !m_bDualWeapons )
-		{
-			// Add left hand gun for weapon that already exists
-			AddLeftHandGun( GetActiveWeapon() );
-			m_bDualWeapons = true;
-			UTIL_Remove( pWeapon );
-			return;
-		}
+		// Add left hand gun for weapon that already exists
+		AddLeftHandGun( GetActiveWeapon() );
+		m_bDualWeapons = true;
+		UTIL_Remove( pWeapon );
+		return true;
 	}
 
-	BaseClass::Weapon_Equip( pWeapon );
+	return false;
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/ez2/npc_assassin.h
+++ b/sp/src/game/server/ez2/npc_assassin.h
@@ -76,7 +76,7 @@ public:
 	void		Weapon_HandleEquip( CBaseCombatWeapon *pWeapon );
 	void		Weapon_EquipHolstered( CBaseCombatWeapon *pWeapon );
 	void		Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector *pvecTarget = NULL, const Vector *pVelocity = NULL );
-	void		Weapon_Equip( CBaseCombatWeapon *pWeapon );
+	bool		Weapon_EquipDual( CBaseCombatWeapon *pWeapon, CBaseCombatWeapon *pExistingWeapon );
 	Vector		GetAttackSpread( CBaseCombatWeapon *pWeapon, CBaseEntity *pTarget = NULL );
 	float		GetSpreadBias( CBaseCombatWeapon *pWeapon, CBaseEntity *pTarget );
 

--- a/sp/src/game/server/player.cpp
+++ b/sp/src/game/server/player.cpp
@@ -7151,8 +7151,16 @@ bool CBasePlayer::BumpWeapon( CBaseCombatWeapon *pWeapon )
 	// ----------------------------------------
 	// If I already have it just take the ammo
 	// ----------------------------------------
-	if (Weapon_OwnsThisType( pWeapon->GetClassname(), pWeapon->GetSubType())) 
+	if (CBaseCombatWeapon *pOwnsThisType = Weapon_OwnsThisType( pWeapon->GetClassname(), pWeapon->GetSubType())) 
 	{
+#ifdef EZ2
+		if ( Weapon_EquipDual( pWeapon, pOwnsThisType ) )
+		{
+			// Weapon has been merged with the existing weapon
+			return true;
+		}
+		else
+#endif
 		if( Weapon_EquipAmmoOnly( pWeapon ) )
 		{
 			// Only remove me if I have no ammo left

--- a/sp/src/game/shared/hl2/basehlcombatweapon_shared.cpp
+++ b/sp/src/game/shared/hl2/basehlcombatweapon_shared.cpp
@@ -51,6 +51,7 @@ BEGIN_DATADESC( CBaseHLCombatWeapon )
 
 #ifdef EZ2
 	DEFINE_INPUTFUNC( FIELD_VOID, "CreateLeftHandGun", InputCreateLeftHandGun ),
+	DEFINE_INPUTFUNC( FIELD_EHANDLE, "SetLeftHandGun", InputSetLeftHandGun ),
 #endif
 
 END_DATADESC()
@@ -581,6 +582,21 @@ CBaseAnimating *CBaseHLCombatWeapon::CreateLeftHandGun()
 void CBaseHLCombatWeapon::InputCreateLeftHandGun( inputdata_t &inputdata )
 {
 	CreateLeftHandGun();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+void CBaseHLCombatWeapon::InputSetLeftHandGun( inputdata_t &inputdata )
+{
+	CBaseEntity *pGun = inputdata.value.Entity();
+	if (!pGun || !pGun->GetBaseAnimating())
+	{
+		SetLeftHandGun( NULL );
+		return;
+	}
+
+	SetLeftHandGun( pGun->GetBaseAnimating() );
 }
 #endif
 #endif

--- a/sp/src/game/shared/hl2/basehlcombatweapon_shared.h
+++ b/sp/src/game/shared/hl2/basehlcombatweapon_shared.h
@@ -86,6 +86,7 @@ public:
 
 	CBaseAnimating			*CreateLeftHandGun();
 	void					InputCreateLeftHandGun( inputdata_t &inputdata );
+	void					InputSetLeftHandGun( inputdata_t &inputdata );
 
 protected:
 


### PR DESCRIPTION
This PR adds a new option to players which allow them to naturally start dual wielding pistols when picking up a second one. The `CanDualWield` keyvalue (used via `logic_playerproxy`) and the `Enable`/`DisableDualWield` inputs can be used to control this behavior. Prior to this PR, player dual wielding could only be engaged with the `CreateLeftHandGun` input on the weapon in question.

This PR also unites this behavior with `npc_assassin`, which had similar code to start using dual pistols when given a second pistol.

This PR also adds a new `SetLeftHandGun` input to capable weapons, which allows an existing fake gun model to be used instead of creating a new one.