### PR TITLE
Start using Mapbase default player and hand model values

### DIFF
--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -514,8 +514,6 @@ void CEZ2_Player::Spawn( void )
 
 	BaseClass::Spawn();
 
-	SetModel( "models/bad_cop.mdl" );
-
 	Activate();
 
 	if (GetBonusChallenge() != EZ_CHALLENGE_NONE)

--- a/sp/src/game/shared/mapbase/mapbase_shared.cpp
+++ b/sp/src/game/shared/mapbase/mapbase_shared.cpp
@@ -254,10 +254,19 @@ public:
 			}
 
 #ifdef GAME_DLL
+#ifdef EZ2
+			Q_strncpy( g_szDefaultPlayerModel, gameinfo->GetString( "player_default_model", "models/bad_cop.mdl" ), sizeof( g_szDefaultPlayerModel ) );
+#else
 			Q_strncpy( g_szDefaultPlayerModel, gameinfo->GetString( "player_default_model", "models/player.mdl" ), sizeof( g_szDefaultPlayerModel ) );
+#endif
 			g_bDefaultPlayerDrawExternally = gameinfo->GetBool( "player_default_draw_externally", false );
 
+#ifdef EZ2
+			extern ConVar sv_player_hands_modelname;
+			Q_strncpy( g_szDefaultHandsModel, gameinfo->GetString( "player_default_hands", sv_player_hands_modelname.GetString() ), sizeof( g_szDefaultHandsModel ) );
+#else
 			Q_strncpy( g_szDefaultHandsModel, gameinfo->GetString( "player_default_hands", "models/weapons/v_hands.mdl" ), sizeof( g_szDefaultHandsModel ) );
+#endif
 			g_iDefaultHandsSkin = gameinfo->GetInt( "player_default_hands_skin", 0 );
 			g_iDefaultHandsBody = gameinfo->GetInt( "player_default_hands_body", 0 );
 #endif


### PR DESCRIPTION
This PR changes Mapbase's default player and hand model values to use E:Z2's parameters, and then removes E:Z2's own override of the player model. This means the player model will now be assigned at [this line in `CHL2_Player`](https://github.com/entropy-zero/source-sdk-2013/blob/ez2/mapbase/sp/src/game/server/hl2/hl2_player.cpp#L1673) rather than directly within `CEZ2_Player`.

This allows mods to override what model the player is using, and it's also needed for the upcoming protagonist system.