### PR TITLE
Fix soldiers looking at enemies when they don't see them

### DIFF
--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -5891,10 +5891,10 @@ void CNPC_Combine::OnEndMoveAndShoot()
 //-----------------------------------------------------------------------------
 bool CNPC_Combine::PickTacticalLookTarget( AILookTargetArgs_t *pArgs )
 {
-	if( GetState() == NPC_STATE_COMBAT )
+	if ( HasCondition( COND_SEE_ENEMY ) )
 	{
 		CBaseEntity *pEnemy = GetEnemy();
-		if ( pEnemy && FVisible( pEnemy ) && ValidHeadTarget(pEnemy->EyePosition()) )
+		if ( pEnemy && ValidHeadTarget( pEnemy->EyePosition() ) )
 		{
 			// Look at the enemy if possible.
 			pArgs->hTarget = pEnemy;
@@ -5903,8 +5903,12 @@ bool CNPC_Combine::PickTacticalLookTarget( AILookTargetArgs_t *pArgs )
 		}
 		else
 		{
-			// Look at yourself instead. We can't be looking in random directions.
-			pArgs->hTarget = this;
+			// Look ahead instead. We can't be looking in random directions.
+			Vector vecForward;
+			GetVectors( &vecForward, NULL, NULL );
+
+			pArgs->vTarget = EyePosition() + (vecForward * 16.0f);
+			pArgs->hTarget = NULL;
 			pArgs->flInfluence = random->RandomFloat( 0.8, 1.0 );
 			pArgs->flRamp = 0;
 		}


### PR DESCRIPTION
This PR fixes Combine soldiers looking at enemies when their AI doesn't see them. Instead of checking for the combat state and then sending a visibility trace, the code now simply checks the "see enemy" condition and then whether the enemy would be a valid head target. As part of this, the code for "looking at self" instead has been changed to simply look ahead, as looking at self did not always work as intended.