### PR TITLE
xen_grenade_thrown context applied with expiration time

### DIFF
--- a/sp/src/game/server/ez2/ez2_player.cpp
+++ b/sp/src/game/server/ez2/ez2_player.cpp
@@ -1988,11 +1988,11 @@ void CEZ2_Player::Weapon_HandleEquip( CBaseCombatWeapon *pWeapon )
 	// Make sure Wilson doesn't remind us of our special weapons for at least 20 minutes
 	if (FClassnameIs( pWeapon, "weapon_hopwire" ))
 	{
-		AddContext( "xen_grenade_thrown", "1", 1200.0f );
+		AddContext( "xen_grenade_thrown", "1", gpGlobals->curtime + 1200.0f );
 	}
 	else if (FClassnameIs( pWeapon, "weapon_displacer_pistol" ))
 	{
-		AddContext( "displacer_used", "1", 1200.0f );
+		AddContext( "displacer_used", "1", gpGlobals->curtime + 1200.0f);
 	}
 }
 
@@ -2056,7 +2056,7 @@ void CEZ2_Player::Event_ThrewGrenade( CBaseCombatWeapon *pWeapon )
 	if (FClassnameIs(pWeapon, "weapon_hopwire"))
 	{
 		// Take note of Xen grenade throws for 20 minutes
-		AddContext("xen_grenade_thrown", "1", 1200.0f);
+		AddContext("xen_grenade_thrown", "1", gpGlobals->curtime + 1200.0f);
 	}
 
 	AI_CriteriaSet modifiers;


### PR DESCRIPTION
The third parameter in ``CBaseEntity::AddContext()`` is misnamed as "duration" when it actually represents an expiration time. When Bad Cop equips or throws a Xen grenade, the context ``xen_grenade_thrown`` would be applied with a fixed expiration time of 20 minutes into the game instead of a duration of 20 minutes. This is corrected to be the current time plus 20 minutes.

This caused a bug in which Wilson would remind Bad Cop about Xen grenades every five minutes regardless of whether or not the player was using them.

---

#### Does this PR close any issues?
* https://github.com/entropy-zero/source-sdk-2013/issues/352

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
