### PR TITLE
Fix incorrect damage scaling behavior in CPropDrivableAPC::OnTakeDamage

### DIFF
--- a/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
+++ b/sp/src/game/server/Human_Error/vehicle_drivable_apc.cpp
@@ -709,10 +709,10 @@ int CPropDrivableAPC::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 		float flNormalDamageModifier = sk_apc_damage_normal.GetFloat();
 
 #ifdef EZ
-		// In Human Error, the view hide damage reduce percent modifier was half of the normal damage modifier divided by the maximum flViewLowered distance, 10
-		// 0.15 / 2 / 10 = 0.0075
-		// In Entropy : Zero, we want it to have half of the normal damage modifier divided by 10 
-		float flViewHideDamageReduce = flNormalDamageModifier / 20.0f;
+		// In Human Error, the view hide damage reduce percent modifier was half of the normal damage modifier divided by flViewLowered which uses the range [-10, 0]
+		// 0.15 + (-10 * 0.0075) = 0.075 or half the original modifier
+		// In Entropy : Zero, to recreate that behavior we just multiply by -0.5
+		float flViewHideDamageReduce = flNormalDamageModifier * -0.5;
 #else
 		float flViewHideDamageReduce = (float)(m_flViewLowered * 0.0075);
 #endif


### PR DESCRIPTION
This resolves an issue with EZ's version of `vehicle_drivable_apc` where players would end up taking marginally more damage when crouching/hiding in the drivers seat because of a mistake with the original implementation

I've updated the comments but the short version is that the APC's `m_flViewLowered` value operates in the range of [-10, 0] rather than [0, 10], resulting in the player taking 0.75% more damage per hit rather than the (I'm assuming) intended behavior of taking half the value of `sk_apc_damage_normal` instead (e.g. 7.5% damage instead of 15%)