### PR TITLE
Arbeit heli gibbing and miniscule fixes

### DIFF
--- a/sp/src/game/server/hl2/npc_attackchopper.cpp
+++ b/sp/src/game/server/hl2/npc_attackchopper.cpp
@@ -6508,6 +6508,10 @@ private:
 	bool		m_bDoorsOpen;
 	float		m_flDoorTransitionTime;
 
+	// Crashing
+	string_t	m_iszBodyGibModel;
+	string_t	m_iszTailGibModel;
+
 	// Attachments
 	int			m_nGunnerAttachments[ ARBEIT_HELI_MAX_GUNNERS ];
 	int			m_nGunnerJumpAttachments[ ARBEIT_HELI_MAX_GUNNERS ];
@@ -6541,6 +6545,9 @@ BEGIN_DATADESC( CNPC_ArbeitHelicopter )
 
 	DEFINE_KEYFIELD( m_bDoorsOpen, FIELD_BOOLEAN,	"DoorsOpen" ),
 	DEFINE_FIELD( m_flDoorTransitionTime, FIELD_TIME ),
+
+	DEFINE_KEYFIELD( m_iszBodyGibModel, FIELD_STRING, "BodyGibModel" ),
+	DEFINE_KEYFIELD( m_iszTailGibModel, FIELD_STRING, "TailGibModel" ),
 
 	DEFINE_INPUTFUNC( FIELD_VOID, "RespawnAllGunners", InputRespawnAllGunners ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "RespawnRightGunner", InputRespawnRightGunner ),
@@ -6633,7 +6640,13 @@ void CNPC_ArbeitHelicopter::Precache( void )
 
 	if (!m_bNonCombat)
 	{
-		PrecacheModel( "models/props_vehicles/arbeit_heli_stationary.mdl" );
+		if (m_iszBodyGibModel == NULL_STRING)
+			m_iszBodyGibModel = MAKE_STRING( "models/props_vehicles/arbeit_heli_stationary.mdl" ); // TODO: Unique crash model
+
+		PrecacheModel( STRING( m_iszBodyGibModel ) );
+
+		if (m_iszTailGibModel != NULL_STRING)
+			PrecacheModel( STRING( m_iszTailGibModel ) );
 	}
 
 	PrecacheScriptSound( "NPC_ArbeitHelicopter.RotorBlast" );
@@ -6842,9 +6855,9 @@ void CNPC_ArbeitHelicopter::PrescheduleThink( void )
 	RefreshGunnerState();
 
 	// TODO
-	if (m_hGunners[0])
+	if (m_hGunners[0] && m_hGunners[0]->IsAlive())
 		m_iSideFacing = GUNNER_RIGHT_ONLY;
-	else if (m_hGunners[1])
+	else if (m_hGunners[1] && m_hGunners[1]->IsAlive())
 		m_iSideFacing = GUNNER_LEFT_ONLY;
 	else
 		m_iSideFacing = GUNNER_NONE;
@@ -6902,7 +6915,7 @@ void CNPC_ArbeitHelicopter::Event_Killed( const CTakeDamageInfo &info )
 
 	if( GetCrashPoint() == NULL )
 	{
-		CBaseEntity *pCrashPoint = gEntList.FindEntityByClassname( NULL, "info_target_helicopter_crash" );
+		CBaseEntity *pCrashPoint = FindCrashPoint();
 		if( pCrashPoint != NULL )
 		{
 			m_hCrashPoint.Set( pCrashPoint );
@@ -6926,6 +6939,10 @@ void CNPC_ArbeitHelicopter::Event_Killed( const CTakeDamageInfo &info )
 			return;
 		}
 	}
+	else
+	{
+		assert_cast<CTargetHelicopterCrash*>( GetCrashPoint() )->HelicopterCrashedOnTarget( this );
+	}
 
 	// Kill our gunners
 	for (int i = 0; i < ARBEIT_HELI_MAX_GUNNERS; i++)
