### PR TITLE
Move E:Z2 player to followup-capable expresser

### DIFF
--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -1601,7 +1601,7 @@ bool CEZ2_Player::GetGameTextSpeechParams( hudtextparms_t &params )
 //-----------------------------------------------------------------------------
 CAI_Expresser *CEZ2_Player::CreateExpresser(void)
 {
-	m_pExpresser = new CAI_Expresser(this);
+	m_pExpresser = new CAI_ExpresserWithFollowup(this);
 	if (!m_pExpresser)
 		return NULL;
 

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -126,6 +126,8 @@ public:
 	virtual CAI_Expresser * CreateExpresser(void);
 	virtual CAI_Expresser * GetExpresser() { return m_pExpresser;  }
 
+	bool			IsAllowedToSpeakFollowup( AIConcept_t concept ) { return IsAllowedToSpeak( concept ); }
+
 	bool			GetGameTextSpeechParams( hudtextparms_t &params );
 
 	void			ModifyOrAppendDamageCriteria(AI_CriteriaSet & set, const CTakeDamageInfo & info, bool bPlayer = true);


### PR DESCRIPTION
This PR changes the E:Z2 player's expresser to the followup expresser, allowing it to dispatch followups. It also adds a previously missing hook for followups to check AI speech conditions.

Progenitors needs this for player followup taunts.