### PR TITLE
In the map az_c3_2 only, fast zombies have their leap attack disabled

### DIFF
--- a/sp/src/game/server/hl2/npc_fastzombie.cpp
+++ b/sp/src/game/server/hl2/npc_fastzombie.cpp
@@ -840,6 +840,17 @@ void CFastZombie::Spawn( void )
 		CapabilitiesRemove( bits_CAP_MOVE_JUMP | bits_CAP_INNATE_RANGE_ATTACK1 );
 	}
 
+#ifdef EZ1
+	// Hackhack
+	// For az_c3_2 only, disable the leap attack.
+	// The darkness in the map makes the leap very unfair as players often have no way to react.
+	// This should be done with the Mapbase input "RemoveCapabilities"
+	if (FStrEq(STRING(gpGlobals->mapname), "az_c3_2"))
+	{
+		CapabilitiesRemove(bits_CAP_INNATE_RANGE_ATTACK1);
+	}
+#endif
+
 	m_flNextAttack = gpGlobals->curtime;
 
 	m_pLayer2 = NULL;


### PR DESCRIPTION
This change is for the upcoming Entropy : Zero update.

I have found that the fast zombie leap attack is a consistent pain point during the "stalker escort" section in the map az_c3_2. To rectify this, I would like to add a hard coded check that prevents the fast zombie leap attack from being used in that map.

Ideally, I would do this with the input "RemoveCapabilities" which was added by Mapbase. Since the update will not include Mapbase, I am implementing this very quick and dirty hack fix as a temporary solution.