@@ -6939,12 +6956,71 @@ void CNPC_ArbeitHelicopter::Event_Killed( const CTakeDamageInfo &info )
 		m_hGunners[i] = NULL;
 	}
 
+	Vector vecChunkPos, vecChunkVelocity, vecForward, vecRight, vecUp;
+	QAngle vecChunkAngles;
+
+	int nBodyAttachment = LookupAttachment( "damage0" );
+	if (nBodyAttachment > 0)
+	{
+		//GetAttachment( nBodyAttachment, vecChunkPos, vecChunkAngles );
+
+		matrix3x4_t attachmentToWorld;
+		GetAttachment( nBodyAttachment, attachmentToWorld );
+		MatrixAngles( attachmentToWorld, vecChunkAngles, vecChunkPos );
+		MatrixGetColumn( attachmentToWorld, 0, vecForward );
+		//MatrixGetColumn( attachmentToWorld, 1, vecRight );
+		MatrixGetColumn( attachmentToWorld, 2, vecUp );
+	}
+	else
+	{
+		vecChunkPos = GetAbsOrigin();
+		vecChunkAngles = GetAbsAngles();
+		vecChunkVelocity = GetAbsVelocity();
+	}
+
+	// We need to get a right hand vector to toss the cockpit and tail pieces
+	// so their motion looks like a continuation of the tailspin animation
+	// that the chopper plays before crashing.
+	GetVectors( NULL, &vecRight, NULL );
+
 	// For now, create a charred stationary version of ourselves
-	// TODO: Unique crash model
-	CHelicopterChunk *pBodyChunk = CHelicopterChunk::CreateHelicopterChunk( GetAbsOrigin(), GetAbsAngles(), GetAbsVelocity(), "models/props_vehicles/arbeit_heli_stationary.mdl", CHUNK_BODY );
+	CHelicopterChunk *pBodyChunk = CHelicopterChunk::CreateHelicopterChunk( vecChunkPos, vecChunkAngles, vecChunkVelocity, STRING( m_iszBodyGibModel ), CHUNK_BODY );
 	if (pBodyChunk)
 	{
 		pBodyChunk->SetRenderColor( 64, 64, 64 );
+	}
+
+	CHelicopterChunk *pTailChunk = NULL;
+	if ( m_iszTailGibModel != NULL_STRING )
+	{
+		// Tail
+		vecChunkPos += (vecForward * -175.0f) + (vecUp * 75.0f);
+		pTailChunk = CHelicopterChunk::CreateHelicopterChunk( vecChunkPos, vecChunkAngles, vecChunkVelocity + (vecRight * -600.0f), STRING( m_iszTailGibModel ), CHUNK_TAIL );
+		if (pTailChunk)
+		{
+			pTailChunk->SetRenderColor( 64, 64, 64 );
+			pTailChunk->m_hMaster = pBodyChunk;
+		}
+	}
+
+	if (pBodyChunk && pTailChunk)
+	{
+		// Constrain all the pieces together loosely
+		IPhysicsObject *pBodyObject = pBodyChunk->VPhysicsGetObject();
+		Assert( pBodyObject );
+
+		IPhysicsObject *pTailObject = pTailChunk->VPhysicsGetObject();
+		Assert( pTailObject );
+
+		IPhysicsConstraintGroup *pGroup = NULL;
+	
+		// Create the constraint
+		constraint_fixedparams_t fixed;
+		fixed.Defaults();
+		fixed.InitWithCurrentObjectState( pBodyObject, pTailObject );
+		fixed.constraint.Defaults();
+
+		pBodyChunk->m_pTailConstraint = physenv->CreateFixedConstraint( pBodyObject, pTailObject, pGroup, fixed );
 	}
 
 	StopLoopingSounds();
