### PR TITLE
Player response concepts for losing and refinding enemies

### DIFF
--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -2067,6 +2067,30 @@ void CEZ2_Player::Event_DisplacerPistolRelease( CBaseCombatWeapon *pWeapon, CBas
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CEZ2_Player::LostEnemySound( CBaseEntity *pEnemy )
+{
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	modifiers.AppendCriteria( "lastseenenemy", gpGlobals->curtime - GetNPCComponent()->GetEnemies()->LastTimeSeen( pEnemy ) );
+
+	SpeakIfAllowed( TLK_LOSTENEMY, modifiers );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CEZ2_Player::FoundEnemySound( CBaseEntity *pEnemy )
+{
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	SpeakIfAllowed( TLK_REFINDENEMY, modifiers );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: called when a game event is fired
 //-----------------------------------------------------------------------------
 void CEZ2_Player::FireGameEvent( IGameEvent *event )
@@ -2912,6 +2936,20 @@ bool CAI_PlayerNPCDummy::UpdateEnemyMemory( CBaseEntity *pEnemy, const Vector &p
 	}
 
 	return false;
+}
+
+//-----------------------------------------------------------------------------
+void CAI_PlayerNPCDummy::LostEnemySound( CBaseEntity *pEnemy )
+{
+	if (GetOuter())
+		GetOuter()->LostEnemySound( pEnemy );
+}
+
+//-----------------------------------------------------------------------------
+void CAI_PlayerNPCDummy::FoundEnemySound( CBaseEntity *pEnemy )
+{
+	if (GetOuter())
+		GetOuter()->FoundEnemySound( pEnemy );
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/ez2/ez2_player.h
+++ b/sp/src/game/server/ez2/ez2_player.h
@@ -190,6 +190,9 @@ public:
 	void			Event_DisplacerPistolDisplace( CBaseCombatWeapon *pWeapon, CBaseEntity *pVictimEntity );
 	void			Event_DisplacerPistolRelease( CBaseCombatWeapon *pWeapon, CBaseEntity *pReleaseEntity, CBaseEntity *pVictimEntity );
 
+	void			LostEnemySound( CBaseEntity *pEnemy );
+	void			FoundEnemySound( CBaseEntity *pEnemy );
+
 	void			FireGameEvent( IGameEvent *event );
 
 	void			InputFinishBonusChallenge( inputdata_t &inputdata );
@@ -345,6 +348,9 @@ public:
 	bool	QuerySeeEntity( CBaseEntity *pEntity, bool bOnlyHateOrFearIfNPC = false );
 
 	bool	UpdateEnemyMemory( CBaseEntity *pEnemy, const Vector &position, CBaseEntity *pInformer = NULL );
+
+	void	LostEnemySound( CBaseEntity *pEnemy );
+	void	FoundEnemySound( CBaseEntity *pEnemy );
 
 	void	DrawDebugGeometryOverlays( void );
 


### PR DESCRIPTION
This PR adds lost/found enemy sounds for E:Z2 player using NPC dummy.

This is in draft because I don't think I got this working. Further code may be needed to make sure the NPC dummy can consider enemies "eluded."