### PR TITLE
Ignore m_bUnableToFire in vehicle_drivable_apc

### DIFF
--- a/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
+++ b/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
@@ -842,11 +842,15 @@ void CPropDrivableAPC::AimGunAt( Vector *endPos, float flInterval )
 
 	//DevMsg("newTargetPitch: %f\n", newTargetPitch);
 
+	// EZ2: Invalid check, this always resolves to true
+	// m_bUnableToFire is unused, ignore block
+#if 0
 	// If the angles have been clamped, we're looking outside of our valid range
 	if ( fabs(newTargetYaw-targetYaw) > 1e-4 || fabs(newTargetPitch-targetPitch) > 1e-4 )
 	{
 		m_bUnableToFire = true;
 	}
+#endif
 
 	targetYaw = newTargetYaw;
 	targetPitch = newTargetPitch;


### PR DESCRIPTION
Resolves #243

I don't have time or disk space to install EZ2 to fix the values, so just ignore the whole check.

I updated the [csgo hud on workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=2986561636) for 1.8.1, you should be able to install it and see the effect of `m_bUnableToFire` in an APC.