@@ -7182,7 +7258,7 @@ void CNPC_ArbeitHelicopter::InputOpenDoors( inputdata_t &inputdata )
 {
 	m_bDoorsOpen = true;
 
-	if (m_flDoorTransitionTime != -1.0f && m_iGunnerSpawnState == GUNNER_NONE)
+	if (m_flDoorTransitionTime == -1.0f /*&& m_iGunnerSpawnState == GUNNER_NONE*/)
 	{
 		m_flDoorTransitionTime = gpGlobals->curtime + ARBEIT_HELI_DOOR_TIME;
 		SetContextThink( &CNPC_ArbeitHelicopter::OpenDoorsThink, gpGlobals->curtime + TICK_INTERVAL, g_pszGunnerSpawnContext );
@@ -7195,7 +7271,7 @@ void CNPC_ArbeitHelicopter::InputCloseDoors( inputdata_t &inputdata )
 {
 	m_bDoorsOpen = false;
 
-	if (m_flDoorTransitionTime != -1.0f && m_iGunnerSpawnState == GUNNER_NONE)
+	if (m_flDoorTransitionTime == -1.0f /*&& m_iGunnerSpawnState == GUNNER_NONE*/)
 	{
 		m_flDoorTransitionTime = gpGlobals->curtime + ARBEIT_HELI_DOOR_TIME;
 		SetContextThink( &CNPC_ArbeitHelicopter::CloseDoorsThink, gpGlobals->curtime + TICK_INTERVAL, g_pszGunnerSpawnContext );

--- a/sp/src/game/server/hl2/npc_combinegunship.cpp
+++ b/sp/src/game/server/hl2/npc_combinegunship.cpp
@@ -187,15 +187,29 @@ public:
 	{
 		return m_bDisabled;
 	}
+#ifdef MAPBASE
+	void	GunshipCrashedOnTarget( CBaseHelicopter *pGunship )
+	{
+		m_OnCrashed.FireOutput( pGunship, this );
+	}
+	void	GunshipAcquiredCrashTarget( CBaseHelicopter *pGunship )
+	{
+		m_OnBeginCrash.FireOutput( pGunship, this );
+	}
+#else
 	void	GunshipCrashedOnTarget( void )
 	{
 		m_OnCrashed.FireOutput( this, this );
 	}
+#endif
 
 private:
 	bool			m_bDisabled;
 
 	COutputEvent	m_OnCrashed;
+#ifdef MAPBASE
+	COutputEvent	m_OnBeginCrash;
+#endif
 };
 
 LINK_ENTITY_TO_CLASS( info_target_gunshipcrash, CTargetGunshipCrash );
@@ -209,6 +223,9 @@ BEGIN_DATADESC( CTargetGunshipCrash )
 
 	// Outputs
 	DEFINE_OUTPUT( m_OnCrashed,			"OnCrashed" ),
+#ifdef MAPBASE
+	DEFINE_OUTPUT( m_OnBeginCrash,			"OnBeginCrash" ),
+#endif
 END_DATADESC()
 
 
@@ -1564,7 +1581,11 @@ void CNPC_CombineGunship::PrescheduleThink( void )
 				{
 					BeginDestruct();
 					m_OnCrashed.FireOutput( this, this );
+#ifdef MAPBASE
+					m_hCrashTarget->GunshipCrashedOnTarget( this );
+#else
 					m_hCrashTarget->GunshipCrashedOnTarget();
+#endif
 					return;
 				}
 			}
@@ -1975,6 +1996,10 @@ bool CNPC_CombineGunship::FindNearestGunshipCrash( void )
   	m_hCrashTarget = pNearest;
 	m_flNextGunshipCrashFind = gpGlobals->curtime + 0.5;
 	m_flEndDestructTime = 0;
+
+#ifdef MAPBASE
+	m_hCrashTarget->GunshipAcquiredCrashTarget( this );
+#endif
 
 	if ( g_debug_gunship.GetInt() )
 	{


### PR DESCRIPTION
This PR allows `npc_arbeit_helicopter` to gib into separate body and tail models. This is in draft because it partially relies on https://github.com/mapbase-source/source-sdk-2013/pull/365. This PR should probably be squashed once the dependent feature is in Mapbase.

This PR also fixes gunners being considered present when dead and allows doors to opened/closed regardless of gunner state.