### PR TITLE
Fix E:Z2 player deriving from base player instead of HL2 player in VScript

### DIFF
--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -82,7 +82,7 @@ BEGIN_DATADESC(CEZ2_Player)
 	DEFINE_INPUTFUNC(FIELD_VOID, "__FinishBonusChallenge", InputFinishBonusChallenge),
 END_DATADESC()
 
-BEGIN_ENT_SCRIPTDESC( CEZ2_Player, CBasePlayer, "E:Z2's player entity." )
+BEGIN_ENT_SCRIPTDESC( CEZ2_Player, CHL2_Player, "E:Z2's player entity." )
 
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetNPCComponent, "GetNPCComponent", "Gets the player's NPC component." )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetStaringEntity, "GetStaringEntity", "Gets the player's staring entity." )


### PR DESCRIPTION
This PR fixes `CEZ2_Player` deriving from `CBasePlayer` instead of `CHL2_Player` in VScript. Deriving from `CHL2_Player` is needed to access HL2-related player functions, such as aux power.