### PR TITLE
Fix Bad Cop interactions not being accessible in VScript

### DIFF
--- a/sp/src/game/server/hl2/hl2_player.cpp
+++ b/sp/src/game/server/hl2/hl2_player.cpp
@@ -814,18 +814,18 @@ void CHL2_Player::Precache( void )
 	// Interactions
 	if ( g_interactionBadCopKick == 0 )
 	{
-		g_interactionBadCopKick = CBaseCombatCharacter::GetInteractionID();
+		CBaseCombatCharacter::AddInteractionWithString( g_interactionBadCopKick, "g_interactionBadCopKick" );
 	}
 	
 	if ( g_interactionBadCopKickWarn == 0 )
 	{
-		g_interactionBadCopKickWarn = CBaseCombatCharacter::GetInteractionID();
+		CBaseCombatCharacter::AddInteractionWithString( g_interactionBadCopKickWarn, "g_interactionBadCopKickWarn" );
 	}
 
 	// Interactions
 	if (g_interactionBadCopOrderSurrender == 0)
 	{
-		g_interactionBadCopOrderSurrender = CBaseCombatCharacter::GetInteractionID();
+		CBaseCombatCharacter::AddInteractionWithString( g_interactionBadCopOrderSurrender, "g_interactionBadCopOrderSurrender" );
 	}
 
 #endif


### PR DESCRIPTION
This PR fixes Bad Cop's kicking and surrender interactions not being accessible in VScript, as VScript utilizes a different function in order to integrate interactions.