### PR TITLE
fix: Stunstick alt-fire checks damage filters and excludes barnacles

### DIFF
--- a/sp/src/game/shared/hl2mp/weapon_stunstick.cpp
+++ b/sp/src/game/shared/hl2mp/weapon_stunstick.cpp
@@ -460,7 +460,7 @@ void CWeaponStunStick::Hit( trace_t &traceHit, Activity nHitActivity, bool bIsSe
 
 		// If the hit object is an NPC, and that NPC is now dead - become a server ragdoll and electrify!
 		CAI_BaseNPC * pNPC = pHitEntity->MyNPCPointer();
-		if ( flDamage > flBaseDamage && pHitEntity->IsNPC() && pNPC != NULL && pNPC->CanBecomeServerRagdoll() && !pNPC->IsEFlagSet( EFL_NO_MEGAPHYSCANNON_RAGDOLL ) && pNPC->m_iHealth - info.GetDamage() <= 0.0f)
+		if ( flDamage > flBaseDamage && pHitEntity->IsNPC() && pNPC != NULL && pNPC->CanBecomeServerRagdoll() && pNPC->PassesDamageFilter(info) && !pNPC->IsEFlagSet( EFL_NO_MEGAPHYSCANNON_RAGDOLL ) && pNPC->m_iHealth - info.GetDamage() <= 0.0f && pNPC->Classify() != CLASS_BARNACLE)
 		{
 			pNPC->BecomeRagdollBoogie( GetOwner(), info.GetDamageForce(), 5.0f, SF_RAGDOLL_BOOGIE_ELECTRICAL );
 		}


### PR DESCRIPTION
This PR changes the conditional for whether or not to create a ragdoll boogie in CWeaponStunStick::Hit() and adds two conditions.
* The damage info for the hit must pass the damage filters on the hit NPC
* The hit NPC must not be classified as ``CLASS_BARNACLE``

This PR targets ez1/dev as it is the oldest common ancestor of all branches which might need this change. This should be merged into the EZU Episode 1 branch and the ez2/mapbase branch.

---

#### Does this PR close any issues?
* https://github.com/entropy-zero/source-sdk-2013/issues/8
* https://github.com/entropy-zero/source-sdk-2013/issues/9

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
