### PR TITLE
Clonecop bossfight linux softlock fix

### DIFF
--- a/sp/src/game/server/ai_basenpc_schedule.cpp
+++ b/sp/src/game/server/ai_basenpc_schedule.cpp
@@ -2800,14 +2800,22 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 	case TASK_SMALL_FLINCH:
 		{
 			Remember(bits_MEMORY_FLINCHED);
-			SetIdealActivity( GetFlinchActivity( false, false ) );
+			Activity flinchActivity = GetFlinchActivity( false, false );
+			if ( HaveSequenceForActivity( flinchActivity ) )
+				SetIdealActivity( flinchActivity );
+			else
+				TaskComplete();
 			m_flNextFlinchTime = gpGlobals->curtime + random->RandomFloat( 3, 5 );
 			break;
 		}
 	case TASK_BIG_FLINCH:
 		{
 			Remember(bits_MEMORY_FLINCHED);
-			SetIdealActivity( GetFlinchActivity( true, false ) );
+			Activity flinchActivity = GetFlinchActivity( true, false );
+			if ( HaveSequenceForActivity( flinchActivity ) )
+				SetIdealActivity( flinchActivity );
+			else
+				TaskComplete();
 			m_flNextFlinchTime = gpGlobals->curtime + random->RandomFloat( 3, 5 );
 			break;
 		}

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -1656,7 +1656,8 @@ CBaseAnimating *CreateServerRagdollSubmodel( CBaseAnimating *pOwner, const char 
 	if (pOwner && pOwner->m_ScriptScope.IsInitialized() && CBaseAnimating::g_Hook_OnServerRagdoll.CanRunInScope( pOwner->m_ScriptScope ))
 	{
 		// ragdoll, submodel
-		ScriptVariant_t args[] = { ScriptVariant_t( pRagdoll->GetScriptInstance() ), true };
+		HSCRIPT hRagdoll = pRagdoll ? pRagdoll->GetScriptInstance() : NULL;
+		ScriptVariant_t args[] = { ScriptVariant_t( hRagdoll ), true };
 		CBaseAnimating::g_Hook_OnServerRagdoll.Call( pOwner->m_ScriptScope, NULL, args );
 	}
 #endif
@@ -1690,7 +1691,8 @@ CBaseEntity *CreateServerRagdoll( CBaseAnimating *pAnimating, int forceBone, con
 	if (pAnimating->m_ScriptScope.IsInitialized() && CBaseAnimating::g_Hook_OnServerRagdoll.CanRunInScope( pAnimating->m_ScriptScope ))
 	{
 		// ragdoll, submodel
-		ScriptVariant_t args[] = { ScriptVariant_t( pRagdoll->GetScriptInstance() ), false };
+		HSCRIPT hRagdoll = pRagdoll ? pRagdoll->GetScriptInstance() : NULL;
+		ScriptVariant_t args[] = { ScriptVariant_t( hRagdoll ), false };
 		CBaseAnimating::g_Hook_OnServerRagdoll.Call( pAnimating->m_ScriptScope, NULL, args );
 	}
 #endif


### PR DESCRIPTION
haii!! I was playing through Entropy: Zero 2 for the first time on native Linux and absolutely loving it, right up until the Clone Cop boss fight at the end of `ez2_c6_1`, where the game crashed the moment I landed my first shot on him. Turns out a few other Linux players have hit the same wall (https://www.reddit.com/r/HalfLife/comments/1sgaghu/entropy_zero_2_bug/). The usual workaround is to switch to Proton, which does let you finish the fight, but older Source runs pretty rough under Proton, so it wasn't great even though I did beat the game that way. So I dug in to fix it properly. This PR sorts out two separate Linux-only (GCC) bugs in that fight that don't show up on Windows/Proton.

**The crash when you first damage Clone Cop**

Clone Cop is meant to only use gesture flinches, so `GetFlinchActivity` returns `ACT_INVALID` for the non-gesture case, but the small/big flinch tasks passed that straight into `SetIdealActivity` without checking it. On Linux/GCC that ends up feeding an invalid sequence into the animation system and segfaults the server; Windows/MSVC just happens to tolerate it. This was the actual cause of the "Linux softlock" others and I was running into. The fix mirrors the `HaveSequenceForActivity` guard the gesture-flinch path already uses a bit further down in the same file.

**The `index 'ragdoll' does not exist` errors**

While I was in there I also hit a second Linux-only(?) issue: the boss respawn can create a ragdoll with a null script instance, and the `OnServerRagdoll` hook sites passed that through unguarded, which left the hook's `ragdoll` parameter undefined on GCC and broke the script's warp effect. Guarded both sites so a valid value always gets passed.

**Repro:** native Linux build, go into any chapter first via the menu (entities break otherwise), `changelevel ez2_c6_1`, reach the fight, fire one shot at clonecop and the server crashes. I verified the fix by building the Linux server through this repo's CI on my fork and swapping in server.so and client.so. and the fight now plays through cleanly start to finish, and the mid-fight autosave loads fine too. (since i died while testing this xD)

Anyway, thanks for making such an awesome mod!! it was a blast to play. In case this gets merged and you'd want to credit me, I go by micr0byte (micr0-dev here on GitHub).

#### Does this PR close any issues?
* I didnt see any issues published on this, but it's the bug from the Reddit thread linked above.

#### PR Checklist
- [x] My PR follows all guidelines in the CONTRIBUTING.md file
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind